### PR TITLE
Fix Orca to not generate unnecessary slices for plans with Subplans

### DIFF
--- a/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
+++ b/src/backend/gpopt/translate/CTranslatorDXLToPlStmt.cpp
@@ -356,14 +356,8 @@ CTranslatorDXLToPlStmt::TranslateDXLOperatorToPlan(
 void
 CTranslatorDXLToPlStmt::SetInitPlanVariables(PlannedStmt *planned_stmt)
 {
-	if (1 !=
-		m_dxl_to_plstmt_context
-			->GetCurrentMotionId())	 // For Distributed Tables m_ulMotionId > 1
-	{
-		planned_stmt->nInitPlans = m_dxl_to_plstmt_context->GetCurrentParamId();
-		planned_stmt->planTree->nInitPlans =
-			m_dxl_to_plstmt_context->GetCurrentParamId();
-	}
+	planned_stmt->nInitPlans = 0;			 // Orca does not produce initplans
+	planned_stmt->planTree->nInitPlans = 0;	 // Orca does not produce initplans
 
 	planned_stmt->nParamExec = m_dxl_to_plstmt_context->GetCurrentParamId();
 

--- a/src/test/regress/expected/explain_format_optimizer.out
+++ b/src/test/regress/expected/explain_format_optimizer.out
@@ -71,8 +71,6 @@ EXPLAIN (ANALYZE) SELECT * from boxes LEFT JOIN apples ON apples.id = boxes.appl
    (slice1)    Executor memory: 60K bytes avg x 3 workers, 60K bytes max (seg0).
    (slice2)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
    (slice3)    Executor memory: 96K bytes avg x 3 workers, 96K bytes max (seg0).
-   (slice4)    
-   (slice5)    
  Memory used:  128000kB
  Optimizer: Pivotal Optimizer (GPORCA)
  Execution time: 23.433 ms
@@ -383,8 +381,6 @@ QUERY PLAN
         Average: 97448
         Workers: 3
         Maximum Memory Used: 97448
-    - Slice: 4
-    - Slice: 5
   Statement statistics: 
     Memory used: 128000
   Settings: 

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14694,3 +14694,40 @@ ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
 drop user ruser;
 drop table foo, bar;
+-- Ensure subplans only generate necessary number of slices
+set gp_max_slices=3;
+create table subplan_test_1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table subplan_test_2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into subplan_test_1 values (1,1);
+insert into subplan_test_2 select i,i from generate_series(1,5)i;
+analyze subplan_test_1;
+analyze subplan_test_2;
+explain (costs off) select (select b from subplan_test_1 where subplan_test_1.b=subplan_test_2.b) from subplan_test_2;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Seq Scan on subplan_test_2
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Filter: (subplan_test_1.b = subplan_test_2.b)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on subplan_test_1
+ Optimizer: Postgres query optimizer
+(9 rows)
+
+select (select b from subplan_test_1 where subplan_test_1.b=subplan_test_2.b) from subplan_test_2;
+ b 
+---
+  
+  
+  
+ 1
+  
+(5 rows)
+
+reset gp_max_slices;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -14927,3 +14927,41 @@ ERROR:  permission denied to set parameter "gp_max_system_slices"
 reset session authorization;
 drop user ruser;
 drop table foo, bar;
+-- Ensure subplans only generate necessary number of slices
+set gp_max_slices=3;
+create table subplan_test_1(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table subplan_test_2(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into subplan_test_1 values (1,1);
+insert into subplan_test_2 select i,i from generate_series(1,5)i;
+analyze subplan_test_1;
+analyze subplan_test_2;
+explain (costs off) select (select b from subplan_test_1 where subplan_test_1.b=subplan_test_2.b) from subplan_test_2;
+                              QUERY PLAN                               
+-----------------------------------------------------------------------
+ Gather Motion 3:1  (slice2; segments: 3)
+   ->  Result
+         ->  Seq Scan on subplan_test_2
+         SubPlan 1  (slice2; segments: 3)
+           ->  Result
+                 Filter: (subplan_test_1.b = subplan_test_2.b)
+                 ->  Materialize
+                       ->  Broadcast Motion 3:3  (slice1; segments: 3)
+                             ->  Seq Scan on subplan_test_1
+ Optimizer: Pivotal Optimizer (GPORCA)
+(10 rows)
+
+select (select b from subplan_test_1 where subplan_test_1.b=subplan_test_2.b) from subplan_test_2;
+ b 
+---
+  
+  
+  
+ 1
+  
+(5 rows)
+
+reset gp_max_slices;

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -3387,6 +3387,18 @@ reset session authorization;
 drop user ruser;
 drop table foo, bar;
 
+-- Ensure subplans only generate necessary number of slices
+set gp_max_slices=3;
+create table subplan_test_1(a int, b int);
+create table subplan_test_2(a int, b int);
+insert into subplan_test_1 values (1,1);
+insert into subplan_test_2 select i,i from generate_series(1,5)i;
+analyze subplan_test_1;
+analyze subplan_test_2;
+explain (costs off) select (select b from subplan_test_1 where subplan_test_1.b=subplan_test_2.b) from subplan_test_2;
+select (select b from subplan_test_1 where subplan_test_1.b=subplan_test_2.b) from subplan_test_2;
+reset gp_max_slices;
+
 -- start_ignore
 DROP SCHEMA orca CASCADE;
 -- end_ignore


### PR DESCRIPTION
Previously, Orca would generate unused extra slices when the plan contained Subplans. This was due to a bug in the logic that set the number of InitPlans (which do require an extra slice) to the number of Subplans. This is incorrect--Orca doesn't generate InitPlans, so this value can safely be set to 0. The dispatcher would create the slice table and number of slices as "n = 1 + nMotions + nSubplans;" (where nSubplans is actually the number of InitPlans).

For the query:

```
create table foo (a int, b int);
create table  bar (a int, b int);
test=# explain analyze select (select b from foo where b=bar.a) from bar;
                                                         QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice2; segments: 3)  (cost=0.00..1324039.51 rows=1 width=12) (actual time=2.762..2.762 rows=0 loops=1)
   ->  Result  (cost=0.00..1324039.51 rows=1 width=12) (never executed)
         ->  Seq Scan on bar  (cost=0.00..1324039.51 rows=334 width=4) (never executed)
         SubPlan 1  (slice2; segments: 3)
           ->  Result  (cost=0.00..431.00 rows=1 width=4) (never executed)
                 Filter: (foo.b = bar.a)
                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4) (never executed)
                       ->  Broadcast Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=4) (never executed)
                             ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=4) (never executed)
 Planning time: 92.378 ms
   (slice0)    Executor memory: 123K bytes.
   (slice1)    Executor memory: 58K bytes avg x 3 workers, 58K bytes max (seg0).
   (slice2)    Executor memory: 92K bytes avg x 3 workers, 92K bytes max (seg0).
   (slice3)
 Memory used:  128000kB
 Optimizer: Pivotal Optimizer (GPORCA)
 Execution time: 61.759 ms
(17 rows)

Time: 161.188 ms
test=#

```

We see that slice3 is initialized, but not used.

This doesn't apply to the Main branch, as this logic was removed in 93abe741c and e7cc27fd05 .