### PR TITLE
[ORCA] Fix ident to const predicate push down optimization

### DIFF
--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -1,6 +1,7 @@
 --
 -- Test queries mixes window functions with aggregate functions or grouping.
 --
+set optimizer_trace_fallback=on;
 DROP TABLE IF EXISTS test_group_window;
 NOTICE:  table "test_group_window" does not exist, skipping
 CREATE TABLE test_group_window(c1 int, c2 int);
@@ -684,3 +685,49 @@ from t1_cte join t2 on t1_cte.b = t2.b;
 (10 rows)
 
 drop table t1, t2, rep;
+--
+-- Test for a bug in ORCA optimizing a CTE view.
+--
+-- This crashed at one point in retail build due to preprocessor creating a
+-- duplicate CTE anchor. That led ORCA to construct a bad plan where
+-- CTEConsumer project list contained an invalid scalar subplan and caused a
+-- SIGSEGV during DXL to PlStmt translation.
+--
+create table a_table(a smallint);
+create view cte_view as
+  with t1 as (select a from a_table)
+  select t1.a from t1
+  where (t1.a = (select t1.a from t1));
+-- Only by tampering with pg_stats directly I was able to guide ORCA cost model
+-- to pick a plan that would crash before this fix
+set allow_system_table_mods=true;
+update pg_class set relpages = 1::int, reltuples = 12.0::real where relname = 'a_table';
+reset allow_system_table_mods;
+explain select * from a_table join cte_view on a_table.a = (select a from cte_view) where cte_view.a = 2024;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000003.50..10000000005.68 rows=3 width=4)
+   InitPlan 2 (returns $1)  (slice5)
+     ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=1.20..2.30 rows=3 width=2)
+           ->  Seq Scan on a_table a_table_3  (cost=0.00..1.05 rows=1 width=2)
+                 Filter: (a = $0)
+                 InitPlan 1 (returns $0)  (slice7)
+                   ->  Gather Motion 3:1  (slice8; segments: 3)  (cost=0.00..1.20 rows=12 width=2)
+                         ->  Seq Scan on a_table a_table_2  (cost=0.00..1.04 rows=4 width=2)
+   ->  Nested Loop  (cost=10000000001.20..10000000003.34 rows=1 width=4)
+         ->  Seq Scan on a_table  (cost=0.00..1.05 rows=1 width=2)
+               Filter: (a = $1)
+         ->  Materialize  (cost=1.20..2.28 rows=1 width=2)
+               ->  Redistribute Motion 1:3  (slice2; segments: 1)  (cost=1.20..2.28 rows=1 width=2)
+                     Hash Key: $1
+                     ->  Result  (cost=1.20..2.25 rows=1 width=2)
+                           One-Time Filter: ($2 = 2024)
+                           InitPlan 3 (returns $2)  (slice3)
+                             ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1.20 rows=12 width=2)
+                                   ->  Seq Scan on a_table a_table_4  (cost=0.00..1.04 rows=4 width=2)
+                           ->  Seq Scan on a_table a_table_1  (cost=0.00..1.05 rows=1 width=2)
+                                 Filter: (a = 2024)
+ Optimizer: Postgres-based planner
+(22 rows)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -1,6 +1,7 @@
 --
 -- Test queries mixes window functions with aggregate functions or grouping.
 --
+set optimizer_trace_fallback=on;
 DROP TABLE IF EXISTS test_group_window;
 NOTICE:  table "test_group_window" does not exist, skipping
 CREATE TABLE test_group_window(c1 int, c2 int);
@@ -305,6 +306,8 @@ SELECT cup.* FROM
 SELECT sum(t.b) OVER(PARTITION BY t.a ) AS e FROM (select 1 as a, 2 as b from pg_class limit 1)foo,t
 ) as cup
 GROUP BY cup.e;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  e 
 ---
  2
@@ -434,12 +437,16 @@ WHERE y.b = z.b - 1;
 -- On seg2, introduce a delay in SISC WRITER (slice1) so that the xslice shared state
 -- which is stored in shared memory is initialized by the SISC READER (slice2 or slice4)
 select gp_inject_fault('get_shareinput_reference_delay_writer', 'suspend', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  gp_inject_fault 
 -----------------
  Success:
 (1 row)
 
 select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  gp_inject_fault 
 -----------------
  Success:
@@ -455,18 +462,24 @@ select gp_inject_fault('get_shareinput_reference_done', 'skip', dbid) from gp_se
 \! bash -c 'psql -X regression -c "set client_min_messages to log; set debug_shareinput_xslice to true; set optimizer_enable_motion_broadcast to off; WITH cte AS MATERIALIZED (SELECT * FROM sisc_t1) SELECT y.a, z.a FROM (SELECT cte1.a, cte1.b FROM cte cte1 JOIN sisc_t2 ON (cte1.a = sisc_t2.d)) y, (SELECT cte2.a, cte2.b FROM cte cte2 JOIN sisc_t2 ON (cte2.a = sisc_t2.d)) z WHERE y.b = z.b - 1;" &> /tmp/bfv_cte.out' &
 -- Wait for both SISC READERs to be initialized and squelched
 select gp_wait_until_triggered_fault('get_shareinput_reference_done', 1, dbid) from gp_segment_configuration where content = 2 and role = 'p';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  gp_wait_until_triggered_fault 
 -------------------------------
  Success:
 (1 row)
 
 select gp_inject_fault('get_shareinput_reference_done', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  gp_inject_fault 
 -----------------
  Success:
 (1 row)
 
 select gp_inject_fault('get_shareinput_reference_delay_writer', 'reset', dbid) from gp_segment_configuration where content = 2 and role = 'p';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  gp_inject_fault 
 -----------------
  Success:
@@ -474,6 +487,16 @@ select gp_inject_fault('get_shareinput_reference_delay_writer', 'reset', dbid) f
 
 -- Wait for the query to finish
 select wait_until_query_output_to_file('/tmp/bfv_cte.out');
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Query Parameter
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: SIRV functions
  wait_until_query_output_to_file 
 ---------------------------------
  
@@ -506,6 +529,8 @@ LOG:  SISC (shareid=0, slice=1): removed xslice state  (seg2 slice1 127.0.1.1:70
 
 -- cleanup
 select gp_inject_fault_infinite('all', 'reset', dbid) from gp_segment_configuration;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
  gp_inject_fault_infinite 
 --------------------------
  Success:
@@ -699,3 +724,71 @@ from t1_cte join t2 on t1_cte.b = t2.b;
 (10 rows)
 
 drop table t1, t2, rep;
+--
+-- Test for a bug in ORCA optimizing a CTE view.
+--
+-- This crashed at one point in retail build due to preprocessor creating a
+-- duplicate CTE anchor. That led ORCA to construct a bad plan where
+-- CTEConsumer project list contained an invalid scalar subplan and caused a
+-- SIGSEGV during DXL to PlStmt translation.
+--
+create table a_table(a smallint);
+create view cte_view as
+  with t1 as (select a from a_table)
+  select t1.a from t1
+  where (t1.a = (select t1.a from t1));
+-- Only by tampering with pg_stats directly I was able to guide ORCA cost model
+-- to pick a plan that would crash before this fix
+set allow_system_table_mods=true;
+update pg_class set relpages = 1::int, reltuples = 12.0::real where relname = 'a_table';
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Queries on coordinator-only tables
+reset allow_system_table_mods;
+explain select * from a_table join cte_view on a_table.a = (select a from cte_view) where cte_view.a = 2024;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2261454580.07 rows=1920 width=4)
+   ->  Nested Loop  (cost=0.00..2261454580.04 rows=640 width=4)
+         Join Filter: true
+         ->  Result  (cost=0.00..2206727.73 rows=134 width=2)
+               Filter: (a_table_1.a = ((SubPlan 1)))
+               ->  Seq Scan on a_table a_table_1  (cost=0.00..2206727.70 rows=334 width=4)
+                     SubPlan 1
+                       ->  Materialize  (cost=0.00..1293.00 rows=12 width=2)
+                             ->  Broadcast Motion 3:3  (slice5; segments: 3)  (cost=0.00..1293.00 rows=12 width=2)
+                                   ->  Sequence  (cost=0.00..1293.00 rows=4 width=2)
+                                         ->  Shared Scan (share slice:id 5:1)  (cost=0.00..431.00 rows=4 width=1)
+                                               ->  Seq Scan on a_table a_table_2  (cost=0.00..431.00 rows=4 width=2)
+                                         ->  Hash Join  (cost=0.00..862.00 rows=4 width=2)
+                                               Hash Cond: (share1_ref3.a = share1_ref2.a)
+                                               ->  Redistribute Motion 1:3  (slice6)  (cost=0.00..431.00 rows=1 width=2)
+                                                     Hash Key: share1_ref3.a
+                                                     ->  Assert  (cost=0.00..431.00 rows=1 width=2)
+                                                           Assert Cond: ((row_number() OVER (?)) = 1)
+                                                           ->  WindowAgg  (cost=0.00..431.00 rows=12 width=10)
+                                                                 ->  Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..431.00 rows=12 width=2)
+                                                                       ->  Shared Scan (share slice:id 7:1)  (cost=0.00..431.00 rows=4 width=2)
+                                               ->  Hash  (cost=431.00..431.00 rows=4 width=2)
+                                                     ->  Shared Scan (share slice:id 5:1)  (cost=0.00..431.00 rows=4 width=2)
+         ->  Materialize  (cost=0.00..1293.00 rows=5 width=2)
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..1293.00 rows=5 width=2)
+                     ->  Sequence  (cost=0.00..1293.00 rows=2 width=2)
+                           ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=4 width=1)
+                                 ->  Seq Scan on a_table  (cost=0.00..431.00 rows=4 width=2)
+                           ->  Hash Join  (cost=0.00..862.00 rows=2 width=2)
+                                 Hash Cond: (share0_ref3.a = share0_ref2.a)
+                                 ->  Redistribute Motion 1:3  (slice3)  (cost=0.00..431.00 rows=1 width=2)
+                                       Hash Key: share0_ref3.a
+                                       ->  Assert  (cost=0.00..431.00 rows=1 width=2)
+                                             Assert Cond: ((row_number() OVER (?)) = 1)
+                                             ->  WindowAgg  (cost=0.00..431.00 rows=12 width=10)
+                                                   ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=12 width=2)
+                                                         ->  Shared Scan (share slice:id 4:0)  (cost=0.00..431.00 rows=4 width=2)
+                                 ->  Hash  (cost=431.00..431.00 rows=2 width=2)
+                                       ->  Result  (cost=0.00..431.00 rows=2 width=2)
+                                             Filter: (share0_ref2.a = 2024)
+                                             ->  Shared Scan (share slice:id 2:0)  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer: GPORCA
+(42 rows)
+
+reset optimizer_trace_fallback;


### PR DESCRIPTION
In preprocessing, ORCA may choose to add select filters in order to help
trigger predicate push down during query normalization. In preprocessing
step PexprReplaceColWithConst(), a duplicate filter is created with
idents replaced by const values. The transformation looks like:

  Input:
```
    Select
      |-- NaryJoin/LeftOuterJoin
      |   |-- ...
      |   +-- Join Pred (has idents)
      +-- Filter
```

  Output:
```
    Select
      |-- Select
      |  |-- NaryJoin/LeftOuterJoin
      |  |  |-- ...
      |  |  +-- Join Pred (has idents)
      |  +-- Join Pred (has consts)
      +-- Filter
```

However, an issue occurs if the Join Pred contains a CTEAnchor. In that
case the CTEAnchor is "duplicated" and leads to an invalid plan. In
retail build that manifests as a crash during DXL to PlStmt translation.
This commit fixes the issue by choosing to not add the select filter
when the Join Pred contains a CTEAnchor.

---

Dev Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-fix-cte-view-crash-rocky8