### PR TITLE
eliminate unneeded comparison

### DIFF
--- a/src/backend/executor/nodeAssertOp.c
+++ b/src/backend/executor/nodeAssertOp.c
@@ -121,7 +121,7 @@ ExecInitAssertOp(AssertOp *node, EState *estate, int eflags)
 	assertOpState->ps.qual =
 		ExecInitQual(node->plan.qual, (PlanState *) assertOpState);
 
-	if (estate->es_instrument && (estate->es_instrument & INSTRUMENT_CDB))
+	if (estate->es_instrument & INSTRUMENT_CDB)
 	{
 		assertOpState->ps.cdbexplainbuf = makeStringInfo();
 	}


### PR DESCRIPTION
This comparison can be safely eliminated. The change is trivial and no tests needed.
