### PR TITLE
Ignore symbol ConfigureNamesBool_gp for base 6.26.3

### DIFF
--- a/.abi-check/6.26.3/postgres.symbols.ignore
+++ b/.abi-check/6.26.3/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp


### PR DESCRIPTION
We have a new release tag for
[6.26.3](https://github.com/greenplum-db/gpdb/releases/tag/6.26.3) that doesn't have the commit [4ac7227](
https://github.com/greenplum-db/gpdb/commit/4ac7227e93dc294b3527557ae7cb5185a734bdd4)
Adding the symbol added as part of the above mentioned commit to be ignored for 6.26.3 release to avoid abi check failures for new PR's on 6X.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
