### PR TITLE
Docs: add guc gp_keep_partition_children_locks

### DIFF
--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -940,7 +940,9 @@ Specifies the executing interval \(in seconds\) of the global deadlock detector 
 
 ## <a id="gp_keep_partition_children_locks"></a>gp_keep_partition_children_locks
 
-Maintains the relation locks on append-optimized partition leaves that are taken during query planning.
+If turned on, maintains the relation locks on all append-optimized leaf partitions involved in a query until the end of a transaction. Turning this parameter on can help avoid relatively rare visibility issues in queries, such as `read beyond eof` when running concurrently with lazy `VACUUM`(s) directly on the leaves.
+
+> **Note** Turning `gp_keep_partition_children_locks` on implies that an additional lock will be held for each append-optimized child in each partition hierarchy involved in a query, until the end of transaction. You may require to increase the value of `max_locks_per_transaction`.
 
 |Value Range|Default|Set Classifications|
 |-----------|-------|-------------------|

--- a/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc-list.html.md
@@ -938,6 +938,14 @@ Specifies the executing interval \(in seconds\) of the global deadlock detector 
 |-----------|-------|-------------------|
 |5 - `INT_MAX` secs|120 secs|master, system, reload|
 
+## <a id="gp_keep_partition_children_locks"></a>gp_keep_partition_children_locks
+
+Maintains the relation locks on append-optimized partition leaves that are taken during query planning.
+
+|Value Range|Default|Set Classifications|
+|-----------|-------|-------------------|
+|Boolean|false|master, session, reload|
+
 ## <a id="gp_log_endpoints"></a>gp\_log\_endpoints
 
 Controls the amount of parallel retrieve cursor endpoint detail that Greenplum Database writes to the server log file.

--- a/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
+++ b/gpdb-doc/markdown/ref_guide/config_params/guc_category-list.html.md
@@ -175,6 +175,7 @@ The following parameters control the types of plan operations the Postgres Plann
 - [gp_enable_relsize_collection](guc-list.html#gp_enable_relsize_collection)
 - [gp_enable_sort_distinct](guc-list.html#gp_enable_sort_distinct)
 - [gp_enable_sort_limit](guc-list.html#gp_enable_sort_limit)
+- [gp_keep_partition_children_locks](#gp_keep_partition_children_locks)
 
 ### <a id="topic23"></a>Postgres Planner Costing Parameters 
 


### PR DESCRIPTION
This PR documents the guc gp_keep_partition_children_locks introduced in https://github.com/greenplum-db/gpdb/pull/16790
