### PR TITLE
Fix no response when alter io_limit of resource group to '-1'

### DIFF
--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -40,6 +40,7 @@
 #include "utils/palloc.h"
 #include "utils/resgroup.h"
 #include "utils/cgroup.h"
+#include "utils/cgroup_io_limit.h"
 #include "utils/resource_manager.h"
 #include "utils/resowner.h"
 #include "utils/syscache.h"
@@ -484,7 +485,6 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 
 	validateCapabilities(pg_resgroupcapability_rel, groupid, &caps, false);
 	AssertImply(limitType != RESGROUP_LIMIT_TYPE_IO_LIMIT, caps.io_limit == NIL);
-	AssertImply(limitType == RESGROUP_LIMIT_TYPE_IO_LIMIT, caps.io_limit != NIL);
 
 	/* cpuset & cpu_max_percent can not coexist.
 	 * if cpuset is active, then cpu_max_percent must set to CPU_RATE_LIMIT_DISABLED,
@@ -517,6 +517,28 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, cgroupOpsRoutine->dumpio(caps.io_limit));
+		else
+		{
+			ListCell *tblspc_cell;
+
+			/* remove limitations */
+			if (oldCaps.io_limit != NIL)
+			{
+				foreach (tblspc_cell, oldCaps.io_limit)
+				{
+					TblSpcIOLimit *limit = (TblSpcIOLimit *)lfirst(tblspc_cell);
+					limit->ioconfig->rbps = IO_LIMIT_EMPTY;
+					limit->ioconfig->wbps = IO_LIMIT_EMPTY;
+					limit->ioconfig->riops = IO_LIMIT_EMPTY;
+					limit->ioconfig->wiops = IO_LIMIT_EMPTY;
+				}
+				cgroupOpsRoutine->setio(groupid, oldCaps.io_limit);
+			}
+
+			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
+										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
+										  0, DefaultIOLimit);
+		}
 	}
 	else
 	{

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -517,6 +517,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, cgroupOpsRoutine->dumpio(caps.io_limit));
 		else
+		{
 			/*
 			 * When alter io_limit to -1 , the caps.io_limit will be nil.
 			 * So we should update the io_limit in capability relation to -1.
@@ -524,6 +525,7 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, DefaultIOLimit);
+		}
 	}
 	else
 	{

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -40,7 +40,6 @@
 #include "utils/palloc.h"
 #include "utils/resgroup.h"
 #include "utils/cgroup.h"
-#include "utils/cgroup_io_limit.h"
 #include "utils/resource_manager.h"
 #include "utils/resowner.h"
 #include "utils/syscache.h"

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -519,21 +519,8 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 										  0, cgroupOpsRoutine->dumpio(caps.io_limit));
 		else
 		{
-			ListCell *tblspc_cell;
-
 			/* remove limitations */
-			if (oldCaps.io_limit != NIL)
-			{
-				foreach (tblspc_cell, oldCaps.io_limit)
-				{
-					TblSpcIOLimit *limit = (TblSpcIOLimit *)lfirst(tblspc_cell);
-					limit->ioconfig->rbps = IO_LIMIT_EMPTY;
-					limit->ioconfig->wbps = IO_LIMIT_EMPTY;
-					limit->ioconfig->riops = IO_LIMIT_EMPTY;
-					limit->ioconfig->wiops = IO_LIMIT_EMPTY;
-				}
-				cgroupOpsRoutine->setio(groupid, oldCaps.io_limit);
-			}
+			cgroupOpsRoutine->cleario(groupid);
 
 			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -517,14 +517,9 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, cgroupOpsRoutine->dumpio(caps.io_limit));
 		else
-		{
-			/* remove limitations */
-			cgroupOpsRoutine->cleario(groupid);
-
 			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, DefaultIOLimit);
-		}
 	}
 	else
 	{

--- a/src/backend/commands/resgroupcmds.c
+++ b/src/backend/commands/resgroupcmds.c
@@ -517,6 +517,10 @@ AlterResourceGroup(AlterResourceGroupStmt *stmt)
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, cgroupOpsRoutine->dumpio(caps.io_limit));
 		else
+			/*
+			 * When alter io_limit to -1 , the caps.io_limit will be nil.
+			 * So we should update the io_limit in capability relation to -1.
+			 */
 			updateResgroupCapabilityEntry(pg_resgroupcapability_rel,
 										  groupid, RESGROUP_LIMIT_TYPE_IO_LIMIT,
 										  0, DefaultIOLimit);

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -807,6 +807,11 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 		}
 		else if (callbackCtx->limittype == RESGROUP_LIMIT_TYPE_IO_LIMIT)
 		{
+			/*
+			 * When alter io_limit to -1 , the caps.io_limit will be nil.
+			 * There are no errors in io_limit string when caps.io_limit is nil.
+			 * When alter io_limit, caps.io_limit is nil means this resource group's io_limit should be clear.
+			 */
 			cgroupOpsRoutine->cleario(callbackCtx->groupid);
 			cgroupOpsRoutine->setio(callbackCtx->groupid, callbackCtx->caps.io_limit);
 		}

--- a/src/backend/utils/resgroup/resgroup.c
+++ b/src/backend/utils/resgroup/resgroup.c
@@ -807,11 +807,8 @@ ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx)
 		}
 		else if (callbackCtx->limittype == RESGROUP_LIMIT_TYPE_IO_LIMIT)
 		{
-			if (callbackCtx->caps.io_limit != NIL)
-			{
-				cgroupOpsRoutine->cleario(callbackCtx->groupid);
-				cgroupOpsRoutine->setio(callbackCtx->groupid, callbackCtx->caps.io_limit);
-			}
+			cgroupOpsRoutine->cleario(callbackCtx->groupid);
+			cgroupOpsRoutine->setio(callbackCtx->groupid, callbackCtx->caps.io_limit);
 		}
 
 		/* reset default group if cpuset has changed */

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -157,3 +157,9 @@ clear_io_max(groupid)
 cgroup_path = "/sys/fs/cgroup/gpdb/%d/io.max" % groupid 
 return os.stat(cgroup_path).st_size == 0 $$ LANGUAGE plpython3u;
 CREATE FUNCTION
+
+0: CREATE OR REPLACE FUNCTION check_io_max_empty(groupname text) RETURNS BOOL AS $$ import ctypes import os 
+# get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
+cgroup_path = "/sys/fs/cgroup/gpdb/%d/io.max" % groupid 
+return os.stat(cgroup_path).st_size == 0 $$ LANGUAGE plpython3u;
+CREATE FUNCTION

--- a/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_auxiliary_tools_v2.out
@@ -158,7 +158,7 @@ cgroup_path = "/sys/fs/cgroup/gpdb/%d/io.max" % groupid
 return os.stat(cgroup_path).st_size == 0 $$ LANGUAGE plpython3u;
 CREATE FUNCTION
 
-0: CREATE OR REPLACE FUNCTION check_io_max_empty(groupname text) RETURNS BOOL AS $$ import ctypes import os 
+0: CREATE OR REPLACE FUNCTION check_io_max_empty(groupname text) RETURNS BOOL AS $$ import os 
 # get group oid sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname result = plpy.execute(sql) groupid = result[0]['groupid'] 
 cgroup_path = "/sys/fs/cgroup/gpdb/%d/io.max" % groupid 
 return os.stat(cgroup_path).st_size == 0 $$ LANGUAGE plpython3u;

--- a/src/test/isolation2/input/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/input/resgroup/resgroup_io_limit.source
@@ -69,6 +69,15 @@ SELECT groupid, groupname, cpuset FROM gp_toolkit.gp_resgroup_config WHERE group
 
 SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
 
+-- clear limitations
+CREATE RESOURCE GROUP rg_test_group7 WITH (concurrency=10, cpu_max_percent=10, io_limit='rg_io_limit_ts_1:rbps=1000,wbps=1000');
+
+SELECT check_cgroup_io_max('rg_test_group7', 'rg_io_limit_ts_1', 'rbps=1048576000 wbps=1048576000 riops=max wiops=max');
+
+ALTER RESOURCE GROUP rg_test_group7 SET IO_LIMIT '-1';
+
+SELECT check_io_max_empty('rg_test_group7');
+
 -- view
 -- start_ignore
 SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
@@ -82,6 +91,7 @@ DROP RESOURCE GROUP rg_test_group2;
 DROP RESOURCE GROUP rg_test_group3;
 DROP RESOURCE GROUP rg_test_group4;
 DROP RESOURCE GROUP rg_test_group5;
+DROP RESOURCE GROUP rg_test_group7;
 
 DROP TABLESPACE rg_io_limit_ts_1;
 

--- a/src/test/isolation2/output/resgroup/resgroup_io_limit.source
+++ b/src/test/isolation2/output/resgroup/resgroup_io_limit.source
@@ -137,6 +137,25 @@ SELECT gp_inject_fault('create_resource_group_fail', 'reset', 1);
  Success:        
 (1 row)
 
+-- clear limitations
+CREATE RESOURCE GROUP rg_test_group7 WITH (concurrency=10, cpu_max_percent=10, io_limit='rg_io_limit_ts_1:rbps=1000,wbps=1000');
+CREATE RESOURCE GROUP
+
+SELECT check_cgroup_io_max('rg_test_group7', 'rg_io_limit_ts_1', 'rbps=1048576000 wbps=1048576000 riops=max wiops=max');
+ check_cgroup_io_max 
+---------------------
+ t                   
+(1 row)
+
+ALTER RESOURCE GROUP rg_test_group7 SET IO_LIMIT '-1';
+ALTER RESOURCE GROUP
+
+SELECT check_io_max_empty('rg_test_group7');
+ check_io_max_empty 
+--------------------
+ t                  
+(1 row)
+
 -- view
 -- start_ignore
 SELECT * from gp_toolkit.gp_resgroup_iostats_per_host;
@@ -166,6 +185,8 @@ DROP RESOURCE GROUP
 DROP RESOURCE GROUP rg_test_group4;
 DROP RESOURCE GROUP
 DROP RESOURCE GROUP rg_test_group5;
+DROP RESOURCE GROUP
+DROP RESOURCE GROUP rg_test_group7;
 DROP RESOURCE GROUP
 
 DROP TABLESPACE rg_io_limit_ts_1;

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -375,7 +375,6 @@ $$ LANGUAGE plpython3u;
 $$ LANGUAGE plpython3u;
 
 0: CREATE OR REPLACE FUNCTION check_io_max_empty(groupname text) RETURNS BOOL AS $$
-    import ctypes
     import os
 
     # get group oid

--- a/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
+++ b/src/test/isolation2/sql/resgroup/resgroup_auxiliary_tools_v2.sql
@@ -373,3 +373,17 @@ $$ LANGUAGE plpython3u;
 
     return os.stat(cgroup_path).st_size == 0
 $$ LANGUAGE plpython3u;
+
+0: CREATE OR REPLACE FUNCTION check_io_max_empty(groupname text) RETURNS BOOL AS $$
+    import ctypes
+    import os
+
+    # get group oid
+    sql = "select groupid from gp_toolkit.gp_resgroup_config where groupname = '%s'" % groupname
+    result = plpy.execute(sql)
+    groupid = result[0]['groupid']
+
+    cgroup_path = "/sys/fs/cgroup/gpdb/%d/io.max" % groupid
+
+    return os.stat(cgroup_path).st_size == 0
+$$ LANGUAGE plpython3u;


### PR DESCRIPTION
Fix no response when alter io_limit of resource group to '-1'.

There is no action when `ALTER RESOURCE GROUP xxx SET IO_LIMIT '-1'` before.
Now the action is that clear the content of `io.max` and update relation `pg_resgroupcapability`.

CI: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-fix_io_limit-rocky8


