### PR TITLE
Docs: add enable_network and roles to remote plc example

### DIFF
--- a/gpdb-doc/markdown/analytics/pl_container_using.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container_using.html.md
@@ -368,7 +368,7 @@ Record the name of the GPU device ID (0 in the above example) or the device UUID
         <image>localhost/plcontainer_python3_cuda_shared:latest</image> 
         <command>/clientdir/py3client.sh</command> 
         <setting roles="gpadmin"/> 
-        <shared_directory access="ro" container="/clientdir" host="/home/sa/GPDB/install/bin/plcontainer_clients"/> 
+        <shared_directory access="ro" container="/clientdir" host="/usr/local/greenplum-db/bin/plcontainer_clients"/> 
         <device_request type="gpu"> 
             <deviceid>0</deviceid> 
         </device_request> 

--- a/gpdb-doc/markdown/analytics/pl_container_using.html.md
+++ b/gpdb-doc/markdown/analytics/pl_container_using.html.md
@@ -552,6 +552,7 @@ This command provides the PL/Container configuration XML file. Add the backend s
 		<command>/clientdir/py3client.sh</command> 
 		<shared_directory access="ro" container="/clientdir" host="/home/sa/GPDB/install/bin/plcontainer_clients"/> 
 		<backend name="calculate_cluster" /> 
+		<setting enable_network="yes" roles="gpadmin" /> 
 	</runtime> 
 </configuration> 
 ```


### PR DESCRIPTION
`enable_network` and `roles` are required due to security reason

No code change, just doc.

I forgot to mention this.