### PR TITLE
Docs q3c module

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -29,6 +29,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [pgvector](pgvector/pgvector.html) - Provides vector similarity search capabilities for Greenplum Database that enable searching, storing, and querying machine language-generated embeddings at large scale.
 -   [postgres\_fdw](postgres_fdw.html) - Provides a foreign data wrapper \(FDW\) for accessing data stored in an external PostgreSQL or Greenplum database.
 -   [postgresql-hll](postgresql-hll.html) - Provides HyperLogLog data types for PostgreSQL and Greenplum Database.
+-   [q3c](q3c.html) - Enables fast cone, ellipse and polygonal searches and cross-matches between large astronomical catalogs inside a PostgreSQL or Greenplum database. 
 -   [sslinfo](sslinfo.html) - Provides information about the SSL certificate that the current client provided when connecting to Greenplum.
 -   [tablefunc](tablefunc.html) - Provides various functions that return tables (multiple rows).
 -   [timestamp9](timestamp9.html) - Provides an efficient nanosecond-precision timestamp data type for Greenplum Database.

--- a/gpdb-doc/markdown/ref_guide/modules/q3c.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/q3c.html.md
@@ -1,0 +1,33 @@
+---
+title: q3c 
+---
+
+The Q3C (Quad Three Cube) module enables fast cone, ellipse and polygonal searches and cross-matches between large astronomical catalogs inside a PostgreSQL or Greenplum database.
+
+## <a id="topic_reg"></a>Installing and Registering the Module
+
+The `q3c` module is installed when you install Greenplum Database. Before you can use it, you must register the `q3c` extension in each database in which you want to use these:
+
+```
+CREATE EXTENSION q3c;
+```
+
+Refer to [Installing Additional Supplied Modules](../../../install_guide/install_modules.html) for more information.
+
+## <a id="topic_upgrading"></a>Upgrading the Module
+
+The `q3c` module is installed when you install or upgrade Greenplum Database. A previous version of the extension will continue to work in existing databases after you upgrade Greenplum. To upgrade to the most recent version of the extension, you must:
+
+```
+ALTER EXTENSION q3c UPDATE TO '2.0.1';
+```
+
+in **every** database in which you registered/use the extension.
+
+## <a id="topic_info"></a>Module Documentation
+
+Refer to the [q3c github documentation](https://github.com/segasai/q3c/blob/master/README.md) for detailed information about using the module.
+
+~                        
+
+

--- a/gpdb-doc/markdown/ref_guide/modules/q3c.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/q3c.html.md
@@ -24,10 +24,6 @@ ALTER EXTENSION q3c UPDATE TO '2.0.1';
 
 in **every** database in which you registered/use the extension.
 
-## <a id="topic_info"></a>Module Documentation
+## <a id="topic_docs"></a>Module Documentation
 
 Refer to the [q3c github documentation](https://github.com/segasai/q3c/blob/master/README.md) for detailed information about using the module.
-
-~                        
-
-


### PR DESCRIPTION
This PR adds the q3c module to the VMware Greenplum documentation. 

Staging site: 
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-q3c/greenplum-database/ref_guide-modules-q3c.html