### PR TITLE
Docs: add pgsphere module reference page

### DIFF
--- a/gpdb-doc/markdown/ref_guide/modules/intro.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/intro.html.md
@@ -26,6 +26,7 @@ The following Greenplum Database and PostgreSQL `contrib` modules are installed;
 -   [pg_buffercache](pg_buffercache.html) - Provides access to five views for obtaining cluster-wide shared buffer metrics.
 -   [pgcrypto](pgcrypto.html) - Provides cryptographic functions for Greenplum Database.
 -   [postgresml](postgresml.html) - Provides functions for using tens of thousands of pre-trained open source AI/machine learning models in VMware Greenplum.
+-   [pgsphere](pgsphere.html) - Provides spherical data types, functions, operators, and indexing for PostgreSQL or Greenplum database.
 -   [pgvector](pgvector/pgvector.html) - Provides vector similarity search capabilities for Greenplum Database that enable searching, storing, and querying machine language-generated embeddings at large scale.
 -   [postgres\_fdw](postgres_fdw.html) - Provides a foreign data wrapper \(FDW\) for accessing data stored in an external PostgreSQL or Greenplum database.
 -   [postgresql-hll](postgresql-hll.html) - Provides HyperLogLog data types for PostgreSQL and Greenplum Database.

--- a/gpdb-doc/markdown/ref_guide/modules/pgsphere.html.md
+++ b/gpdb-doc/markdown/ref_guide/modules/pgsphere.html.md
@@ -1,0 +1,29 @@
+---
+title: pgsphere 
+---
+
+The phsphere module provides spherical data types, functions, operators, and indexing for PostgreSQL or Greenplum database.
+
+## <a id="topic_reg"></a>Installing and Registering the Module
+
+The `pgsphere` module is installed when you install Greenplum Database. Before you can use it, you must register the `pgsphere` extension in each database in which you want to use these:
+
+```
+CREATE EXTENSION pgsphere;
+```
+
+Refer to [Installing Additional Supplied Modules](../../../install_guide/install_modules.html) for more information.
+
+## <a id="topic_upgrading"></a>Upgrading the Module
+
+The `pgsphere` module is installed when you install or upgrade Greenplum Database. A previous version of the extension will continue to work in existing databases after you upgrade Greenplum. To upgrade to the most recent version of the extension, you must:
+
+```
+ALTER EXTENSION pgsphere UPDATE TO '1.5.0';
+```
+
+in **every** database in which you registered/use the extension.
+
+## <a id="topic_docs"></a>Module Documentation
+
+Refer to the [pgsphere github documentation](https://github.com/postgrespro/pgsphere/blob/master/README.pg_sphere) for detailed information about using the module.


### PR DESCRIPTION
This PR adds a page for the pgpshere documentation reference pages.
