### PR TITLE
[Doc] Add an description entry for pg_config --gp_version.

### DIFF
--- a/gpdb-doc/markdown/utility_guide/ref/pg_config.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/pg_config.html.md
@@ -9,7 +9,7 @@ pg_config [<option> ...]
 
 pg_config -? | --help
 
-pg_config --version
+pg_config --gp_version
 ```
 
 ## <a id="section3"></a>Description 
@@ -84,6 +84,9 @@ If more than one option is given, the information is printed in that order, one 
 :   Print the value of the `LIBS` variable that was used for building Greenplum Database. This normally contains `-l` switches for external libraries linked into Greenplum Database.
 
 --version
+:   Print the version of PostgreSQL backend server.
+
+--gp_version
 :   Print the version of Greenplum Database.
 
 ## <a id="section5"></a>Examples 


### PR DESCRIPTION
With commit a427242, we are able to retrieve the version of Greenplum via 'pg_config --gp_version'. This patch adds doc about it with little correction.
