### PR TITLE
remove fixme in nodeLockRows.c

### DIFF
--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -110,11 +110,6 @@ lnext:
 		}
 		erm->ermActive = true;
 
-		/*
-		 * GPDB_96_MERGE_FIXME: Shouldn't we fetch gp_segment_id as well, and
-		 * verify that this tuple originated from this server?
-		 */
-
 		/* fetch the tuple's ctid */
 		datum = ExecGetJunkAttribute(slot,
 									 aerm->ctidAttNo,


### PR DESCRIPTION
In GPDB, we generate LockRows plan node only when Global Deadlock Detector is enabled and the select statement with locking clause contains only one table. In such case, we can sure that there are no motions, don't bother to check gp_segment_id here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
