### PR TITLE
[6X] Fix join condition lost after pull up sublink to join

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -406,6 +406,13 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 		 */
 		context->safeToConvert = false;
 	}
+	else
+	{
+		/*
+		 * For other expressions, we should keep them in original place.
+		 */
+		context->innerQual = make_and_qual(context->innerQual, node);
+	}
 
 	return;
 }

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -1077,3 +1077,85 @@ select (select max((select t.i))) from t;
 (1 row)
 
 drop table t;
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+explain(costs off, verbose on)
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   Output: tl1.a, tl1.b, tl1.c, tl1.d
+   ->  Hash Join
+         Output: tl1.a, tl1.b, tl1.c, tl1.d
+         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)
+               Output: tl1.a, tl1.b, tl1.c, tl1.d
+               Hash Key: tl1.c
+               ->  Seq Scan on public.tl1
+                     Output: tl1.a, tl1.b, tl1.c, tl1.d
+         ->  Hash
+               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+               ->  Subquery Scan on "Expr_SUBQUERY"
+                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                     ->  HashAggregate
+                           Output: tl2.b, max((max(tl2.a)))
+                           Group Key: tl2.b
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: tl2.b, (max(tl2.a))
+                                 Hash Key: tl2.b
+                                 ->  HashAggregate
+                                       Output: tl2.b, max(tl2.a)
+                                       Group Key: tl2.b
+                                       ->  Hash Join
+                                             Output: tl2.b, tl2.a
+                                             Hash Cond: (tl4.d = tl2.d)
+                                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                   Output: tl4.d, tl4.a
+                                                   ->  Seq Scan on public.tl4
+                                                         Output: tl4.d, tl4.a
+                                             ->  Hash
+                                                   Output: tl2.b, tl2.a, tl2.d
+                                                   ->  Seq Scan on public.tl2
+                                                         Output: tl2.b, tl2.a, tl2.d
+ Optimizer: Postgres query optimizer
+ Settings: optimizer=off
+(36 rows)
+
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1147,3 +1147,91 @@ select (select max((select t.i))) from t;
 (1 row)
 
 drop table t;
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+explain(costs off, verbose on)
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+                                                     QUERY PLAN                                                      
+---------------------------------------------------------------------------------------------------------------------
+ Hash Join
+   Output: tl1.a, tl1.b, tl1.c, tl1.d
+   Hash Cond: ((tl1.b = (max((max(tl2.a))))) AND (tl1.c = tl2.b))
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Output: tl1.a, tl1.b, tl1.c, tl1.d
+         ->  Seq Scan on public.tl1
+               Output: tl1.a, tl1.b, tl1.c, tl1.d
+   ->  Hash
+         Output: tl2.b, (max((max(tl2.a))))
+         ->  Gather Motion 3:1  (slice4; segments: 3)
+               Output: tl2.b, (max((max(tl2.a))))
+               ->  Result
+                     Output: tl2.b, (max((max(tl2.a))))
+                     ->  GroupAggregate
+                           Output: max((max(tl2.a))), tl2.b
+                           Group Key: tl2.b
+                           ->  Sort
+                                 Output: tl2.b, (max(tl2.a))
+                                 Sort Key: tl2.b
+                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                       Output: tl2.b, (max(tl2.a))
+                                       Hash Key: tl2.b
+                                       ->  Result
+                                             Output: tl2.b, (max(tl2.a))
+                                             ->  GroupAggregate
+                                                   Output: max(tl2.a), tl2.b
+                                                   Group Key: tl2.b
+                                                   ->  Sort
+                                                         Output: tl2.a, tl2.b
+                                                         Sort Key: tl2.b
+                                                         ->  Hash Join
+                                                               Output: tl2.a, tl2.b
+                                                               Hash Cond: (tl2.d = tl4.d)
+                                                               ->  Seq Scan on public.tl2
+                                                                     Output: tl2.a, tl2.b, tl2.d
+                                                               ->  Hash
+                                                                     Output: tl4.d
+                                                                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                                                           Output: tl4.d
+                                                                           ->  Seq Scan on public.tl4
+                                                                                 Output: tl4.d
+ Optimizer: Pivotal Optimizer (GPORCA)
+(42 rows)
+
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -571,3 +571,46 @@ select (select max((select t.i))) from t;
 select (select max((select t.i))) from t;
 
 drop table t;
+
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
+
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+
+explain(costs off, verbose on)
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+
+select * from tl1
+where
+  tl1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl4
+      on tl4.d = tl2.d
+    where
+      tl2.b = tl1.c
+  );
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;


### PR DESCRIPTION
from main branch https://github.com/greenplum-db/gpdb/pull/17115
As we pull up the sublink to join, the raw join condition is lost in such case:

```
postgres=# explain (costs off, verbose on) WITH cte1(a, b, c, d) AS
(
  select * from tl1
) 
select * from cte1 
where 
  cte1.b = (
    select 
      max(tl2.a) 
    from 
      tl2 join tl3 on tl3.c = tl2.c 
      join tl4 on tl4.d = tl2.d 
    where 
      tl2.b = cte1.c
  );
                                               QUERY PLAN                                                
---------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice5; segments: 3)
   Output: tl1.a, tl1.b, tl1.c, tl1.d
   ->  Hash Join
         Output: tl1.a, tl1.b, tl1.c, tl1.d
         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
         ->  Seq Scan on public.tl1
               Output: tl1.a, tl1.b, tl1.c, tl1.d
         ->  Hash
               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
                     ->  Subquery Scan on "Expr_SUBQUERY"
                           Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
                           ->  HashAggregate
                                 Output: tl2.b, max((max(tl2.a)))
                                 Group Key: tl2.b
                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                       Output: tl2.b, (max(tl2.a))
                                       Hash Key: tl2.b
                                       ->  HashAggregate
                                             Output: tl2.b, max(tl2.a)
                                             Group Key: tl2.b
                                             ->  Nested Loop
                                                   Output: tl2.b, tl2.a
                                                   ->  Hash Join
                                                         Output: tl2.b, tl2.a
                                                         Hash Cond: (tl3.c = tl2.c)
                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                                               Output: tl3.c, tl3.a
                                                               ->  Seq Scan on public.tl3
                                                                     Output: tl3.c, tl3.a
                                                         ->  Hash
                                                               Output: tl2.b, tl2.a, tl2.c
                                                               ->  Seq Scan on public.tl2
                                                                     Output: tl2.b, tl2.a, tl2.c
                                                   ->  Materialize
                                                         Output: tl4.a
                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                                               Output: tl4.a
                                                               ->  Seq Scan on public.tl4
                                                                     Output: tl4.a
 Optimizer: Postgres query optimizer
 Settings: optimizer=off
(43 rows)
```
join condition in original place `tl4.d = tl2.d` lost after pulled up, so we need to keep those original uncorrelated
condition in `SubqueryToJoinWalker`

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
