### PR TITLE
Fix join condition lost after pull up sublink to join

### DIFF
--- a/src/backend/cdb/cdbsubselect.c
+++ b/src/backend/cdb/cdbsubselect.c
@@ -460,6 +460,13 @@ SubqueryToJoinWalker(Node *node, ConvertSubqueryToJoinContext *context)
 		 */
 		context->safeToConvert = false;
 	}
+	else
+	{
+		/*
+		 * For other expressions, we should keep them in original place.
+		 */
+		context->innerQual = make_and_qual(context->innerQual, node);
+	}
 
 	return;
 }

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2073,3 +2073,113 @@ select (select max((select t.i))) from t;
 (1 row)
 
 drop table t;
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl2(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl3(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl4(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+explain(costs off, verbose on)
+WITH cte1(a, b, c, d) AS
+(
+  select * from tl1
+)
+select * from cte1
+where
+  cte1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl3 on tl3.c = tl2.c
+      join tl4 on tl4.d = tl2.d
+    where
+      tl2.b = cte1.c
+  );
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: tl1.a, tl1.b, tl1.c, tl1.d
+   ->  Hash Join
+         Output: tl1.a, tl1.b, tl1.c, tl1.d
+         Inner Unique: true
+         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
+         ->  Seq Scan on public.tl1
+               Output: tl1.a, tl1.b, tl1.c, tl1.d
+         ->  Hash
+               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                     ->  Subquery Scan on "Expr_SUBQUERY"
+                           Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                           ->  Finalize GroupAggregate
+                                 Output: tl2.b, max(tl2.a)
+                                 Group Key: tl2.b
+                                 ->  Sort
+                                       Output: tl2.b, (PARTIAL max(tl2.a))
+                                       Sort Key: tl2.b
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: tl2.b, (PARTIAL max(tl2.a))
+                                             Hash Key: tl2.b
+                                             ->  Partial HashAggregate
+                                                   Output: tl2.b, PARTIAL max(tl2.a)
+                                                   Group Key: tl2.b
+                                                   ->  Hash Join
+                                                         Output: tl2.b, tl2.a
+                                                         Hash Cond: (tl2.d = tl4.d)
+                                                         ->  Hash Join
+                                                               Output: tl2.b, tl2.a, tl2.d
+                                                               Hash Cond: (tl3.c = tl2.c)
+                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                                     Output: tl3.c
+                                                                     ->  Seq Scan on public.tl3
+                                                                           Output: tl3.c
+                                                               ->  Hash
+                                                                     Output: tl2.b, tl2.a, tl2.c, tl2.d
+                                                                     ->  Seq Scan on public.tl2
+                                                                           Output: tl2.b, tl2.a, tl2.c, tl2.d
+                                                         ->  Hash
+                                                               Output: tl4.d
+                                                               ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                                     Output: tl4.d
+                                                                     ->  Seq Scan on public.tl4
+                                                                           Output: tl4.d
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off'
+(48 rows)
+
+WITH cte1(a, b, c, d) AS
+(
+  select * from tl1
+)
+select * from cte1
+where
+  cte1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl3 on tl3.c = tl2.c
+      join tl4 on tl4.d = tl2.d
+    where
+      tl2.b = cte1.c
+  );
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2085,23 +2085,19 @@ insert into tl2 values (1, 1, 1, 0);
 insert into tl3 values (9, 9, 1, 9);
 insert into tl4 values (-1, -1, -1, -1);
 explain(costs off, verbose on)
-WITH cte1(a, b, c, d) AS
-(
-  select * from tl1
-)
-select * from cte1
+select * from tl1
 where
-  cte1.b = (
+  tl1.b = (
     select
       max(tl2.a)
     from
-      tl2 join tl3 on tl3.c = tl2.c
-      join tl4 on tl4.d = tl2.d
+      tl2 join tl4
+      on tl4.d = tl2.d
     where
-      tl2.b = cte1.c
+      tl2.b = tl1.c
   );
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                               QUERY PLAN                                                
+---------------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: tl1.a, tl1.b, tl1.c, tl1.d
    ->  Hash Join
@@ -2130,42 +2126,29 @@ where
                                                    Group Key: tl2.b
                                                    ->  Hash Join
                                                          Output: tl2.b, tl2.a
-                                                         Hash Cond: (tl2.d = tl4.d)
-                                                         ->  Hash Join
-                                                               Output: tl2.b, tl2.a, tl2.d
-                                                               Hash Cond: (tl3.c = tl2.c)
-                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                                     Output: tl3.c
-                                                                     ->  Seq Scan on public.tl3
-                                                                           Output: tl3.c
-                                                               ->  Hash
-                                                                     Output: tl2.b, tl2.a, tl2.c, tl2.d
-                                                                     ->  Seq Scan on public.tl2
-                                                                           Output: tl2.b, tl2.a, tl2.c, tl2.d
-                                                         ->  Hash
+                                                         Hash Cond: (tl4.d = tl2.d)
+                                                         ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                                                Output: tl4.d
-                                                               ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                               ->  Seq Scan on public.tl4
                                                                      Output: tl4.d
-                                                                     ->  Seq Scan on public.tl4
-                                                                           Output: tl4.d
+                                                         ->  Hash
+                                                               Output: tl2.b, tl2.a, tl2.d
+                                                               ->  Seq Scan on public.tl2
+                                                                     Output: tl2.b, tl2.a, tl2.d
  Optimizer: Postgres-based planner
  Settings: optimizer = 'off'
-(48 rows)
+(39 rows)
 
-WITH cte1(a, b, c, d) AS
-(
-  select * from tl1
-)
-select * from cte1
+select * from tl1
 where
-  cte1.b = (
+  tl1.b = (
     select
       max(tl2.a)
     from
-      tl2 join tl3 on tl3.c = tl2.c
-      join tl4 on tl4.d = tl2.d
+      tl2 join tl4
+      on tl4.d = tl2.d
     where
-      tl2.b = cte1.c
+      tl2.b = tl1.c
   );
  a | b | c | d 
 ---+---+---+---

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -2074,18 +2074,10 @@ select (select max((select t.i))) from t;
 
 drop table t;
 -- Fix join condition expression lost as pull up sublink to join.
-create table tl1(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table tl2(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table tl3(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table tl4(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
 insert into tl1 values (-1, 3, 1, 0);
 insert into tl2 values (2, 1, 1, 0);
 insert into tl2 values (3, 1, 1, 0);

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2174,86 +2174,68 @@ insert into tl2 values (1, 1, 1, 0);
 insert into tl3 values (9, 9, 1, 9);
 insert into tl4 values (-1, -1, -1, -1);
 explain(costs off, verbose on)
-WITH cte1(a, b, c, d) AS
-(
-  select * from tl1
-)
-select * from cte1
+select * from tl1
 where
-  cte1.b = (
+  tl1.b = (
     select
       max(tl2.a)
     from
-      tl2 join tl3 on tl3.c = tl2.c
-      join tl4 on tl4.d = tl2.d
+      tl2 join tl4
+      on tl4.d = tl2.d
     where
-      tl2.b = cte1.c
+      tl2.b = tl1.c
   );
-                                                  QUERY PLAN                                                   
----------------------------------------------------------------------------------------------------------------
+                                           QUERY PLAN                                           
+------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: tl1.a, tl1.b, tl1.c, tl1.d
    ->  Hash Join
          Output: tl1.a, tl1.b, tl1.c, tl1.d
-         Inner Unique: true
-         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
-         ->  Seq Scan on public.tl1
+         Hash Cond: ((tl1.b = (max(tl2.a))) AND (tl1.c = tl2.b))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
                Output: tl1.a, tl1.b, tl1.c, tl1.d
+               Hash Key: tl1.c
+               ->  Seq Scan on public.tl1
+                     Output: tl1.a, tl1.b, tl1.c, tl1.d
          ->  Hash
-               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
-               ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
-                     ->  Subquery Scan on "Expr_SUBQUERY"
-                           Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
-                           ->  Finalize GroupAggregate
-                                 Output: tl2.b, max(tl2.a)
-                                 Group Key: tl2.b
-                                 ->  Sort
-                                       Output: tl2.b, (PARTIAL max(tl2.a))
-                                       Sort Key: tl2.b
-                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                                             Output: tl2.b, (PARTIAL max(tl2.a))
-                                             Hash Key: tl2.b
-                                             ->  Partial HashAggregate
-                                                   Output: tl2.b, PARTIAL max(tl2.a)
-                                                   Group Key: tl2.b
-                                                   ->  Hash Join
-                                                         Output: tl2.b, tl2.a
-                                                         Hash Cond: (tl2.d = tl4.d)
-                                                         ->  Hash Join
-                                                               Output: tl2.b, tl2.a, tl2.d
-                                                               Hash Cond: (tl3.c = tl2.c)
-                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
-                                                                     Output: tl3.c
-                                                                     ->  Seq Scan on public.tl3
-                                                                           Output: tl3.c
-                                                               ->  Hash
-                                                                     Output: tl2.b, tl2.a, tl2.c, tl2.d
-                                                                     ->  Seq Scan on public.tl2
-                                                                           Output: tl2.b, tl2.a, tl2.c, tl2.d
-                                                         ->  Hash
-                                                               Output: tl4.d
-                                                               ->  Broadcast Motion 3:3  (slice5; segments: 3)
-                                                                     Output: tl4.d
-                                                                     ->  Seq Scan on public.tl4
-                                                                           Output: tl4.d
- Optimizer: Postgres-based planner
-(47 rows)
+               Output: (max(tl2.a)), tl2.b
+               ->  GroupAggregate
+                     Output: max(tl2.a), tl2.b
+                     Group Key: tl2.b
+                     ->  Sort
+                           Output: tl2.a, tl2.b
+                           Sort Key: tl2.b
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Output: tl2.a, tl2.b
+                                 Hash Key: tl2.b
+                                 ->  Hash Join
+                                       Output: tl2.a, tl2.b
+                                       Hash Cond: (tl2.d = tl4.d)
+                                       ->  Redistribute Motion 3:3  (slice4; segments: 3)
+                                             Output: tl2.a, tl2.b, tl2.d
+                                             Hash Key: tl2.d
+                                             ->  Seq Scan on public.tl2
+                                                   Output: tl2.a, tl2.b, tl2.d
+                                       ->  Hash
+                                             Output: tl4.d
+                                             ->  Redistribute Motion 3:3  (slice5; segments: 3)
+                                                   Output: tl4.d
+                                                   Hash Key: tl4.d
+                                                   ->  Seq Scan on public.tl4
+                                                         Output: tl4.d
+ Optimizer: GPORCA
+(37 rows)
 
-WITH cte1(a, b, c, d) AS
-(
-  select * from tl1
-)
-select * from cte1
+select * from tl1
 where
-  cte1.b = (
+  tl1.b = (
     select
       max(tl2.a)
     from
-      tl2 join tl3 on tl3.c = tl2.c
-      join tl4 on tl4.d = tl2.d
+      tl2 join tl4
+      on tl4.d = tl2.d
     where
-      tl2.b = cte1.c
+      tl2.b = tl1.c
   );
  a | b | c | d 
 ---+---+---+---

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2163,18 +2163,10 @@ select (select max((select t.i))) from t;
 
 drop table t;
 -- Fix join condition expression lost as pull up sublink to join.
-create table tl1(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table tl2(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table tl3(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-create table tl4(a int, b int, c int, d int);
-NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
-HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
 insert into tl1 values (-1, 3, 1, 0);
 insert into tl2 values (2, 1, 1, 0);
 insert into tl2 values (3, 1, 1, 0);

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -2162,3 +2162,112 @@ select (select max((select t.i))) from t;
 (1 row)
 
 drop table t;
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl2(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl3(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tl4(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+explain(costs off, verbose on)
+WITH cte1(a, b, c, d) AS
+(
+  select * from tl1
+)
+select * from cte1
+where
+  cte1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl3 on tl3.c = tl2.c
+      join tl4 on tl4.d = tl2.d
+    where
+      tl2.b = cte1.c
+  );
+                                                  QUERY PLAN                                                   
+---------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   Output: tl1.a, tl1.b, tl1.c, tl1.d
+   ->  Hash Join
+         Output: tl1.a, tl1.b, tl1.c, tl1.d
+         Inner Unique: true
+         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
+         ->  Seq Scan on public.tl1
+               Output: tl1.a, tl1.b, tl1.c, tl1.d
+         ->  Hash
+               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+               ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                     ->  Subquery Scan on "Expr_SUBQUERY"
+                           Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
+                           ->  Finalize GroupAggregate
+                                 Output: tl2.b, max(tl2.a)
+                                 Group Key: tl2.b
+                                 ->  Sort
+                                       Output: tl2.b, (PARTIAL max(tl2.a))
+                                       Sort Key: tl2.b
+                                       ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                             Output: tl2.b, (PARTIAL max(tl2.a))
+                                             Hash Key: tl2.b
+                                             ->  Partial HashAggregate
+                                                   Output: tl2.b, PARTIAL max(tl2.a)
+                                                   Group Key: tl2.b
+                                                   ->  Hash Join
+                                                         Output: tl2.b, tl2.a
+                                                         Hash Cond: (tl2.d = tl4.d)
+                                                         ->  Hash Join
+                                                               Output: tl2.b, tl2.a, tl2.d
+                                                               Hash Cond: (tl3.c = tl2.c)
+                                                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
+                                                                     Output: tl3.c
+                                                                     ->  Seq Scan on public.tl3
+                                                                           Output: tl3.c
+                                                               ->  Hash
+                                                                     Output: tl2.b, tl2.a, tl2.c, tl2.d
+                                                                     ->  Seq Scan on public.tl2
+                                                                           Output: tl2.b, tl2.a, tl2.c, tl2.d
+                                                         ->  Hash
+                                                               Output: tl4.d
+                                                               ->  Broadcast Motion 3:3  (slice5; segments: 3)
+                                                                     Output: tl4.d
+                                                                     ->  Seq Scan on public.tl4
+                                                                           Output: tl4.d
+ Optimizer: Postgres-based planner
+(47 rows)
+
+WITH cte1(a, b, c, d) AS
+(
+  select * from tl1
+)
+select * from cte1
+where
+  cte1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl3 on tl3.c = tl2.c
+      join tl4 on tl4.d = tl2.d
+    where
+      tl2.b = cte1.c
+  );
+ a | b | c | d 
+---+---+---+---
+(0 rows)
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1041,36 +1041,28 @@ insert into tl3 values (9, 9, 1, 9);
 insert into tl4 values (-1, -1, -1, -1);
 
 explain(costs off, verbose on)
-WITH cte1(a, b, c, d) AS
-(
-  select * from tl1
-)
-select * from cte1
+select * from tl1
 where
-  cte1.b = (
+  tl1.b = (
     select
       max(tl2.a)
     from
-      tl2 join tl3 on tl3.c = tl2.c
-      join tl4 on tl4.d = tl2.d
+      tl2 join tl4
+      on tl4.d = tl2.d
     where
-      tl2.b = cte1.c
+      tl2.b = tl1.c
   );
 
-WITH cte1(a, b, c, d) AS
-(
-  select * from tl1
-)
-select * from cte1
+select * from tl1
 where
-  cte1.b = (
+  tl1.b = (
     select
       max(tl2.a)
     from
-      tl2 join tl3 on tl3.c = tl2.c
-      join tl4 on tl4.d = tl2.d
+      tl2 join tl4
+      on tl4.d = tl2.d
     where
-      tl2.b = cte1.c
+      tl2.b = tl1.c
   );
 
 drop table tl1;

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1028,10 +1028,10 @@ select (select max((select t.i))) from t;
 drop table t;
 
 -- Fix join condition expression lost as pull up sublink to join.
-create table tl1(a int, b int, c int, d int);
-create table tl2(a int, b int, c int, d int);
-create table tl3(a int, b int, c int, d int);
-create table tl4(a int, b int, c int, d int);
+create table tl1(a int, b int, c int, d int) distributed by (a);
+create table tl2(a int, b int, c int, d int) distributed by (a);
+create table tl3(a int, b int, c int, d int) distributed by (a);
+create table tl4(a int, b int, c int, d int) distributed by (a);
 
 insert into tl1 values (-1, 3, 1, 0);
 insert into tl2 values (2, 1, 1, 0);

--- a/src/test/regress/sql/subselect.sql
+++ b/src/test/regress/sql/subselect.sql
@@ -1026,3 +1026,54 @@ select (select max((select t.i))) from t;
 select (select max((select t.i))) from t;
 
 drop table t;
+
+-- Fix join condition expression lost as pull up sublink to join.
+create table tl1(a int, b int, c int, d int);
+create table tl2(a int, b int, c int, d int);
+create table tl3(a int, b int, c int, d int);
+create table tl4(a int, b int, c int, d int);
+
+insert into tl1 values (-1, 3, 1, 0);
+insert into tl2 values (2, 1, 1, 0);
+insert into tl2 values (3, 1, 1, 0);
+insert into tl2 values (1, 1, 1, 0);
+insert into tl3 values (9, 9, 1, 9);
+insert into tl4 values (-1, -1, -1, -1);
+
+explain(costs off, verbose on)
+WITH cte1(a, b, c, d) AS
+(
+  select * from tl1
+)
+select * from cte1
+where
+  cte1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl3 on tl3.c = tl2.c
+      join tl4 on tl4.d = tl2.d
+    where
+      tl2.b = cte1.c
+  );
+
+WITH cte1(a, b, c, d) AS
+(
+  select * from tl1
+)
+select * from cte1
+where
+  cte1.b = (
+    select
+      max(tl2.a)
+    from
+      tl2 join tl3 on tl3.c = tl2.c
+      join tl4 on tl4.d = tl2.d
+    where
+      tl2.b = cte1.c
+  );
+
+drop table tl1;
+drop table tl2;
+drop table tl3;
+drop table tl4;


### PR DESCRIPTION
As we pull up the sublink to join, the raw join condition is lost in such case:

```
postgres=# explain (costs off, verbose on) WITH cte1(a, b, c, d) AS
(
  select * from tl1
) 
select * from cte1 
where 
  cte1.b = (
    select 
      max(tl2.a) 
    from 
      tl2 join tl3 on tl3.c = tl2.c 
      join tl4 on tl4.d = tl2.d 
    where 
      tl2.b = cte1.c
  );
                                               QUERY PLAN                                                
---------------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice5; segments: 3)
   Output: tl1.a, tl1.b, tl1.c, tl1.d
   ->  Hash Join
         Output: tl1.a, tl1.b, tl1.c, tl1.d
         Hash Cond: ((tl1.b = "Expr_SUBQUERY".csq_c1) AND (tl1.c = "Expr_SUBQUERY".csq_c0))
         ->  Seq Scan on public.tl1
               Output: tl1.a, tl1.b, tl1.c, tl1.d
         ->  Hash
               Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                     Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
                     ->  Subquery Scan on "Expr_SUBQUERY"
                           Output: "Expr_SUBQUERY".csq_c1, "Expr_SUBQUERY".csq_c0
                           ->  HashAggregate
                                 Output: tl2.b, max((max(tl2.a)))
                                 Group Key: tl2.b
                                 ->  Redistribute Motion 3:3  (slice3; segments: 3)
                                       Output: tl2.b, (max(tl2.a))
                                       Hash Key: tl2.b
                                       ->  HashAggregate
                                             Output: tl2.b, max(tl2.a)
                                             Group Key: tl2.b
                                             ->  Nested Loop
                                                   Output: tl2.b, tl2.a
                                                   ->  Hash Join
                                                         Output: tl2.b, tl2.a
                                                         Hash Cond: (tl3.c = tl2.c)
                                                         ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                                               Output: tl3.c, tl3.a
                                                               ->  Seq Scan on public.tl3
                                                                     Output: tl3.c, tl3.a
                                                         ->  Hash
                                                               Output: tl2.b, tl2.a, tl2.c
                                                               ->  Seq Scan on public.tl2
                                                                     Output: tl2.b, tl2.a, tl2.c
                                                   ->  Materialize
                                                         Output: tl4.a
                                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                                               Output: tl4.a
                                                               ->  Seq Scan on public.tl4
                                                                     Output: tl4.a
 Optimizer: Postgres query optimizer
 Settings: optimizer=off
(43 rows)
```
join condition in original place `tl4.d = tl2.d` lost after pulled up, so we need to keep those original uncorrelated
condition in `SubqueryToJoinWalker`

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
