### PR TITLE
[6x only]Introduce GUC `gp_enable_mdqa_shared_scan` for queries with multi-DQA

### DIFF
--- a/src/backend/cdb/cdbgroup.c
+++ b/src/backend/cdb/cdbgroup.c
@@ -5203,7 +5203,7 @@ cost_3phase_aggregation(PlannerInfo *root, MppGroupContext *ctx, AggPlanInfo *in
 	}
 
 	/* Determine whether to use input sharing. */
-	if (ctx->numDistinctCols < 2)
+	if (ctx->numDistinctCols < 2 || !gp_enable_mdqa_shared_scan)
 	{
 		reexec_cost = total_cost;
 		use_sharing = false;

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -295,6 +295,7 @@ bool		gp_log_dynamic_partition_pruning = false;
 bool		gp_cte_sharing = false;
 bool		gp_enable_relsize_collection = false;
 bool		gp_recursive_cte = true;
+bool		gp_enable_mdqa_shared_scan = true;
 
 /* Optimizer related gucs */
 bool		optimizer;
@@ -2072,6 +2073,18 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&gp_recursive_cte,
+		true, NULL, NULL
+	},
+
+		{
+		{"gp_enable_mdqa_shared_scan", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Planner Only. True: planner will decide whether to use shared scan in the plan for"
+			"multiple DQA query based on costs calculation for better performance. False: disable it to avoid"
+			"large spill file."),
+			NULL,
+			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_enable_mdqa_shared_scan,
 		true, NULL, NULL
 	},
 

--- a/src/include/cdb/cdbvars.h
+++ b/src/include/cdb/cdbvars.h
@@ -797,6 +797,8 @@ extern bool gp_dynamic_partition_pruning;
 extern bool gp_cte_sharing;
 /* Enable RECURSIVE clauses in common table expressions */
 extern bool gp_recursive_cte;
+/* Enable shared scan in three stage agg */
+extern bool gp_enable_mdqa_shared_scan;
 
 /* Enable check for compatibility of encoding and locale in createdb */
 extern bool gp_encoding_check_locale_compatibility;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -184,6 +184,7 @@
 		"gp_enable_minmax_optimization",
 		"gp_enable_minmax_optimization",
 		"gp_enable_motion_deadlock_sanity",
+		"gp_enable_mdqa_shared_scan",
 		"gp_enable_multiphase_agg",
 		"gp_enable_predicate_propagation",
 		"gp_enable_preunique",

--- a/src/test/regress/expected/gp_aggregates.out
+++ b/src/test/regress/expected/gp_aggregates.out
@@ -648,3 +648,79 @@ GROUP BY bb.v;
 
 reset optimizer;
 reset enable_groupagg;
+-- test multi DQA with guc gp_enable_mdqa_shared_scan
+set optimizer = off; -- the case is planner only, so disable orca
+set gp_enable_mdqa_shared_scan = true;
+explain select sum(distinct a), sum(distinct b), c from agg_a group by c;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.59..2.64 rows=1 width=48)
+   ->  Hash Join  (cost=2.59..2.64 rows=1 width=48)
+         Hash Cond: (NOT (share0_ref2.c IS DISTINCT FROM share0_ref1.c))
+         ->  HashAggregate  (cost=1.29..1.30 rows=1 width=24)
+               Group Key: share0_ref2.c
+               ->  HashAggregate  (cost=1.27..1.28 rows=1 width=20)
+                     Group Key: share0_ref2.c, share0_ref2.a
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.23..1.25 rows=1 width=20)
+                           Hash Key: share0_ref2.c
+                           ->  HashAggregate  (cost=1.23..1.23 rows=1 width=20)
+                                 Group Key: share0_ref2.c, share0_ref2.a
+                                 ->  Shared Scan (share slice:id 1:0)  (cost=1.01..1.22 rows=1 width=13)
+         ->  Hash  (cost=1.31..1.31 rows=1 width=24)
+               ->  HashAggregate  (cost=1.29..1.30 rows=1 width=24)
+                     Group Key: share0_ref1.c
+                     ->  HashAggregate  (cost=1.27..1.28 rows=1 width=20)
+                           Group Key: share0_ref1.c, share0_ref1.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.23..1.25 rows=1 width=20)
+                                 Hash Key: share0_ref1.c
+                                 ->  HashAggregate  (cost=1.23..1.23 rows=1 width=20)
+                                       Group Key: share0_ref1.c, share0_ref1.b
+                                       ->  Shared Scan (share slice:id 2:0)  (cost=1.01..1.22 rows=1 width=13)
+                                             ->  Materialize  (cost=0.00..1.01 rows=1 width=13)
+                                                   ->  Seq Scan on agg_a  (cost=0.00..1.01 rows=1 width=13)
+ Optimizer: Postgres query optimizer
+(25 rows)
+
+select sum(distinct a), sum(distinct b), c from agg_a group by c;
+ sum | sum |  c  
+-----+-----+-----
+   1 |   1 | 100
+(1 row)
+
+set gp_enable_mdqa_shared_scan = false;
+explain select sum(distinct a), sum(distinct b), c from agg_a group by c;
+                                                   QUERY PLAN                                                    
+-----------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=2.17..2.22 rows=1 width=48)
+   ->  Hash Join  (cost=2.17..2.22 rows=1 width=48)
+         Hash Cond: (NOT (agg_a.c IS DISTINCT FROM agg_a_1.c))
+         ->  HashAggregate  (cost=1.09..1.10 rows=1 width=24)
+               Group Key: agg_a.c
+               ->  HashAggregate  (cost=1.06..1.07 rows=1 width=20)
+                     Group Key: agg_a.c, agg_a.a
+                     ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=1.02..1.04 rows=1 width=20)
+                           Hash Key: agg_a.c
+                           ->  HashAggregate  (cost=1.02..1.02 rows=1 width=20)
+                                 Group Key: agg_a.c, agg_a.a
+                                 ->  Seq Scan on agg_a  (cost=0.00..1.01 rows=1 width=13)
+         ->  Hash  (cost=1.11..1.11 rows=1 width=24)
+               ->  HashAggregate  (cost=1.09..1.10 rows=1 width=24)
+                     Group Key: agg_a_1.c
+                     ->  HashAggregate  (cost=1.06..1.07 rows=1 width=20)
+                           Group Key: agg_a_1.c, agg_a_1.b
+                           ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=1.02..1.04 rows=1 width=20)
+                                 Hash Key: agg_a_1.c
+                                 ->  HashAggregate  (cost=1.02..1.02 rows=1 width=20)
+                                       Group Key: agg_a_1.c, agg_a_1.b
+                                       ->  Seq Scan on agg_a agg_a_1  (cost=0.00..1.01 rows=1 width=13)
+ Optimizer: Postgres query optimizer
+(23 rows)
+
+select sum(distinct a), sum(distinct b), c from agg_a group by c;
+ sum | sum |  c  
+-----+-----+-----
+   1 |   1 | 100
+(1 row)
+
+reset optimizer;
+reset gp_enable_mdqa_shared_scan;

--- a/src/test/regress/sql/gp_aggregates.sql
+++ b/src/test/regress/sql/gp_aggregates.sql
@@ -247,3 +247,17 @@ ON a.a = bb.b
 GROUP BY bb.v;
 reset optimizer;
 reset enable_groupagg;
+
+-- test multi DQA with guc gp_enable_mdqa_shared_scan
+set optimizer = off; -- the case is planner only, so disable orca
+set gp_enable_mdqa_shared_scan = true;
+
+explain select sum(distinct a), sum(distinct b), c from agg_a group by c;
+select sum(distinct a), sum(distinct b), c from agg_a group by c;
+
+set gp_enable_mdqa_shared_scan = false;
+explain select sum(distinct a), sum(distinct b), c from agg_a group by c;
+select sum(distinct a), sum(distinct b), c from agg_a group by c;
+
+reset optimizer;
+reset gp_enable_mdqa_shared_scan;


### PR DESCRIPTION
Introduce GUC `gp_enable_mdqa_shared_scan ` for queries with multi-DQA

In some scenarios, using a shared scan during three-stage aggregation
can lead to significant disk I/O and generate large spill files. To
address this issue, a new GUC, `gp_enable_mdqa_shared_scan`, has been
introduced. This configuration option controls whether to use shared
scan in three-stage aggregations.

By default, `gp_enable_mdqa_shared_scan` is set to `true`, enabling
shared scans during three-stage aggregation. This default setting aims
to optimize performance in general use cases. However, for specific
scenarios where disk I/O and spill file size are concerns, users can now
disable shared scans by setting this GUC to `false`.

This change allows for more flexible performance tuning.

This change is 6x only. since GPDB7 will not generate similar query plans for multi DQA.
## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
