### PR TITLE
Remove fixme in nodeModifyTable.c.

### DIFF
--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -141,10 +141,6 @@ ExecCheckPlanOutput(Relation resultRel, List *targetList)
 			 * In any case the planner has most likely inserted an INT4 null.
 			 * What we insist on is just *some* NULL constant.
 			 */
-			/* GPDB_96_MERGE_FIXME: the subplan can be a Motion, so that the NULLs
-			 * are transferred through the Motion node.
-			 */
-#if 0
 			if (!IsA(tle->expr, Const) ||
 				!((Const *) tle->expr)->constisnull)
 				ereport(ERROR,
@@ -152,7 +148,6 @@ ExecCheckPlanOutput(Relation resultRel, List *targetList)
 						 errmsg("table row type and query-specified row type do not match"),
 						 errdetail("Query provides a value for a dropped column at ordinal position %d.",
 								   attno)));
-#endif
 		}
 	}
 	if (attno != resultDesc->natts)

--- a/src/test/regress/expected/update_gp.out
+++ b/src/test/regress/expected/update_gp.out
@@ -100,6 +100,25 @@ explain (costs off) update base_tbl set a=a+1;
 (12 rows)
 
 update base_tbl set a = 5;
+-- Test dropped column for update.
+alter table base_tbl drop column b;
+explain (costs off) update base_tbl set a=a+1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Update on base_tbl
+   Update on base_tbl
+   Update on child_a
+   Update on child_b
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
+         ->  Split
+               ->  Seq Scan on base_tbl
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+         ->  Split
+               ->  Seq Scan on child_a
+   ->  Seq Scan on child_b
+ Optimizer: Postgres-based planner
+(12 rows)
+
 --
 -- Explicit Distribution motion must be added if any of the child nodes
 -- contains any motion excluding the motions in initplans.

--- a/src/test/regress/expected/update_gp_optimizer.out
+++ b/src/test/regress/expected/update_gp_optimizer.out
@@ -100,6 +100,25 @@ explain (costs off) update base_tbl set a=a+1;
 (12 rows)
 
 update base_tbl set a = 5;
+-- Test dropped column for update.
+alter table base_tbl drop column b;
+explain (costs off) update base_tbl set a=a+1;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Update on base_tbl
+   Update on base_tbl
+   Update on child_a
+   Update on child_b
+   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
+         ->  Split
+               ->  Seq Scan on base_tbl
+   ->  Explicit Redistribute Motion 3:3  (slice2; segments: 3)
+         ->  Split
+               ->  Seq Scan on child_a
+   ->  Seq Scan on child_b
+ Optimizer: Postgres-based planner
+(12 rows)
+
 --
 -- Explicit Distribution motion must be added if any of the child nodes
 -- contains any motion excluding the motions in initplans.

--- a/src/test/regress/sql/update_gp.sql
+++ b/src/test/regress/sql/update_gp.sql
@@ -72,6 +72,10 @@ insert into base_tbl select g, g from generate_series(1, 5) g;
 explain (costs off) update base_tbl set a=a+1;
 update base_tbl set a = 5;
 
+-- Test dropped column for update.
+alter table base_tbl drop column b;
+explain (costs off) update base_tbl set a=a+1;
+
 --
 -- Explicit Distribution motion must be added if any of the child nodes
 -- contains any motion excluding the motions in initplans.


### PR DESCRIPTION
Before this PR, when merging 9.6, this part of the code was commented by the commit https://github.com/greenplum-db/gpdb-postgres-merge/commit/2a864ff1421a631be1ebd2fb68f93cdfb8df09a4.

The test case will report an error because the `tle->expr` is var, not const.
```
test=# create table base_tbl (a int4, b int4) distributed by (a);
CREATE TABLE
test=# insert into base_tbl select g, g from generate_series(1, 5) g;
INSERT 0 5
test=# explain (costs off) update base_tbl set a=a+1;
                          QUERY PLAN
---------------------------------------------------------------
 Update on base_tbl
   ->  Explicit Redistribute Motion 3:3  (slice1; segments: 3)
         ->  Split
               ->  Seq Scan on base_tbl
 Optimizer: Postgres query optimizer
(5 rows)

test=# alter table base_tbl drop column b;
ALTER TABLE
test=# explain (costs off) update base_tbl set a=a+1;
ERROR:  table row type and query-specified row type do not match
DETAIL:  Query provides a value for a dropped column at ordinal position 2.
```

But on the latest version, inside the `set_dummy_tlist_references()`, if it's const, it will skip `makeVar()` for the dropped column.

We have merged the commit https://github.com/greenplum-db/gpdb/commit/da8f3ebf30bef9c950595dc0d1f03bce2b1b8563 to fix the problem. So remove the fixme.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
