### PR TITLE
Remove unused buf[MAXPGPATH] variable in mdcreate_ao()

### DIFF
--- a/src/backend/storage/smgr/md.c
+++ b/src/backend/storage/smgr/md.c
@@ -353,7 +353,6 @@ void
 mdcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
 {
 	char	   *path;
-	char		buf[MAXPGPATH];
 	File		fd;
 
 	path = aorelpath(rnode, segmentFileNum);
@@ -382,8 +381,7 @@ mdcreate_ao(RelFileNodeBackend rnode, int32 segmentFileNum, bool isRedo)
 		}
 	}
 
-	if (path != buf)
-		pfree(path);
+	pfree(path);
 }
 
 /*


### PR DESCRIPTION
backport https://github.com/greenplum-db/gpdb/pull/17123

This change has no impact to existing behavior but could avoid intermediate unnecessary memory allocation.

It was forgotten to delete by https://github.com/greenplum-db/gpdb-postgres-merge/commit/92a49f49ea1d7015b702e8e9c636a096a9bf71f6#diff-30ebbb2a1d78f03e00b9464c3234529da0eeb1828ce3877750ed7969383bd8a9

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
