### PR TITLE
Improvment of cancel/terminate mechanism between QD and QE

### DIFF
--- a/src/backend/cdb/dispatcher/cdbdisp_async.c
+++ b/src/backend/cdb/dispatcher/cdbdisp_async.c
@@ -907,6 +907,71 @@ handlePollSuccess(CdbDispatchCmdAsync *pParms,
 }
 
 /*
+ * Send cancel/finish request to still-running QE through libpq.
+ * Request packet includes all backend pid in one segment, and
+ * all QEs in same segment will be killed at one time.
+ *
+ * errbuf is used to return error message(recommended size is 256 bytes).
+ *
+ * Returns true if we successfully sent a signal
+ * (not necessarily received by the target process).
+ */
+static bool
+signalSegmentQEs(CdbDispatchCmdAsync *pParms,
+				 SegmentDatabaseDescriptor *segdb,
+				 char *errbuf,
+				 bool isCancel)
+{
+	bool		ret;
+	int 		i = 0;
+	ListCell 	*lc = NULL;
+	List		*mppBackends = NIL;
+	int			numBackends = 0;
+
+	PGcancel   *cancel = PQgetCancel(segdb->conn);
+
+	if (cancel == NULL)
+		return false;
+
+	for (int i = 0; i < pParms->dispatchCount; i++)
+	{
+		CdbDispatchResult *dispatchResult = pParms->dispatchResultPtrArray[i];
+
+		Assert(dispatchResult != NULL);
+		SegmentDatabaseDescriptor *segdbDesc = dispatchResult->segdbDesc;
+
+		/*
+		 * Don't send the signal if - QE is finished or canceled - the signal
+		 * was already sent - connection is dead
+		 */
+
+		if (!dispatchResult->stillRunning ||
+			dispatchResult->wasCanceled ||
+			(pParms->waitMode == DISPATCH_WAIT_ACK_ROOT &&
+			 dispatchResult->receivedAckMsg) ||
+			cdbconn_isBadConnection(segdbDesc) ||
+			segdbDesc->segindex != segdb->segindex)
+			continue;
+
+		mppBackends = lappend_int(mppBackends, segdbDesc->backendPid);
+	}
+
+	numBackends = list_length(mppBackends);
+	int *backendsArray = palloc0(sizeof(int) * numBackends);
+
+	foreach_with_count(lc, mppBackends, i)
+		backendsArray[i] = lfirst_int(lc);
+
+	if (isCancel)
+		ret = PQMppcancel(cancel, errbuf, 256, numBackends, backendsArray);
+	else
+		ret = PQMpprequestFinish(cancel, errbuf, 256, numBackends, backendsArray);
+
+	PQfreeCancel(cancel);
+	return ret;
+}
+
+/*
  * Send finish or cancel signal to QEs if needed.
  */
 static void
@@ -914,6 +979,7 @@ signalQEs(CdbDispatchCmdAsync *pParms)
 {
 	int			i;
 	DispatchWaitMode waitMode = pParms->waitMode;
+	List			 *segindexList = NIL;
 
 	for (i = 0; i < pParms->dispatchCount; i++)
 	{
@@ -933,16 +999,19 @@ signalQEs(CdbDispatchCmdAsync *pParms)
 			dispatchResult->wasCanceled ||
 			(pParms->waitMode == DISPATCH_WAIT_ACK_ROOT &&
 			 dispatchResult->receivedAckMsg) ||
-			cdbconn_isBadConnection(segdbDesc))
+			cdbconn_isBadConnection(segdbDesc) ||
+			list_member_int(segindexList, segdbDesc->segindex))
 			continue;
+
+		segindexList = lappend_int(segindexList, segdbDesc->segindex);
 
 		memset(errbuf, 0, sizeof(errbuf));
 
-		sent = cdbconn_signalQE(segdbDesc, errbuf, waitMode == DISPATCH_WAIT_CANCEL);
+		sent = signalSegmentQEs(pParms, segdbDesc, errbuf, waitMode == DISPATCH_WAIT_CANCEL);
 		if (sent)
 			dispatchResult->sentSignal = waitMode;
 		else
-			elog(LOG, "Unable to cancel: %s",
+			elog(LOG, "Unable to Mpp cancel: %s",
 				 strlen(errbuf) == 0 ? "cannot allocate PGCancel" : errbuf);
 	}
 }

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -513,6 +513,7 @@ static int	BackendStartup(Port *port);
 static int	ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done);
 static void SendNegotiateProtocolVersion(List *unrecognized_protocol_options);
 static void processCancelRequest(Port *port, void *pkt, MsgType code);
+static void processMppRequest(Port *port, void *pkt, MsgType code);
 static int	initMasks(fd_set *rmask);
 static void report_fork_failure_to_client(Port *port, int errnum);
 static CAC_state canAcceptConnections(int backend_type);
@@ -2335,6 +2336,12 @@ ProcessStartupPacket(Port *port, bool ssl_done, bool gss_done)
 		return STATUS_ERROR;
 	}
 
+	if (proto == MPP_CANCEL_REQUEST_CODE || proto == MPP_FINISH_REQUEST_CODE)
+	{
+		processMppRequest(port, buf, proto);
+		return STATUS_ERROR;
+	}
+
 	if (proto == NEGOTIATE_SSL_CODE && !ssl_done)
 	{
 		char		SSLok;
@@ -2853,6 +2860,82 @@ processCancelRequest(Port *port, void *pkt, MsgType code)
 	CancelRequestPacket *canc = (CancelRequestPacket *) pkt;
 	int			backendPID;
 	int32		cancelAuthCode;
+	Backend    *bp;
+
+#ifndef EXEC_BACKEND
+	dlist_iter	iter;
+#else
+	int			i;
+#endif
+
+	backendPID = (int) pg_ntoh32(canc->backendPID);
+	cancelAuthCode = (int32) pg_ntoh32(canc->cancelAuthCode);
+
+	/*
+	 * See if we have a matching backend.  In the EXEC_BACKEND case, we can no
+	 * longer access the postmaster's own backend list, and must rely on the
+	 * duplicate array in shared memory.
+	 */
+#ifndef EXEC_BACKEND
+	dlist_foreach(iter, &BackendList)
+	{
+		bp = dlist_container(Backend, elem, iter.cur);
+#else
+	for (i = MaxLivePostmasterChildren() - 1; i >= 0; i--)
+	{
+		bp = (Backend *) &ShmemBackendArray[i];
+#endif
+		if (bp->pid == backendPID)
+		{
+			if (bp->cancel_key == cancelAuthCode)
+			{
+				/* Found a match; signal that backend to cancel current op */
+				if (code == FINISH_REQUEST_CODE)
+				{
+					ereport(LOG,
+							(errmsg_internal("query finish request to process %d",
+											 backendPID)));
+					SendProcSignal(bp->pid, PROCSIG_QUERY_FINISH,
+								   InvalidBackendId);
+				}
+				else
+				{
+					ereport(DEBUG2,
+							(errmsg_internal("processing cancel request: sending SIGINT to process %d",
+											 backendPID)));
+					signal_child(bp->pid, SIGINT);
+				}
+			}
+			else
+				/* Right PID, wrong key: no way, Jose */
+				ereport(LOG,
+						(errmsg("wrong key in cancel request for process %d",
+								backendPID)));
+			return;
+		}
+#ifndef EXEC_BACKEND			/* make GNU Emacs 26.1 see brace balance */
+	}
+#else
+	}
+#endif
+
+	/* No matching backend */
+	ereport(LOG,
+			(errmsg("PID %d in cancel request did not match any process",
+					backendPID)));
+}
+
+/*
+ * The client has sent a mpp request packet, not a normal
+ * start-a-new-connection packet.  Perform the necessary processing.
+ * Nothing is sent back to the client.
+ */
+static void
+processMppRequest(Port *port, void *pkt, MsgType code)
+{
+	MppRequestPacket *canc = (MppRequestPacket *) pkt;
+	int			backendPID;
+	int32		cancelAuthCode;
 	int32		numsBackends;
 
 	Backend    *bp;
@@ -2889,59 +2972,40 @@ processCancelRequest(Port *port, void *pkt, MsgType code)
 			if (bp->cancel_key == cancelAuthCode)
 			{
 				/* Found a match; signal that backend to cancel current op */
-				if (code == FINISH_REQUEST_CODE)
+				if (code == MPP_FINISH_REQUEST_CODE)
 				{
 					ereport(LOG,
-							(errmsg_internal("query finish request to process %d",
-											 backendPID)));
-					SendProcSignal(bp->pid, PROCSIG_QUERY_FINISH,
-								   InvalidBackendId);
-					if (numsBackends == 0)
+							(errmsg_internal("query MPP finish request executed on process %d",
+							 backendPID)));
+					for (int i = 0; i < numsBackends; i++)
 					{
-						ereport(LOG,
-								(errmsg_internal("query finish request to process %d",
-												 backendPID)));
-						SendProcSignal(bp->pid, PROCSIG_QUERY_FINISH,
-									   InvalidBackendId);
-					}
-					else
-					{
-						for (int i = 0; i < numsBackends; i++)
+						if (SendProcSignal(QEBackends[i], PROCSIG_QUERY_FINISH, InvalidBackendId) < 0)
 						{
-							ereport(LOG,
-									(errmsg_internal("query MPP finish request to process %d",
-													 QEBackends[i])));
-							SendProcSignal(QEBackends[i], PROCSIG_QUERY_FINISH,
-											InvalidBackendId);
+							/* Again, just a warning to allow loops */
+							ereport(WARNING,
+									(errmsg("could not send signal to process %d", QEBackends[i])));
 						}
 					}
 				}
 				else
 				{
-					if (numsBackends == 0)
+					ereport(LOG,
+							(errmsg_internal("query MPP cancel request executed on process %d",
+							 backendPID)));
+					for (int i = 0; i < numsBackends; i++)
 					{
 						ereport(DEBUG2,
-								(errmsg_internal("processing cancel request: sending SIGINT to process %d",
-												 backendPID)));
-						signal_child(backendPID, SIGINT);
-					}
-					else
-					{
-						for (int i = 0; i < numsBackends; i++)
-						{
-							ereport(DEBUG2,
-									(errmsg_internal("processing MPP cancel request: sending SIGINT to process %d",
-													 QEBackends[i])));
-							signal_child(QEBackends[i], SIGINT);
-						}
+								(errmsg_internal("processing MPP cancel request: sending SIGINT to process %d",
+								 QEBackends[i])));
+						signal_child(QEBackends[i], SIGINT);
 					}
 				}
 			}
 			else
 				/* Right PID, wrong key: no way, Jose */
 				ereport(LOG,
-						(errmsg("wrong key in cancel request for process %d",
-								backendPID)));
+						(errmsg("wrong key in MPP request for process %d",
+						 backendPID)));
 			return;
 		}
 #ifndef EXEC_BACKEND			/* make GNU Emacs 26.1 see brace balance */
@@ -2952,7 +3016,7 @@ processCancelRequest(Port *port, void *pkt, MsgType code)
 
 	/* No matching backend */
 	ereport(LOG,
-			(errmsg("PID %d in cancel request did not match any process",
+			(errmsg("PID %d in MPP request did not match any process",
 					backendPID)));
 }
 

--- a/src/include/libpq/pqcomm.h
+++ b/src/include/libpq/pqcomm.h
@@ -202,12 +202,15 @@ typedef uint32 AuthRequest;
  */
 #define FINISH_REQUEST_CODE PG_PROTOCOL(1234,5677)
 
+#define MPP_BACKEND_ARRAY	1024
 typedef struct CancelRequestPacket
 {
 	/* Note that each field is stored in network byte order! */
 	MsgType		cancelRequestCode;	/* code to identify a cancel request */
 	uint32		backendPID;		/* PID of client's backend */
 	uint32		cancelAuthCode; /* secret key to authorize cancel */
+	uint32		numMppBackends;	/* number backend pid send to QE */
+	uint32		MppBackends[MPP_BACKEND_ARRAY]; /* QE backend pid array */
 } CancelRequestPacket;
 
 

--- a/src/include/libpq/pqcomm.h
+++ b/src/include/libpq/pqcomm.h
@@ -202,17 +202,30 @@ typedef uint32 AuthRequest;
  */
 #define FINISH_REQUEST_CODE PG_PROTOCOL(1234,5677)
 
-#define MPP_BACKEND_ARRAY	1024
+/*
+ * mpp request operation is a message between QD and QE, used to
+ * cancel/finish all QEs in one segment at the same time.
+ */
+#define MPP_FINISH_REQUEST_CODE PG_PROTOCOL(1234,5676)
+#define MPP_CANCEL_REQUEST_CODE PG_PROTOCOL(1234,5675)
+
 typedef struct CancelRequestPacket
 {
 	/* Note that each field is stored in network byte order! */
 	MsgType		cancelRequestCode;	/* code to identify a cancel request */
 	uint32		backendPID;		/* PID of client's backend */
 	uint32		cancelAuthCode; /* secret key to authorize cancel */
-	uint32		numMppBackends;	/* number backend pid send to QE */
-	uint32		MppBackends[MPP_BACKEND_ARRAY]; /* QE backend pid array */
 } CancelRequestPacket;
 
+typedef struct MppRequestPacket
+{
+	/* Note that each field is stored in network byte order! */
+	MsgType		requestCode;	/* code to identify a cancel request */
+	uint32		backendPID;		/* PID of client's backend */
+	uint32		cancelAuthCode; /* secret key to authorize cancel */
+	uint32		numMppBackends;	/* number backend pid send to QE */
+	uint32		MppBackends[FLEXIBLE_ARRAY_MEMBER]; /* QE backend pid array */
+} MppRequestPacket;
 
 /*
  * A client can also start by sending a SSL or GSSAPI negotiation request to

--- a/src/interfaces/libpq/fe-connect.c
+++ b/src/interfaces/libpq/fe-connect.c
@@ -4392,8 +4392,7 @@ PQfreeCancel(PGcancel *cancel)
  */
 static int
 internal_cancel(SockAddr *raddr, int be_pid, int be_key,
-				char *errbuf, int errbufsize, bool requestFinish,
-				int numQEBackends, int *QEBackends)
+				char *errbuf, int errbufsize, bool requestFinish)
 {
 	int			save_errno = SOCK_ERRNO;
 	pgsocket	tmpsock = PGINVALID_SOCKET;
@@ -4434,37 +4433,18 @@ retry3:
 	 * We needn't set nonblocking I/O or NODELAY options here.
 	 */
 
-	int packetlen = sizeof(uint32) + offsetof(CancelRequestPacket, MppBackends) + numQEBackends * sizeof(uint32);
+	/* Create and send the cancel request packet. */
 
-	if (numQEBackends == 0)
-	{
-		crp.packetlen = pg_hton32((uint32) packetlen);
-		if (requestFinish)
-			crp.cp.cancelRequestCode = (MsgType) pg_hton32(FINISH_REQUEST_CODE);
-		else
-			crp.cp.cancelRequestCode = (MsgType) pg_hton32(CANCEL_REQUEST_CODE);
-		crp.cp.backendPID = pg_hton32(be_pid);
-		crp.cp.cancelAuthCode = pg_hton32(be_key);
-		crp.cp.numMppBackends = 0;
-	}
+	crp.packetlen = pg_hton32((uint32) sizeof(crp));
+	if (requestFinish)
+		crp.cp.cancelRequestCode = (MsgType) pg_hton32(FINISH_REQUEST_CODE);
 	else
-	{
-		crp.packetlen = pg_hton32((uint32) packetlen);
-		if (requestFinish)
-			crp.cp.cancelRequestCode = (MsgType) pg_hton32(FINISH_REQUEST_CODE);
-		else
-			crp.cp.cancelRequestCode = (MsgType) pg_hton32(CANCEL_REQUEST_CODE);
-		crp.cp.backendPID = pg_hton32(be_pid);
-		crp.cp.cancelAuthCode = pg_hton32(be_key);
-		crp.cp.numMppBackends = pg_hton32(numQEBackends);
-		for (int i = 0; i < numQEBackends; i++)
-		{
-			crp.cp.MppBackends[i] = pg_hton32(QEBackends[i]);
-		}
-	}
+		crp.cp.cancelRequestCode = (MsgType) pg_hton32(CANCEL_REQUEST_CODE);
+	crp.cp.backendPID = pg_hton32(be_pid);
+	crp.cp.cancelAuthCode = pg_hton32(be_key);
 
 retry4:
-	if (send(tmpsock, (char *) &crp, packetlen, 0) != (int) packetlen)
+	if (send(tmpsock, (char *) &crp, sizeof(crp), 0) != (int) sizeof(crp))
 	{
 		if (SOCK_ERRNO == EINTR)
 			/* Interrupted system call - we'll just try again */
@@ -4563,6 +4543,184 @@ cancel_errReturn:
 }
 
 /*
+ * mpp_request: send mpp request to segment
+ *
+ * same as internal_cancel except sending a dynamic
+ * array in request packet.
+ */
+static int
+mpp_request(SockAddr *raddr, int be_pid, int be_key,
+				char *errbuf, int errbufsize, int requestCancel,
+				int numQEBackends, int *QEBackends)
+{
+	int			save_errno = SOCK_ERRNO;
+	pgsocket	tmpsock = PGINVALID_SOCKET;
+	int			maxlen;
+	struct
+	{
+		uint32		packetlen;
+		MppRequestPacket *cp;
+	}			crp;
+
+#ifndef WIN32
+	struct pollfd	pollFds[1];
+	int				pollRet;
+
+retry2:
+#endif
+	/*
+	 * We need to open a temporary connection to the postmaster. Do this with
+	 * only kernel calls.
+	 */
+	if ((tmpsock = socket(raddr->addr.ss_family, SOCK_STREAM, 0)) == PGINVALID_SOCKET)
+	{
+		strlcpy(errbuf, "PQMppRequest() -- socket() failed: ", errbufsize);
+		goto cancel_errReturn;
+	}
+retry3:
+	if (connect(tmpsock, (struct sockaddr *) &raddr->addr,
+				raddr->salen) < 0)
+	{
+		if (SOCK_ERRNO == EINTR)
+			/* Interrupted system call - we'll just try again */
+			goto retry3;
+		strlcpy(errbuf, "PQMppRequest() -- connect() failed: ", errbufsize);
+		goto cancel_errReturn;
+	}
+
+	/* construct mpp request packet */
+	int packetlen = sizeof(crp.packetlen) + offsetof(MppRequestPacket, MppBackends) + numQEBackends * sizeof(uint32);
+	char *packet = (char *)malloc(packetlen);
+
+	crp.cp = (MppRequestPacket *)malloc(sizeof(MppRequestPacket));
+	crp.packetlen = pg_hton32((uint32) packetlen);
+	if (requestCancel)
+		crp.cp->requestCode = (MsgType) pg_hton32(MPP_CANCEL_REQUEST_CODE);
+	else
+		crp.cp->requestCode = (MsgType) pg_hton32(MPP_FINISH_REQUEST_CODE);
+	crp.cp->backendPID = pg_hton32(be_pid);
+	crp.cp->cancelAuthCode = pg_hton32(be_key);
+	crp.cp->numMppBackends = pg_hton32(numQEBackends);
+
+	uint32 * MppBackends = (uint32 *)malloc(numQEBackends * sizeof(uint32));
+	memset(MppBackends, 0, numQEBackends * sizeof(uint32));
+	for (int i = 0; i < numQEBackends; i++)
+	{
+		MppBackends[i] = pg_hton32(QEBackends[i]);
+	}
+
+	/* memcpy crp.packetlen */
+	memcpy(packet, &(crp.packetlen), sizeof(crp.packetlen));
+	/* memcpy crp.cp elements */
+	memcpy(packet + sizeof(crp.packetlen), crp.cp, offsetof(MppRequestPacket, MppBackends));
+	/* memcpy crp.cp.MppBackends dynamic array */
+	memcpy(packet + sizeof(crp.packetlen) + offsetof(MppRequestPacket, MppBackends), MppBackends, numQEBackends * sizeof(uint32));
+
+	free(MppBackends);
+	free(crp.cp);
+
+retry4:
+	if (send(tmpsock, packet, packetlen, 0) != (int) packetlen)
+	{
+		if (SOCK_ERRNO == EINTR)
+			/* Interrupted system call - we'll just try again */
+			goto retry4;
+		strlcpy(errbuf, "PQMppRequest() -- send() failed: ", errbufsize);
+		goto cancel_errReturn;
+	}
+
+	/*
+	 * Wait for the postmaster to close the connection, which indicates that
+	 * it's processed the request.  Without this delay, we might issue another
+	 * command only to find that our cancel zaps that command instead of the
+	 * one we thought we were canceling.  Note we don't actually expect this
+	 * read to obtain any data, we are just waiting for EOF to be signaled.
+	 */
+#ifndef WIN32
+retry5:
+	pollFds[0].fd = tmpsock;
+	pollFds[0].events = POLLIN;
+	pollFds[0].revents = 0;
+
+	/*
+	 * Wait for at most 660 seconds, which is the sum of max values of
+	 * authentication_timeout and pre_auth_delay. Most likely, it's long enough
+	 * to make sure the process forked by the postmaster on segment is finished.
+	 */
+	pollRet = poll(pollFds, 1, 660 * 1000);
+	if (pollRet == 0)
+	{
+		/* timeout */
+		close(tmpsock);
+		tmpsock = -1;
+		goto retry2;
+	}
+	else if (pollRet < 0)
+	{
+		int olderrno = errno;
+		if (olderrno == EAGAIN || olderrno == EINTR)
+			goto retry5;
+
+		/* error */
+		close(tmpsock);
+		tmpsock = -1;
+		goto retry2;
+	}
+#endif
+
+retry6:
+	if (recv(tmpsock, (char *) &crp, 1, 0) < 0)
+	{
+		if (SOCK_ERRNO == EINTR)
+			/* Interrupted system call - we'll just try again */
+			goto retry6;
+		/* we ignore other error conditions */
+	}
+
+	/* All done */
+	closesocket(tmpsock);
+	SOCK_ERRNO_SET(save_errno);
+	free(packet);
+	return true;
+
+cancel_errReturn:
+
+	/*
+	 * Make sure we don't overflow the error buffer. Leave space for the \n at
+	 * the end, and for the terminating zero.
+	 */
+	maxlen = errbufsize - strlen(errbuf) - 2;
+	if (maxlen >= 0)
+	{
+		/*
+		 * We can't invoke strerror here, since it's not signal-safe.  Settle
+		 * for printing the decimal value of errno.  Even that has to be done
+		 * the hard way.
+		 */
+		int			val = SOCK_ERRNO;
+		char		buf[32];
+		char	   *bufp;
+
+		bufp = buf + sizeof(buf) - 1;
+		*bufp = '\0';
+		do
+		{
+			*(--bufp) = (val % 10) + '0';
+			val /= 10;
+		} while (val > 0);
+		bufp -= 6;
+		memcpy(bufp, "error ", 6);
+		strncat(errbuf, bufp, maxlen);
+		strcat(errbuf, "\n");
+	}
+	if (tmpsock != PGINVALID_SOCKET)
+		closesocket(tmpsock);
+	SOCK_ERRNO_SET(save_errno);
+	free(packet);
+	return false;
+}
+
+/*
  * PQcancel: request query cancel
  *
  * Returns true if able to send the cancel request, false if not.
@@ -4581,7 +4739,7 @@ PQcancel(PGcancel *cancel, char *errbuf, int errbufsize)
 	}
 
 	return internal_cancel(&cancel->raddr, cancel->be_pid, cancel->be_key,
-						   errbuf, errbufsize, false, 0, NULL);
+						   errbuf, errbufsize, false);
 }
 
 /*
@@ -4600,50 +4758,32 @@ PQrequestFinish(PGcancel *cancel, char *errbuf, int errbufsize)
 	}
 
 	return internal_cancel(&cancel->raddr, cancel->be_pid, cancel->be_key,
-						   errbuf, errbufsize, true, 0, NULL);
+						   errbuf, errbufsize, true);
 }
 
 /*
- * PQMppcancel: request Mpp query cancel
+ * PQMppcancel: request Mpp query cancel or finish
  *
- * Returns true if able to send the cancel request, false if not.
+ * Returns true if able to send the request, false if not.
  *
  * On failure, an error message is stored in *errbuf, which must be of size
  * errbufsize (recommended size is 256 bytes).  *errbuf is not changed on
  * success return.
  */
 int
-PQMppcancel(PGcancel *cancel, char *errbuf, int errbufsize, int nums, int *QEBackends)
+PQMppRequest(PGcancel *cancel,char *errbuf, int errbufsize,
+				int numQEBackends, int *QEBackends, int requestCancel)
 {
 	if (!cancel)
 	{
-		strlcpy(errbuf, "PQMppcancel() -- no cancel object supplied", errbufsize);
-		return false;
-	}
-
-	return internal_cancel(&cancel->raddr, cancel->be_pid, cancel->be_key,
-						   errbuf, errbufsize, false, nums, QEBackends);
-}
-
-/*
- * PQMpprequestFinish: request Mpp query finish
- *
- * Same as PQMppcancel, except it sends a finish request.
- */
-int
-PQMpprequestFinish(PGcancel *cancel, char *errbuf, int errbufsize, int nums, int *QEBackends)
-{
-	if (!cancel)
-	{
-		strlcpy(errbuf, "PQMpprequestFinish() -- no cancel object supplied",
+		strlcpy(errbuf, "PQMppRequest() -- no request object supplied",
 				errbufsize);
 		return false;
 	}
 
-	return internal_cancel(&cancel->raddr, cancel->be_pid, cancel->be_key,
-						   errbuf, errbufsize, true, nums, QEBackends);
+	return mpp_request(&cancel->raddr, cancel->be_pid, cancel->be_key,
+					   errbuf, errbufsize, requestCancel, numQEBackends, QEBackends);
 }
-
 
 /*
  * PQrequestCancel: old, not thread-safe function for requesting query cancel
@@ -4678,7 +4818,7 @@ PQrequestCancel(PGconn *conn)
 
 	r = internal_cancel(&conn->raddr, conn->be_pid, conn->be_key,
 						conn->errorMessage.data, conn->errorMessage.maxlen,
-						false, 0, NULL);
+						false);
 
 	if (!r)
 		conn->errorMessage.len = strlen(conn->errorMessage.data);

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -322,6 +322,12 @@ extern int	PQrequestFinish(PGcancel *cancel, char *errbuf, int errbufsize);
 /* backwards compatible version of PQcancel; not thread-safe */
 extern int	PQrequestCancel(PGconn *conn);
 
+/* issue a cancel request */
+extern int	PQMppcancel(PGcancel *cancel, char *errbuf, int errbufsize, int nums, int *QEBackends);
+
+/* issue a finsh request */
+extern int	PQMpprequestFinish(PGcancel *cancel, char *errbuf, int errbufsize, int nums, int *QEBackends);
+
 /* Accessor functions for PGconn objects */
 extern char *PQdb(const PGconn *conn);
 extern char *PQuser(const PGconn *conn);

--- a/src/interfaces/libpq/libpq-fe.h
+++ b/src/interfaces/libpq/libpq-fe.h
@@ -322,11 +322,9 @@ extern int	PQrequestFinish(PGcancel *cancel, char *errbuf, int errbufsize);
 /* backwards compatible version of PQcancel; not thread-safe */
 extern int	PQrequestCancel(PGconn *conn);
 
-/* issue a cancel request */
-extern int	PQMppcancel(PGcancel *cancel, char *errbuf, int errbufsize, int nums, int *QEBackends);
-
-/* issue a finsh request */
-extern int	PQMpprequestFinish(PGcancel *cancel, char *errbuf, int errbufsize, int nums, int *QEBackends);
+/* issue a Mpp request */
+extern int	PQMppRequest(PGcancel *cancel, char *errbuf, int errbufsize,
+			int numQEBackends, int *QEBackends, int requestCancel);
 
 /* Accessor functions for PGconn objects */
 extern char *PQdb(const PGconn *conn);


### PR DESCRIPTION
Currently, the Query Dispatcher (QD) endeavors to terminate all Query Executor (QE) processes
within gangs upon receiving cancellation requests such as pg_cancel_backend()/pg_terminate_backend()
from the frontend.

The process should proceed as follows:

* Upon receiving the cancellation signal from the frontend, QD handles it within the interrupt exception
   and subsequently dispatches a cancellation request packet to each QE process within the slice/gang.
* For instance, if we have 3 segments and 3 slices, the total number of QE processes would be 3x3 = 9.
  Accordingly, QD should dispatch cancel requests to segments 3x3 = 9 times.
* Upon reception of the cancel request packet, the QE postmaster forks a new backend process to
   manage it. The forked process then invokes kill() to terminate the respective QE process.

However, overhead arises at this point. It is unnecessary to dispatch the cancel packet to each QE
process within the same segment, as forking too many processes could lead to performance
degradation, particularly in high-load environments.

To address this issue, we have proposed two approaches:
* Sending a cancel packet to only one QE process within the segment and leaving it to terminate other
   QEs operating on the same query within segments. Yet, achieving global gang information at the QE
   level is challenging, and iterating PROCARRAY in shared memory also results in performance degradation.
* Including the QE process PID list in the cancel packet sent to the QE postmaster. Subsequently, the QE
   master only needs to fork() one process and then terminate all relevant QE processes (recording PID list
   in the cancel request packet) working on the same query within one segment.

The Pull Request (PR) implements the second approach. Primarily, we augment a list to cancel packets in QD
and parse it in BackendInitialize() backend forked by QE postmaster. However, the list is a fixed-length array,
set to 1024 (MPP_BACKEND_ARRAY). It is assumed that this should be enough unless there are more than 
1024 slices in one segment, which should not occur.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
