### PR TITLE
[ORCA] Fix ident to const predicate push down optimization

### DIFF
--- a/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CExpressionPreprocessor.cpp
@@ -2161,7 +2161,13 @@ CExpressionPreprocessor::PexprReplaceColWithConst(
 {
 	GPOS_ASSERT(NULL != pexpr);
 
-	COperator *pop = pexpr->Pop();
+	CExpression *pexprFilter = NULL;
+	if (COperator::EopLogicalNAryJoin == pexpr->Pop()->Eopid() ||
+		COperator::EopLogicalSelect == pexpr->Pop()->Eopid())
+	{
+		pexprFilter = (*pexpr)[pexpr->Arity() - 1];
+	}
+
 	// Here we check for following pattern:
 	//
 	//     Select
@@ -2178,15 +2184,15 @@ CExpressionPreprocessor::PexprReplaceColWithConst(
 		(COperator::EopLogicalLeftOuterJoin == ((*pexpr)[0])->Pop()->Eopid() ||
 		 COperator::EopLogicalNAryJoin == ((*pexpr)[0])->Pop()->Eopid()))
 	{
-		UpdateExprToConstantPredicateMapping(mp, (*pexpr)[pexpr->Arity() - 1],
-											 phmExprToConst, true);
+		UpdateExprToConstantPredicateMapping(mp, pexprFilter, phmExprToConst,
+											 true);
 
 		CExpression *pexprNew =
 			PexprReplaceColWithConst(mp, pexpr, phmExprToConst, false);
 
 		// erase values from map...
-		UpdateExprToConstantPredicateMapping(mp, (*pexpr)[pexpr->Arity() - 1],
-											 phmExprToConst, false);
+		UpdateExprToConstantPredicateMapping(mp, pexprFilter, phmExprToConst,
+											 false);
 
 		return pexprNew;
 	}
@@ -2202,19 +2208,24 @@ CExpressionPreprocessor::PexprReplaceColWithConst(
 		pdrgpexpr->Append(pexprChild);
 	}
 
-	if (COperator::EopLogicalNAryJoin == pexpr->Pop()->Eopid() &&
-		phmExprToConst->Size() > 0)
-	{
-		CExpression *pexprFilter = SubstituteConstantIdentifier(
-			mp, (*pexpr)[pexpr->Arity() - 1], phmExprToConst);
+	COperator *pop = pexpr->Pop();
+	pop->AddRef();
 
-		pop->AddRef();
-		return GPOS_NEW(mp) CExpression(
-			mp, GPOS_NEW(mp) CLogicalSelect(mp),
-			GPOS_NEW(mp) CExpression(mp, pop, pdrgpexpr), pexprFilter);
+	// Add a select with a filter where idents are replaced by const values.
+	// Skip if the filter contains a CTEAnchor to prevent creating an invalid
+	// plan with a duplicate CTEAnchor.
+	if (COperator::EopLogicalNAryJoin == pexpr->Pop()->Eopid() &&
+		phmExprToConst->Size() > 0 && !CUtils::FHasCTEAnchor(pexprFilter))
+	{
+		CExpression *pexprFilterWithConsts =
+			SubstituteConstantIdentifier(mp, pexprFilter, phmExprToConst);
+
+		return GPOS_NEW(mp)
+			CExpression(mp, GPOS_NEW(mp) CLogicalSelect(mp),
+						GPOS_NEW(mp) CExpression(mp, pop, pdrgpexpr),
+						pexprFilterWithConsts);
 	}
 
-	pop->AddRef();
 	return GPOS_NEW(mp) CExpression(mp, pop, pdrgpexpr);
 }
 

--- a/src/test/regress/expected/bfv_cte.out
+++ b/src/test/regress/expected/bfv_cte.out
@@ -1,6 +1,7 @@
 --
 -- Test queries mixes window functions with aggregate functions or grouping.
 --
+set optimizer_trace_fallback=on;
 DROP TABLE IF EXISTS test_group_window;
 NOTICE:  table "test_group_window" does not exist, skipping
 CREATE TABLE test_group_window(c1 int, c2 int);
@@ -480,3 +481,49 @@ from t1_cte join dist2 on t1_cte.b = dist2.b;
 (10 rows)
 
 drop table dist1, dist2, rep;
+--
+-- Test for a bug in ORCA optimizing a CTE view.
+--
+-- This crashed at one point in retail build due to preprocessor creating a
+-- duplicate CTE anchor. That led ORCA to construct a bad plan where
+-- CTEConsumer project list contained an invalid scalar subplan and caused a
+-- SIGSEGV during DXL to PlStmt translation.
+--
+create table a_table(a smallint);
+create view cte_view as
+  with t1 as (select a from a_table)
+  select t1.a from t1
+  where (t1.a = (select t1.a from t1));
+-- Only by tampering with pg_stats directly I was able to guide ORCA cost model
+-- to pick a plan that would crash before this fix
+set allow_system_table_mods=true;
+update pg_class set relpages = 1::int, reltuples = 12.0::real where relname = 'a_table';
+reset allow_system_table_mods;
+explain select * from a_table join cte_view on a_table.a = (select a from cte_view) where cte_view.a = 2024;
+                                                 QUERY PLAN                                                  
+-------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice5; segments: 3)  (cost=10000000000.51..10000000001.73 rows=4 width=4)
+   ->  Nested Loop  (cost=10000000000.51..10000000001.73 rows=2 width=4)
+         InitPlan 2 (returns $1)  (slice7)
+           ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..1.15 rows=1 width=2)
+                 ->  Seq Scan on a_table a_table_3  (cost=0.00..1.15 rows=1 width=2)
+                       Filter: (a = $0)
+                       InitPlan 1 (returns $0)  (slice6)
+                         ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.12 rows=12 width=2)
+                               ->  Seq Scan on a_table a_table_2  (cost=0.00..1.12 rows=4 width=2)
+         ->  Seq Scan on a_table  (cost=0.00..1.15 rows=1 width=2)
+               Filter: (a = $1)
+         ->  Materialize  (cost=0.24..0.30 rows=1 width=2)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.24..0.29 rows=1 width=2)
+                     Hash Key: $1
+                     ->  Result  (cost=0.24..0.26 rows=1 width=2)
+                           One-Time Filter: ($2 = 2024)
+                           InitPlan 3 (returns $2)  (slice8)
+                             ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1.12 rows=12 width=2)
+                                   ->  Seq Scan on a_table a_table_4  (cost=0.00..1.12 rows=4 width=2)
+                           ->  Seq Scan on a_table a_table_1  (cost=0.00..1.15 rows=1 width=2)
+                                 Filter: (a = 2024)
+ Optimizer: Postgres query optimizer
+(22 rows)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -1,6 +1,7 @@
 --
 -- Test queries mixes window functions with aggregate functions or grouping.
 --
+set optimizer_trace_fallback=on;
 DROP TABLE IF EXISTS test_group_window;
 NOTICE:  table "test_group_window" does not exist, skipping
 CREATE TABLE test_group_window(c1 int, c2 int);
@@ -305,6 +306,8 @@ SELECT cup.* FROM
 SELECT sum(t.b) OVER(PARTITION BY t.a ) AS e FROM (select 1 as a, 2 as b from pg_class limit 1)foo,t
 ) as cup
 GROUP BY cup.e;
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Queries on master-only tables
  e 
 ---
  2
@@ -499,3 +502,76 @@ from t1_cte join dist2 on t1_cte.b = dist2.b;
 (10 rows)
 
 drop table dist1, dist2, rep;
+--
+-- Test for a bug in ORCA optimizing a CTE view.
+--
+-- This crashed at one point in retail build due to preprocessor creating a
+-- duplicate CTE anchor. That led ORCA to construct a bad plan where
+-- CTEConsumer project list contained an invalid scalar subplan and caused a
+-- SIGSEGV during DXL to PlStmt translation.
+--
+create table a_table(a smallint);
+create view cte_view as
+  with t1 as (select a from a_table)
+  select t1.a from t1
+  where (t1.a = (select t1.a from t1));
+-- Only by tampering with pg_stats directly I was able to guide ORCA cost model
+-- to pick a plan that would crash before this fix
+set allow_system_table_mods=true;
+update pg_class set relpages = 1::int, reltuples = 12.0::real where relname = 'a_table';
+INFO:  GPORCA failed to produce a plan, falling back to planner
+DETAIL:  Feature not supported: Queries on master-only tables
+reset allow_system_table_mods;
+explain select * from a_table join cte_view on a_table.a = (select a from cte_view) where cte_view.a = 2024;
+NOTICE:  One or more columns in the following table(s) do not have statistics: a_table
+HINT:  For non-partitioned tables, run analyze <table_name>(<column_list>). For partitioned tables, run analyze rootpartition <table_name>(<column_list>). See log for columns missing statistics.
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice7; segments: 3)  (cost=0.00..2261454580.07 rows=1920 width=4)
+   ->  Nested Loop  (cost=0.00..2261454580.04 rows=640 width=4)
+         Join Filter: true
+         ->  Result  (cost=0.00..2206727.73 rows=134 width=2)
+               Filter: (a_table_1.a = ((SubPlan 1)))
+               ->  Result  (cost=0.00..2206727.70 rows=334 width=4)
+                     ->  Seq Scan on a_table a_table_1  (cost=0.00..2206727.70 rows=334 width=4)
+                     SubPlan 1  (slice7; segments: 3)
+                       ->  Materialize  (cost=0.00..1293.00 rows=12 width=2)
+                             ->  Broadcast Motion 3:3  (slice6; segments: 3)  (cost=0.00..1293.00 rows=12 width=2)
+                                   ->  Sequence  (cost=0.00..1293.00 rows=4 width=2)
+                                         ->  Shared Scan (share slice:id 6:1)  (cost=0.00..431.00 rows=4 width=1)
+                                               ->  Materialize  (cost=0.00..431.00 rows=4 width=1)
+                                                     ->  Seq Scan on a_table a_table_2  (cost=0.00..431.00 rows=4 width=2)
+                                         ->  Hash Join  (cost=0.00..862.00 rows=4 width=2)
+                                               Hash Cond: (share1_ref3.a = share1_ref2.a)
+                                               ->  Redistribute Motion 1:3  (slice5)  (cost=0.00..431.00 rows=1 width=2)
+                                                     Hash Key: share1_ref3.a
+                                                     ->  Assert  (cost=0.00..431.00 rows=1 width=2)
+                                                           Assert Cond: ((row_number() OVER (?)) = 1)
+                                                           ->  WindowAgg  (cost=0.00..431.00 rows=4 width=10)
+                                                                 ->  Gather Motion 3:1  (slice4; segments: 3)  (cost=0.00..431.00 rows=12 width=2)
+                                                                       ->  Shared Scan (share slice:id 4:1)  (cost=0.00..431.00 rows=4 width=2)
+                                               ->  Hash  (cost=431.00..431.00 rows=4 width=2)
+                                                     ->  Shared Scan (share slice:id 6:1)  (cost=0.00..431.00 rows=4 width=2)
+         ->  Materialize  (cost=0.00..1293.00 rows=5 width=2)
+               ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..1293.00 rows=5 width=2)
+                     ->  Sequence  (cost=0.00..1293.00 rows=2 width=2)
+                           ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=1)
+                                 ->  Materialize  (cost=0.00..431.00 rows=4 width=1)
+                                       ->  Seq Scan on a_table  (cost=0.00..431.00 rows=4 width=2)
+                           ->  Hash Join  (cost=0.00..862.00 rows=2 width=2)
+                                 Hash Cond: (share0_ref3.a = share0_ref2.a)
+                                 ->  Redistribute Motion 1:3  (slice2)  (cost=0.00..431.00 rows=1 width=2)
+                                       Hash Key: share0_ref3.a
+                                       ->  Assert  (cost=0.00..431.00 rows=1 width=2)
+                                             Assert Cond: ((row_number() OVER (?)) = 1)
+                                             ->  WindowAgg  (cost=0.00..431.00 rows=4 width=10)
+                                                   ->  Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..431.00 rows=12 width=2)
+                                                         ->  Shared Scan (share slice:id 1:0)  (cost=0.00..431.00 rows=4 width=2)
+                                 ->  Hash  (cost=431.00..431.00 rows=2 width=2)
+                                       ->  Result  (cost=0.00..431.00 rows=2 width=2)
+                                             Filter: (share0_ref2.a = 2024)
+                                             ->  Shared Scan (share slice:id 3:0)  (cost=0.00..431.00 rows=4 width=2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(45 rows)
+
+reset optimizer_trace_fallback;

--- a/src/test/regress/sql/bfv_cte.sql
+++ b/src/test/regress/sql/bfv_cte.sql
@@ -1,6 +1,7 @@
 --
 -- Test queries mixes window functions with aggregate functions or grouping.
 --
+set optimizer_trace_fallback=on;
 DROP TABLE IF EXISTS test_group_window;
 
 CREATE TABLE test_group_window(c1 int, c2 int);
@@ -283,3 +284,28 @@ when (dist2.b in (1,2)) then (select rep_cte.a from rep_cte)
 end as rep_cte_a
 from t1_cte join dist2 on t1_cte.b = dist2.b;
 drop table dist1, dist2, rep;
+
+--
+-- Test for a bug in ORCA optimizing a CTE view.
+--
+-- This crashed at one point in retail build due to preprocessor creating a
+-- duplicate CTE anchor. That led ORCA to construct a bad plan where
+-- CTEConsumer project list contained an invalid scalar subplan and caused a
+-- SIGSEGV during DXL to PlStmt translation.
+--
+create table a_table(a smallint);
+
+create view cte_view as
+  with t1 as (select a from a_table)
+  select t1.a from t1
+  where (t1.a = (select t1.a from t1));
+
+-- Only by tampering with pg_stats directly I was able to guide ORCA cost model
+-- to pick a plan that would crash before this fix
+set allow_system_table_mods=true;
+update pg_class set relpages = 1::int, reltuples = 12.0::real where relname = 'a_table';
+reset allow_system_table_mods;
+
+explain select * from a_table join cte_view on a_table.a = (select a from cte_view) where cte_view.a = 2024;
+
+reset optimizer_trace_fallback;


### PR DESCRIPTION
In preprocessing, ORCA may choose to add select filters in order to help
trigger predicate push down during query normalization. In preprocessing
step PexprReplaceColWithConst(), a duplicate filter is created of join
predicates, with idents replaced by consts from equality predicates
among the select filter. The transformation looks like:
```
  Input:
    Select
      |-- NaryJoin/LeftOuterJoin
      |   |-- ...
      |   +-- Join Pred (has idents)
      +-- Filter
```
```
  Output:
    Select
      |-- Select
      |  |-- NaryJoin/LeftOuterJoin
      |  |  |-- ...
      |  |  +-- Join Pred (has idents)
      |  +-- Join Pred (has consts)
      +-- Filter
```

However, an issue occurs if the Join Pred contains a CTEAnchor. In that
case the CTEAnchor is "duplicated" and leads to an invalid plan. In
retail build that manifests as a crash during DXL to PlStmt translation.
This commit fixes the issue by choosing to not add the select filter
when the Join Pred contains a CTEAnchor.

(cherry picked from commit 99a34e3f27680011bb12557193c5a7d0b040cedc)

---

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-6x-fix-cte-view-crash-rocky8

Backport was mostly clean:
  - usual NULL vs nullptr
  - different fallback messages after enabling optimizer_trace_fallback (or lack thereof)
  - test plan changed, but still repro'd crash/fallback without fix