### PR TITLE
Add a set of new hooks to support data encryption

### DIFF
--- a/concourse/pipelines/templates/gpdb-tpl.yml
+++ b/concourse/pipelines/templates/gpdb-tpl.yml
@@ -223,6 +223,7 @@ groups:
   - icw_gporca_jit_[[ os_type ]]
   - icw_gporca_memory_[[ os_type ]]
   - icw_planner_[[ os_type ]]
+  - icw_planner_tde_[[ os_type ]]
   - icw_planner_jit_[[ os_type ]]
   - icw_gporca_icproxy_[[ os_type ]]
   - icw_planner_icproxy_[[ os_type ]]
@@ -1006,6 +1007,53 @@ jobs:
       CONFIGURE_FLAGS: ((configure_flags))
       BLDWRAP_POSTGRES_CONF_ADDONS:
         - optimizer_use_gpdb_allocators=off
+
+- name: icw_planner_tde_[[ os_type ]]
+  plan:
+  - in_parallel:
+      steps:
+      - get: gpdb_src
+        passed: [gate_icw_start]
+      - get: bin_gpdb
+        passed: [gate_icw_start]
+        trigger: true
+      {% if os_type == "rhel8" or os_type == "oel8" or os_type == "rocky8" %}
+      - get: binary_swap_gpdb
+        passed: [gate_icw_start]
+        resource: binary_swap_gpdb_[[ os_type ]]
+      {% endif %}
+      - get: gpdb7-[[ os_type ]]-test
+  - task: ic_gpdb
+    {% if use_ICW_workers %}
+    tags: [icw-worker]
+    {% endif %}
+    {% if os_type == "rhel8" or os_type == "oel8" or os_type == "rocky8" %}
+    file: gpdb_src/concourse/tasks/ic_gpdb_binary_swap.yml
+    {% else %}
+    file: gpdb_src/concourse/tasks/ic_gpdb.yml
+    {% endif %}
+    image: gpdb7-[[ os_type ]]-test
+    timeout: 24h
+    params:
+      SHARED_PRELOAD_LIBRARIES: "data_encryption"
+      MAKE_TEST_PRERUN_SHELL_COMMAND: |
+        # ao_checksum_corruption will read AO table directly
+        # log_directory will use pg_basebackup with is not supported for now
+        find "$COORDINATOR_DATA_DIRECTORY/../../../../../src/test/" -name '*_schedule' | xargs sed -i 's,\(ao_checksum_corruption\|log_directory\), ,' ;
+        find "$COORDINATOR_DATA_DIRECTORY/../../../../../src/test/" -name '*_schedule' | xargs sed -i 's,^test: *$, ,' ;
+        # replica_check will read table file directly
+        sed -i 's,gp_replica_check.py -d=all -r=all,true,' "$COORDINATOR_DATA_DIRECTORY/../../../../../gpcontrib/gp_replica_check/Makefile" ;
+        # pg_upgrade will read and write table file directly
+        echo "#!/usr/bin/env true" | sudo tee "$COORDINATOR_DATA_DIRECTORY/../../../../../src/bin/pg_upgrade/test_gpdb.sh" ;
+        # binary_swap will boot the old gpdb with out TDE support
+        echo "#!/usr/bin/env true" | sudo tee "$COORDINATOR_DATA_DIRECTORY/../../../../../src/test/binary_swap/test_binary_swap.sh" ;
+      MAKE_TEST_COMMAND: -k PGOPTIONS='-c optimizer=off -c jit=off' installcheck-world
+      TEST_OS: [[ test_os ]]
+      {% if os_type == "rhel8" or os_type == "oel8" or os_type == "rocky8" %}
+      TEST_BINARY_SWAP: ((test-binary-swap))
+      {% endif %}
+      CONFIGURE_FLAGS: ((configure_flags))
+      DUMP_DB: "true"
 
 - name: icw_planner_[[ os_type ]]
   plan:

--- a/concourse/scripts/filedump_gpdb.bash
+++ b/concourse/scripts/filedump_gpdb.bash
@@ -31,6 +31,8 @@ function gen_env(){
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		source gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 		cd "\${1}/filedump_src"
+
+		${MAKE_TEST_PRERUN_SHELL_COMMAND:-true}
 		PG_TEST_EXTRA="kerberos ssl" make -s ${MAKE_TEST_COMMAND}
 	EOF
 

--- a/concourse/scripts/ic_gpdb.bash
+++ b/concourse/scripts/ic_gpdb.bash
@@ -31,6 +31,8 @@ function gen_env(){
 		source /usr/local/greenplum-db-devel/greenplum_path.sh
 		cd "\${1}/gpdb_src"
 		source gpAux/gpdemo/gpdemo-env.sh
+
+		${MAKE_TEST_PRERUN_SHELL_COMMAND:-true}
 		PG_TEST_EXTRA="kerberos ssl" make -s ${MAKE_TEST_COMMAND}
 	EOF
 

--- a/concourse/scripts/ic_resgroup.bash
+++ b/concourse/scripts/ic_resgroup.bash
@@ -97,6 +97,7 @@ run_resgroup_icw_test() {
         LANG=en_US.utf8 make create-demo-cluster WITH_MIRRORS=${WITH_MIRRORS:-true}
         source /home/gpadmin/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
 
+        ${MAKE_TEST_PRERUN_SHELL_COMMAND:-true}
         PG_TEST_EXTRA="kerberos ssl" make -s ${MAKE_TEST_COMMAND}
 EOF
 }

--- a/gpMgmt/bin/gpinitsystem
+++ b/gpMgmt/bin/gpinitsystem
@@ -157,6 +157,7 @@ USAGE () {
 		$ECHO "          postgresql.conf file during Greenplum database initialization."
 		$ECHO "      -P, standby_port [optional]"
 		$ECHO "      -s, standby_hostname [optional]"
+		$ECHO "      --shared-preload-libraries [optional], same as shared_preload_libraries in postgresql.conf [defaults to '']"
 		$ECHO
 		$ECHO "      Return codes:"
 		$ECHO "      0 - No problems encountered with requested operation"
@@ -395,6 +396,13 @@ CHK_PARAMS () {
 			if [ $COORDINATOR_MAX_CONNECT -lt 1 ];then
 				ERROR_EXIT "[FATAL]:-COORDINATOR_MAX_CONNECT less than 1"
 			fi
+		fi
+		# SHARED_PRELOAD_LIBRARIES
+		if [ x"" = x"$SHARED_PRELOAD_LIBRARIES" ]; then
+		    LOG_MSG "[INFO]:-SHARED_PRELOAD_LIBRARIES not set, will set to default value $DEFAULT_SHARED_PRELOAD_LIBRARIES" 1
+		    SHARED_PRELOAD_LIBRARIES=$DEFAULT_SHARED_PRELOAD_LIBRARIES
+		else
+		    LOG_MSG "[INFO]:-Server process will load libraries: $SHARED_PRELOAD_LIBRARIES" 1
 		fi
 		((QE_MAX_CONNECT=$COORDINATOR_MAX_CONNECT*$QE_CONNECT_FACTOR))
 		LOG_MSG "[INFO]:-Setting segment instance MAX_CONNECTIONS to $QD_MAX_CONNECT"
@@ -1038,22 +1046,24 @@ DISPLAY_CONFIG () {
 		LOG_MSG "[INFO]:---------------------------------------" 1
 		LOG_MSG "[INFO]:-Coordinator Configuration" 1
 		LOG_MSG "[INFO]:---------------------------------------" 1
-		LOG_MSG "[INFO]:-Coordinator hostname       = $GP_HOSTADDRESS" 1
-		LOG_MSG "[INFO]:-Coordinator port           = $COORDINATOR_PORT" 1
-		LOG_MSG "[INFO]:-Coordinator instance dir   = $GP_DIR" 1
-		LOG_MSG "[INFO]:-Coordinator LOCALE         = $LOCALE_SETTING" 1
-		LOG_MSG "[INFO]:-Greenplum segment prefix   = $SEG_PREFIX" 1
-		LOG_MSG "[INFO]:-Coordinator Database       = $DATABASE_NAME" 1
-		LOG_MSG "[INFO]:-Coordinator connections    = $COORDINATOR_MAX_CONNECT" 1
-		LOG_MSG "[INFO]:-Coordinator buffers        = $COORDINATOR_SHARED_BUFFERS" 1
-		LOG_MSG "[INFO]:-Segment connections        = $QE_MAX_CONNECT" 1
-		LOG_MSG "[INFO]:-Segment buffers            = $QE_SHARED_BUFFERS" 1
-		LOG_MSG "[INFO]:-Encoding                   = $ENCODING" 1
-		LOG_MSG "[INFO]:-Postgres param file        = $PG_ADD" 1
-		LOG_MSG "[INFO]:-Initdb to be used          = $INITDB" 1
-		LOG_MSG "[INFO]:-GP_LIBRARY_PATH is         = $GP_LIBRARY_PATH" 1
-		LOG_MSG "[INFO]:-HEAP_CHECKSUM is           = $HEAP_CHECKSUM" 1
-		LOG_MSG "[INFO]:-HBA_HOSTNAMES is           = $HBA_HOSTNAMES" 1
+		LOG_MSG "[INFO]:-Coordinator hostname                 = $GP_HOSTADDRESS" 1
+		LOG_MSG "[INFO]:-Coordinator port                     = $COORDINATOR_PORT" 1
+		LOG_MSG "[INFO]:-Coordinator instance dir             = $GP_DIR" 1
+		LOG_MSG "[INFO]:-Coordinator LOCALE                   = $LOCALE_SETTING" 1
+		LOG_MSG "[INFO]:-Greenplum segment prefix             = $SEG_PREFIX" 1
+		LOG_MSG "[INFO]:-Coordinator Database                 = $DATABASE_NAME" 1
+		LOG_MSG "[INFO]:-Coordinator connections              = $COORDINATOR_MAX_CONNECT" 1
+		LOG_MSG "[INFO]:-Coordinator buffers                  = $COORDINATOR_SHARED_BUFFERS" 1
+		LOG_MSG "[INFO]:-Coordinator shared preload libraries = $SHARED_PRELOAD_LIBRARIES" 1
+		LOG_MSG "[INFO]:-Segment connections                  = $QE_MAX_CONNECT" 1
+		LOG_MSG "[INFO]:-Segment buffers                      = $QE_SHARED_BUFFERS" 1
+		LOG_MSG "[INFO]:-Segment shared preload libraries     = $SHARED_PRELOAD_LIBRARIES" 1
+		LOG_MSG "[INFO]:-Encoding                             = $ENCODING" 1
+		LOG_MSG "[INFO]:-Postgres param file                  = $PG_ADD" 1
+		LOG_MSG "[INFO]:-Initdb to be used                    = $INITDB" 1
+		LOG_MSG "[INFO]:-GP_LIBRARY_PATH is                   = $GP_LIBRARY_PATH" 1
+		LOG_MSG "[INFO]:-HEAP_CHECKSUM is                     = $HEAP_CHECKSUM" 1
+		LOG_MSG "[INFO]:-HBA_HOSTNAMES is                     = $HBA_HOSTNAMES" 1
 		if [ $ULIMIT_WARN -eq 1 ];then
 			LOG_MSG "[WARN]:-Ulimit check               = Warnings generated, see log file $WARN_MARK" 1
 		else
@@ -1188,6 +1198,9 @@ CREATE_QD_DB () {
 		cmd="$cmd $LC_ALL_SETTINGS"
 		cmd="$cmd --max_connections=$COORDINATOR_MAX_CONNECT"
 		cmd="$cmd --shared_buffers=$COORDINATOR_SHARED_BUFFERS"
+		if [ x"$SHARED_PRELOAD_LIBRARIES" != x ]; then
+			cmd="$cmd --shared-preload-libraries=$SHARED_PRELOAD_LIBRARIES"
+		fi
 		if [ x"$HEAP_CHECKSUM" == x"on" ]; then
 			cmd="$cmd --data-checksums"
 		fi
@@ -1351,6 +1364,7 @@ CREATE_SEGMENT () {
 			export QE_MAX_CONNECT
 			export QE_SHARED_BUFFERS
 			export SEG_PREFIX
+			export SHARED_PRELOAD_LIBRARIES
 			if [ $DEBUG_LEVEL -eq 0 ] && [ x"" != x"$VERBOSE" ];then $NOLINE_ECHO ".\c";fi
 				FLAG=""
 			if [ x"" != x"$PG_CONF_ADD_FILE" ] ; then
@@ -1902,6 +1916,7 @@ while getopts ":vaqe:c:l:-:p:m:h:n:s:P:S:b:DB:I:O:" opt
 						"standby-datadir" ) STANDBY_DATADIR=$VAL ;;
 						"help"            ) USAGE "print_doc" ;;
 						"version"         ) print_version ;;
+						"shared-preload-libraries" ) SHARED_PRELOAD_LIBRARIES=$VAL ;;
 						* ) LOG_MSG "[ERROR]:-Unknown option --$NAME" 1; USAGE ;;
 					esac
 

--- a/gpMgmt/bin/lib/gp_bash_functions.sh
+++ b/gpMgmt/bin/lib/gp_bash_functions.sh
@@ -161,6 +161,7 @@ DEFAULTDB=template1
 
 DEFAULT_CHK_PT_SEG=8
 DEFAULT_QD_MAX_CONNECT=250
+DEFAULT_SHARED_PRELOAD_LIBRARIES=""
 QE_CONNECT_FACTOR=3
 # DEFAULT_BUFFERS sets the default shared_buffers unless overridden by '-b'.
 # It applies to the coordinator db and segment dbs.  Specify either the number of

--- a/gpMgmt/bin/lib/gpcreateseg.sh
+++ b/gpMgmt/bin/lib/gpcreateseg.sh
@@ -100,6 +100,9 @@ CREATE_QES_PRIMARY () {
     cmd="$cmd $LC_ALL_SETTINGS"
     cmd="$cmd --max_connections=$QE_MAX_CONNECT"
     cmd="$cmd --shared_buffers=$QE_SHARED_BUFFERS"
+    if [ x"$SHARED_PRELOAD_LIBRARIES" != x ]; then
+        cmd="$cmd --shared-preload-libraries=$SHARED_PRELOAD_LIBRARIES"
+    fi
     if [ x"$HEAP_CHECKSUM" == x"on" ]; then
         cmd="$cmd --data-checksums"
     fi

--- a/gpcontrib/Makefile
+++ b/gpcontrib/Makefile
@@ -21,8 +21,9 @@ ifeq "$(enable_debug_extensions)" "yes"
                gp_exttable_fdw \
                gp_legacy_string_agg \
                gp_replica_check \
+               pg_hint_plan \
                gp_toolkit \
-               pg_hint_plan
+               data_encryption
 else
 	recurse_targets = gp_sparse_vector \
                gp_distribution_policy \

--- a/gpcontrib/data_encryption/Makefile
+++ b/gpcontrib/data_encryption/Makefile
@@ -1,0 +1,13 @@
+MODULE_big = data_encryption
+OBJS = data_encryption.o
+
+REGRESS = data_encryption
+
+ifdef USE_PGXS
+  PGXS := $(shell pg_config --pgxs)
+  include $(PGXS)
+else
+  top_builddir = ../..
+  include $(top_builddir)/src/Makefile.global
+  include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/data_encryption/data_encryption.c
+++ b/gpcontrib/data_encryption/data_encryption.c
@@ -1,0 +1,124 @@
+#include <stdint.h>
+
+#include "postgres.h"
+
+#include "fmgr.h" // for PG_MODULE_MAGIC
+
+#include "cdb/cdbappendonlyam.h" // for MAX_APPENDONLY_BLOCK_SIZE
+#include "access/aomd.h"         // for ao hooks
+#include "storage/smgr.h"        // for heap hooks
+
+PG_MODULE_MAGIC;
+
+static file_read_buffer_modify_hook_type     pre_file_read_hook     = NULL;
+static file_write_buffer_modify_hook_type    pre_file_write_hook    = NULL;
+static file_extend_buffer_modify_hook_type   pre_file_extend_hook   = NULL;
+static ao_file_read_buffer_modify_hook_type  pre_ao_file_read_hook  = NULL;
+static ao_file_write_buffer_modify_hook_type pre_ao_file_write_hook = NULL;
+
+// process local buffer
+static char file_write_hook_buffer[BLCKSZ]                       = {'\0'};
+static char ao_file_write_hook_buffer[MAX_APPENDONLY_BLOCK_SIZE] = {'\0'};
+
+static void
+file_read_hook_invert(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer)
+{
+	for (int i = 0; i < BLCKSZ; i++)
+	{
+		buffer[i] = ~((uint8_t)buffer[i]);
+	}
+
+	// run file read hook after we decrypt the buffer, read hook need a decrypted data
+	if (pre_file_read_hook)
+	{
+		pre_file_read_hook(reln, forknum, blocknum, buffer);
+	}
+}
+
+static char *
+file_extend_hook_invert(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer)
+{
+	if (pre_file_extend_hook)
+	{
+		buffer = pre_file_extend_hook(reln, forknum, blocknum, buffer);
+	}
+
+	// extend with NULL means only alloc disk
+	if (buffer == NULL)
+	{
+		return buffer;
+	}
+
+	for (int i = 0; i < BLCKSZ; i++)
+	{
+		file_write_hook_buffer[i] = ~((uint8_t)buffer[i]);
+	}
+
+	return file_write_hook_buffer;
+}
+
+static char *
+file_write_hook_invert(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer)
+{
+	if (pre_file_write_hook)
+	{
+		buffer = pre_file_write_hook(reln, forknum, blocknum, buffer);
+	}
+
+	for (int i = 0; i < BLCKSZ; i++)
+	{
+		file_write_hook_buffer[i] = ~((uint8_t)buffer[i]);
+	}
+
+	return file_write_hook_buffer;
+}
+
+static void
+ao_file_read_hook_invert(File file, char *buffer, int actualLen, off_t offset)
+{
+	for (int i = 0; i < actualLen; i++)
+	{
+		buffer[i] = ~((uint8_t)buffer[i]);
+	}
+
+	if (pre_ao_file_read_hook)
+	{
+		pre_ao_file_read_hook(file, buffer, actualLen, offset);
+	}
+}
+
+static char *
+ao_file_write_hook_invert(File file, char *buffer, int amount, off_t offset)
+{
+	if (pre_ao_file_write_hook)
+	{
+		buffer = pre_ao_file_write_hook(file, buffer, amount, offset);
+	}
+
+	for (int i = 0; i < amount; i++)
+	{
+		ao_file_write_hook_buffer[i] = ~((uint8_t)buffer[i]);
+	}
+
+	return ao_file_write_hook_buffer;
+}
+
+void _PG_init(void);
+void
+_PG_init(void)
+{
+	pre_file_read_hook = file_read_buffer_modify_hook;
+	file_read_buffer_modify_hook = file_read_hook_invert;
+
+	pre_file_write_hook = file_write_buffer_modify_hook;
+	file_write_buffer_modify_hook = file_write_hook_invert;
+
+	pre_file_extend_hook = file_extend_buffer_modify_hook;
+	file_extend_buffer_modify_hook = file_extend_hook_invert;
+
+	pre_ao_file_read_hook = ao_file_read_buffer_modify_hook;
+	ao_file_read_buffer_modify_hook = ao_file_read_hook_invert;
+
+	pre_ao_file_write_hook = ao_file_write_buffer_modify_hook;
+	ao_file_write_buffer_modify_hook = ao_file_write_hook_invert;
+}

--- a/src/backend/cdb/cdbappendonlyxlog.c
+++ b/src/backend/cdb/cdbappendonlyxlog.c
@@ -89,6 +89,10 @@ ao_insert_replay(XLogReaderState *record)
 		return;
 	}
 
+	// pre-write process the buffer by extension
+	if (ao_file_write_buffer_modify_hook)
+		buffer = ao_file_write_buffer_modify_hook(file, buffer, len, xlrec->target.offset);
+
 	written_len = FileWrite(file, buffer, len, xlrec->target.offset,
 							WAIT_EVENT_COPY_FILE_WRITE);
 	if (written_len < 0 || written_len != len)

--- a/src/backend/storage/smgr/smgr.c
+++ b/src/backend/storage/smgr/smgr.c
@@ -45,6 +45,10 @@ file_extend_hook_type file_extend_hook = NULL;
 file_truncate_hook_type file_truncate_hook = NULL;
 file_unlink_hook_type file_unlink_hook = NULL;
 
+file_read_buffer_modify_hook_type file_read_buffer_modify_hook = NULL;
+file_write_buffer_modify_hook_type file_write_buffer_modify_hook = NULL;
+file_extend_buffer_modify_hook_type file_extend_buffer_modify_hook = NULL;
+
 static const f_smgr smgrsw[] = {
 	/* magnetic disk */
 	{
@@ -577,6 +581,9 @@ void
 smgrextend(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		   char *buffer, bool skipFsync)
 {
+	if (file_extend_buffer_modify_hook)
+		buffer = file_extend_buffer_modify_hook(reln, forknum, blocknum, buffer);
+
 	(*reln->storageManager).smgr_extend(reln, forknum, blocknum,
 										 buffer, skipFsync);
     if (file_extend_hook)
@@ -605,6 +612,9 @@ smgrread(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		 char *buffer)
 {
 	(*reln->storageManager).smgr_read(reln, forknum, blocknum, buffer);
+
+	if (file_read_buffer_modify_hook)
+		file_read_buffer_modify_hook(reln, forknum, blocknum, buffer);
 }
 
 /*
@@ -626,6 +636,9 @@ void
 smgrwrite(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum,
 		  char *buffer, bool skipFsync)
 {
+	if (file_write_buffer_modify_hook)
+		buffer = file_write_buffer_modify_hook(reln, forknum, blocknum, buffer);
+
 	(*reln->storageManager).smgr_write(reln, forknum, blocknum,
 										buffer, skipFsync);
 }

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -735,6 +735,11 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	InitBufferPoolBackend();
 
 	/*
+	 * load preload libraries in {bootstrap, single, normal} mode
+	 */
+	process_shared_preload_libraries();
+
+	/*
 	 * Initialize local process's access to XLOG.
 	 */
 	if (IsUnderPostmaster)

--- a/src/include/access/aomd.h
+++ b/src/include/access/aomd.h
@@ -68,4 +68,11 @@ extern void ao_foreach_extent_file(ao_extent_callback callback, void *ctx);
 extern void register_dirty_segment_ao(RelFileNode rnode, int segno, File vfd);
 
 extern uint64 ao_rel_get_physical_size(Relation aorel);
+
+typedef void (*ao_file_read_buffer_modify_hook_type)(File file, char *buffer, int actualLen, off_t offset);
+extern PGDLLIMPORT ao_file_read_buffer_modify_hook_type ao_file_read_buffer_modify_hook;  // in cdbbufferedread.c
+
+typedef char* (*ao_file_write_buffer_modify_hook_type)(File file, char *buffer, int amount, off_t offset);
+extern PGDLLIMPORT ao_file_write_buffer_modify_hook_type ao_file_write_buffer_modify_hook; // in cdbbufferedappend.c
+
 #endif							/* AOMD_H */

--- a/src/include/storage/smgr.h
+++ b/src/include/storage/smgr.h
@@ -171,11 +171,20 @@ extern void AtEOXact_SMgr(void);
  * For example, disk quota extension will use these hooks to
  * detect active tables.
  */
+typedef void (*file_read_buffer_modify_hook_type)(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer);
+extern PGDLLIMPORT file_read_buffer_modify_hook_type file_read_buffer_modify_hook;
+
 typedef void (*file_create_hook_type)(RelFileNodeBackend rnode);
 extern PGDLLIMPORT file_create_hook_type file_create_hook;
 
+typedef char* (*file_write_buffer_modify_hook_type)(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer);
+extern PGDLLIMPORT file_write_buffer_modify_hook_type file_write_buffer_modify_hook;
+
 typedef void (*file_extend_hook_type)(RelFileNodeBackend rnode);
 extern PGDLLIMPORT file_extend_hook_type file_extend_hook;
+
+typedef char* (*file_extend_buffer_modify_hook_type)(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer);
+extern PGDLLIMPORT file_extend_buffer_modify_hook_type file_extend_buffer_modify_hook;
 
 typedef void (*file_truncate_hook_type)(RelFileNodeBackend rnode);
 extern PGDLLIMPORT file_truncate_hook_type file_truncate_hook;


### PR DESCRIPTION
This PR is adding some new hooks:

```c
typedef void (*file_read_buffer_modify_hook_type)(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer);
typedef char* (*file_write_buffer_modify_hook_type)(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer);
typedef char* (*file_extend_buffer_modify_hook_type)(SMgrRelation reln, ForkNumber forknum, BlockNumber blocknum, char *buffer);
typedef void (*ao_file_read_buffer_modify_hook_type)(File file, char *buffer, int actualLen, off_t offset);
typedef char* (*ao_file_write_buffer_modify_hook_type)(File file, char *buffer, int amount, off_t offset);
```

Extensions can use those hooks to modify the read/write buffer before writing to disk.

This PR also adds an example extension, data_encryption, to show how to use those hooks. This extension just inverts all user data bit by bit.
The example extension has a test job, it will load the extension and run all pre-existing test cases. But some tests are not supported by design, like read/write file directly (ao_checksum) or not supported for now (pgbasebackup and pg_upgrade)