### PR TITLE
Fix GPDB_12_MERGE_FIXME in nodeShareInputScan

### DIFF
--- a/src/backend/executor/nodeShareInputScan.c
+++ b/src/backend/executor/nodeShareInputScan.c
@@ -724,7 +724,6 @@ ShareInputShmemInit(void)
 	{
 		HASHCTL		info;
 
-		/* GPDB_12_MERGE_FIXME: would be nicer to store this hash in the DSM segment or DSA */
 		info.keysize = sizeof(shareinput_tag);
 		info.entrysize = sizeof(shareinput_Xslice_state);
 


### PR DESCRIPTION
```
/* GPDB_12_MERGE_FIXME: would be nicer to store this hash in the DSM segment or DSA */
info.keysize = sizeof(shareinput_tag);
info.entrysize = sizeof(shareinput_Xslice_state);

shareinput_Xslice_hash = ShmemInitHash("ShareInputScan notifications",
								  N_SHAREINPUT_SLOTS(),
								  N_SHAREINPUT_SLOTS(),
					      		          &info,
								  HASH_ELEM | HASH_BLOBS);
```
Shmem is static shared memory which is pre-allocated and initialized during the startup of the postmaster.
It stores frequently accessed data pages and it is suitable for fixed-size data.
The address of static shared memory is the same between different backends. Using static shared memory is much simpler.

DSM and DSA is dynamic shared memory is allocated and managed dynamically during the runtime of the postgres.
It is suitable for temporary data storage, and communication between PostgreSQL backend processes. The address between different backends is different.

shareinput_Xslice_state is small and we access the field frequently, So I think use static shared memory is enough for shareinput_Xslice_state. And it is simpler than use DSM or DSA.

Remove the fixme.