### PR TITLE
Fix the MCV comment issue for version 7

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1598,7 +1598,7 @@ def checkAOLastrownums():
 # Exclude these tuples from the catalog table scan
 # pg_depend: classid 2603 (pg_amproc) is excluded because their OIDs can be
 #            nonsynchronous (catalog.c:RelationNeedsSynchronizedOIDs())
-MISSING_ENTRY_EXCLUDE = {'pg_depend': 'WHERE classid != 2603'}
+MISSING_ENTRY_EXCLUDE = {'pg_depend': 'WHERE classid != 2603', 'pg_description': 'WHERE classoid!= 3381'}
 
 def missingEntryQuery(max_content, catname, pkey, castedPkey):
     # =================


### PR DESCRIPTION
The MCV(in pg_statistic_ext) is Master only, and it's comment is Master only too, so when check missing entry for comment should exclude this kind.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
