### PR TITLE
Fix gp_toolkit.__gp_aocsseg_history crash on non-aocs tables.

### DIFF
--- a/gpcontrib/gp_toolkit/.gitignore
+++ b/gpcontrib/gp_toolkit/.gitignore
@@ -1,0 +1,1 @@
+/results/

--- a/gpcontrib/gp_toolkit/expected/gp_toolkit_ao_funcs.out
+++ b/gpcontrib/gp_toolkit/expected/gp_toolkit_ao_funcs.out
@@ -78,6 +78,10 @@ SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_aocs_test');
 ---------+-------+----------------+----------+--------------+-------------+-----------
 (0 rows)
 
+CREATE TABLE toolkit_heap_test (a INT) DISTRIBUTED BY (a);
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg_history('toolkit_heap_test');
+ERROR:  Relation 'toolkit_heap_test' does not have append-optimized column-oriented storage  (seg0 slice1 127.0.1.1:7002 pid=1226082)
+DROP TABLE toolkit_heap_test;
 -- The same, but on the segments.
 SELECT (t).* FROM (
   SELECT gp_toolkit.__gp_aovisimap('toolkit_ao_test') AS t FROM gp_dist_random('gp_id')

--- a/gpcontrib/gp_toolkit/sql/gp_toolkit_ao_funcs.sql
+++ b/gpcontrib/gp_toolkit/sql/gp_toolkit_ao_funcs.sql
@@ -37,6 +37,10 @@ SELECT count(*) FROM gp_toolkit.__gp_aoseg('toolkit_ao_test');
 SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_ao_test');
 SELECT * FROM gp_toolkit.__gp_aoblkdir('toolkit_aocs_test');
 
+CREATE TABLE toolkit_heap_test (a INT) DISTRIBUTED BY (a);
+SELECT count(*) FROM gp_toolkit.__gp_aocsseg_history('toolkit_heap_test');
+DROP TABLE toolkit_heap_test;
+
 -- The same, but on the segments.
 SELECT (t).* FROM (
   SELECT gp_toolkit.__gp_aovisimap('toolkit_ao_test') AS t FROM gp_dist_random('gp_id')

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -1477,7 +1477,6 @@ gp_aocsseg_history(PG_FUNCTION_ARGS)
 		aocsRel = heap_open(aocsRelOid, AccessShareLock);
 		if (!RelationStorageIsAoCols(aocsRel))
 		{
-			heap_close(aocsRel, AccessShareLock);
 			ereport(ERROR,
 			        (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
 					 errmsg("Relation '%s' does not have append-optimized column-oriented storage",


### PR DESCRIPTION
Fix #17142 

We try to use macro to fetch relation'name after closing the relation in error message, which causes a crash.
We do have heap_close in later lines, don't need to close here.

Only for aocs function, ao function is correct, doesn't have this issue.


Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
