### PR TITLE
Add ORCA GUC's for dynamic index/bitmap scan

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -377,6 +377,13 @@ CConfigParamMapping::PackConfigParamInBitset(
 		bitmap_index_bitset->Release();
 	}
 
+	// disable dynamic bitmap scan if the corresponding GUC is turned off
+	if (!optimizer_enable_dynamicbitmapscan)
+	{
+		traceflag_bitset->ExchangeSet(
+			GPOPT_DISABLE_XFORM_TF(CXform::ExfSelect2DynamicBitmapBoolOp));
+	}
+
 	// disable outerjoin to unionall transformation if GUC is turned off
 	if (!optimizer_enable_outerjoin_to_unionall_rewrite)
 	{
@@ -433,6 +440,13 @@ CConfigParamMapping::PackConfigParamInBitset(
 		// disable index only scan if the corresponding GUC is turned off
 		traceflag_bitset->ExchangeSet(
 			GPOPT_DISABLE_XFORM_TF(CXform::ExfIndexGet2IndexOnlyScan));
+	}
+
+	if (!optimizer_enable_dynamicindexscan)
+	{
+		// disable dynamic index scan if the corresponding GUC is turned off
+		traceflag_bitset->ExchangeSet(GPOPT_DISABLE_XFORM_TF(
+			CXform::ExfDynamicIndexGet2DynamicIndexScan));
 	}
 
 	if (!optimizer_enable_hashagg)

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -359,6 +359,8 @@ bool		optimizer_enable_dml_constraints;
 bool		optimizer_enable_master_only_queries;
 bool		optimizer_enable_hashjoin;
 bool		optimizer_enable_dynamictablescan;
+bool		optimizer_enable_dynamicindexscan;
+bool		optimizer_enable_dynamicbitmapscan;
 bool		optimizer_enable_indexscan;
 bool		optimizer_enable_indexonlyscan;
 bool		optimizer_enable_tablescan;
@@ -2487,6 +2489,28 @@ struct config_bool ConfigureNamesBool_gp[] =
 			GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
 		},
 		&optimizer_enable_dynamictablescan,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_dynamicindexscan", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enables the optimizer's use of plans with dynamic index scan."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_dynamicindexscan,
+		true,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_dynamicbitmapscan", PGC_USERSET, DEVELOPER_OPTIONS,
+			gettext_noop("Enables the optimizer's use of plans with dynamic bitmap scan."),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_dynamicbitmapscan,
 		true,
 		NULL, NULL, NULL
 	},

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -486,6 +486,8 @@ extern bool optimizer_enable_direct_dispatch;
 extern bool optimizer_enable_master_only_queries;
 extern bool optimizer_enable_hashjoin;
 extern bool optimizer_enable_dynamictablescan;
+extern bool optimizer_enable_dynamicindexscan;
+extern bool optimizer_enable_dynamicbitmapscan;
 extern bool optimizer_enable_indexscan;
 extern bool optimizer_enable_indexonlyscan;
 extern bool optimizer_enable_tablescan;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -371,6 +371,8 @@
 		"optimizer_enable_dml_constraints",
 		"optimizer_enable_dml_triggers",
 		"optimizer_enable_dynamictablescan",
+		"optimizer_enable_dynamicindexscan",
+		"optimizer_enable_dynamicbitmapscan",
 		"optimizer_enable_eageragg",
 		"optimizer_enable_orderedagg",
 		"optimizer_enable_gather_on_segment_for_dml",

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -9931,7 +9931,7 @@ alter table orca.bm_dyn_test drop column to_be_dropped;
 alter table orca.bm_dyn_test add partition part5 values(5);
 NOTICE:  CREATE TABLE will create partition "bm_dyn_test_1_prt_part5" for table "bm_dyn_test"
 insert into orca.bm_dyn_test values(2, 5, '2');
-set optimizer_enable_bitmapscan=on;
+set optimizer_enable_dynamicbitmapscan=on;
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test where i=2 and t='2';
                                      QUERY PLAN                                     
@@ -12248,7 +12248,7 @@ HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sur
                      ->  Result  (cost=0.00..0.01 rows=1 width=0)
                            Output: '2020-01-01', '99'
  Optimizer: Postgres query optimizer
- Settings: optimizer=off, optimizer_join_order=query
+ Settings: optimizer=off, optimizer_enable_dynamicbitmapscan=on, optimizer_join_order=query
 (16 rows)
 
 CREATE TABLE TP AS

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -9982,7 +9982,7 @@ alter table orca.bm_dyn_test drop column to_be_dropped;
 alter table orca.bm_dyn_test add partition part5 values(5);
 NOTICE:  CREATE TABLE will create partition "bm_dyn_test_1_prt_part5" for table "bm_dyn_test"
 insert into orca.bm_dyn_test values(2, 5, '2');
-set optimizer_enable_bitmapscan=on;
+set optimizer_enable_dynamicbitmapscan=on;
 -- gather on 1 segment because of direct dispatch
 explain select * from orca.bm_dyn_test where i=2 and t='2';
                                                   QUERY PLAN                                                   

--- a/src/test/regress/sql/bfv_partition_plans.sql
+++ b/src/test/regress/sql/bfv_partition_plans.sql
@@ -100,6 +100,7 @@ drop table mpp7980;
 -- SETUP
 -- start_ignore
 set optimizer_enable_bitmapscan=on;
+set optimizer_enable_dynamicbitmapscan=on;
 set optimizer_enable_indexjoin=on;
 drop table if exists mpp23195_t1;
 drop table if exists mpp23195_t2;
@@ -121,6 +122,7 @@ select * from mpp23195_t1,mpp23195_t2 where mpp23195_t1.i < mpp23195_t2.i;
 drop table if exists mpp23195_t1;
 drop table if exists mpp23195_t2;
 set optimizer_enable_bitmapscan=off;
+set optimizer_enable_dynamicbitmapscan=off;
 set optimizer_enable_indexjoin=off;
 -- end_ignore
 

--- a/src/test/regress/sql/gporca.sql
+++ b/src/test/regress/sql/gporca.sql
@@ -1468,7 +1468,7 @@ alter table orca.bm_dyn_test drop column to_be_dropped;
 alter table orca.bm_dyn_test add partition part5 values(5);
 insert into orca.bm_dyn_test values(2, 5, '2');
 
-set optimizer_enable_bitmapscan=on;
+set optimizer_enable_dynamicbitmapscan=on;
 -- start_ignore
 analyze orca.bm_dyn_test;
 -- end_ignore


### PR DESCRIPTION
optimizer_enable_dynamicindexscan
optimizer_enable_dynamicbitmapscan

Fix #16885

I meant for the GUC tests to be as sutble as possible. I did verify locally that if those GUC's are turned off, plans not involving dynamic bitmap/index scan are returned in the gporca suite. Specifically, dynamic bitmap/index scan was replaced by dynamic sequential scan.

(cherry picked from commit f82f956350cd4603985227affb8bdd9b7d367689)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
