### PR TITLE
Lift NOT_SUPPORTED notice for pg_start|stop_backup

### DIFF
--- a/src/backend/access/transam/xlogfuncs.c
+++ b/src/backend/access/transam/xlogfuncs.c
@@ -69,11 +69,6 @@ pg_start_backup(PG_FUNCTION_ARGS)
 	XLogRecPtr	startpoint;
 	SessionBackupState status = get_backup_status();
 
-	ereport(NOTICE,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("pg_start_backup() is not supported in Greenplum Database"),
-			 errhint("Contact support to get more information and resolve the issue")));
-
 	backupidstr = text_to_cstring(backupid);
 
 	if (status == SESSION_BACKUP_NON_EXCLUSIVE)
@@ -135,11 +130,6 @@ pg_stop_backup(PG_FUNCTION_ARGS)
 {
 	XLogRecPtr	stoppoint = InvalidXLogRecPtr;
 	SessionBackupState status = get_backup_status();
-
-	ereport(NOTICE,
-			(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
-			 errmsg("pg_stop_backup() is not supported in Greenplum Database"),
-			 errhint("Contact support to get more information and resolve the issue")));
 
 	if (status == SESSION_BACKUP_NON_EXCLUSIVE)
 		ereport(ERROR,


### PR DESCRIPTION
It is definitely supported and used by differential recovery in-tree.
The NOTICE was added when WAL replication was introduced into GPDB in
737e216e9e5f. We have come a long way since then.

Reviewed-by: Huansong Fu <fuhuansong@gmail.com>
