### PR TITLE
CO: Support RLE with Zstandard

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -34,6 +34,7 @@
 #include "utils/memutils.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
+#include "storage/gp_compress.h"
 
 /*
  * Helper macro used for validation
@@ -1014,12 +1015,12 @@ validate_and_adjust_options(StdRdOptions *result,
 
 		if (result->compresstype[0] &&
 			(pg_strcasecmp(result->compresstype, "rle_type") == 0) &&
-			(result->compresslevel > 4))
+			(result->compresslevel > RLE_MAX_LEVEL))
 		{
 			if (validate)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("compresslevel=%d is out of range for rle_type (should be in the range 1 to 4)",
+						 errmsg("compresslevel=%d is out of range for rle_type (should be in the range 1 to 6)",
 								result->compresslevel)));
 
 			result->compresslevel = setDefaultCompressionLevel(result->compresstype);

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -432,7 +432,19 @@ init_datumstream_info(
 				ao_attr->compressType = "zlib";
 				ao_attr->compressLevel = 9;
 				break;
+#ifdef USE_ZSTD
+			case 5:
+				ao_attr->compress = true;
+				ao_attr->compressType = "zstd";
+				ao_attr->compressLevel = 1;
+				break;
 
+			case 6:
+				ao_attr->compress = true;
+				ao_attr->compressType = "zstd";
+				ao_attr->compressLevel = 3; /* zstd recommended default */
+				break;
+#endif
 			default:
 				ereport(ERROR,
 						(errmsg("Unexpected compresslevel %d",

--- a/src/include/storage/gp_compress.h
+++ b/src/include/storage/gp_compress.h
@@ -80,6 +80,12 @@ typedef struct
 extern void zstd_free_context(zstd_context *context);
 extern zstd_context *zstd_alloc_context(void);
 
+#define RLE_MAX_LEVEL	(6)
+
+#else
+
+#define RLE_MAX_LEVEL	(4)
+
 #endif	/* USE_ZSTD */
 
 

--- a/src/test/binary_swap/test_binary_swap.sh
+++ b/src/test/binary_swap/test_binary_swap.sh
@@ -25,6 +25,12 @@ clean_output()
     rm -f dump_current.sql dump_other.sql
 }
 
+## Run pre test to ignore expected failures
+run_pre_test()
+{
+    psql -f test_binary_swap_pre.sql postgres > /dev/null 2>&1
+}
+
 ## Run tests via pg_regress with given schedule name
 run_tests()
 {
@@ -134,6 +140,7 @@ clean_output
 
 ## Start/restart current Greenplum and do initial dump to compare against
 start_binary $GPHOME_CURRENT
+run_pre_test
 run_tests schedule1${VARIANT}
 
 ## Change the binary, dump, and then compare the two dumps generated

--- a/src/test/binary_swap/test_binary_swap_pre.sql
+++ b/src/test/binary_swap/test_binary_swap_pre.sql
@@ -1,0 +1,12 @@
+-- WARNING: This file is executed against the postgres database. If
+-- objects are to be manipulated in other databases, make sure to
+-- change to the correct database first.
+
+\c regression;
+
+-- Drop tables carrying rle with zstd compression. That is not available in
+-- earlier minor versions.
+DROP TABLE co_rle_zstd1;
+DROP TABLE co_rle_zstd3;
+DROP TABLE co_rle_zlib_to_zstd;
+DROP TABLE co6;

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -542,16 +542,14 @@ create table co6(
 	a int encoding (compresstype=rle_type),
 	b float encoding (blocksize=8192))
 	distributed by (a);
-ERROR:  compresslevel=5 is out of range for rle_type (should be in the range 1 to 4)
 create table co7(a int, b float,
 	default column encoding (compresstype=RLE_TYPE, compresslevel=7))
 	distributed by (a);
-ERROR:  compresslevel=7 is out of range for rle_type (should be in the range 1 to 4)
+ERROR:  compresslevel=7 is out of range for rle_type (should be in the range 1 to 6)
 -- negative tests - session level set
 set gp_default_storage_options = "compresstype=zlib,compresslevel=11";
 ERROR:  compresslevel=11 is out of range for zlib (should be in the range 1 to 9)
 set gp_default_storage_options = "compresslevel=5,compresstype=RLE_TYPE";
-ERROR:  compresslevel=5 is out of range for rle_type (should be in the range 1 to 4)
 set gp_default_storage_options = "compresslevel=1,compresstype=rle";
 ERROR:  unknown compresstype "rle"
 set gp_default_storage_options = "checksum=1234";
@@ -561,9 +559,9 @@ ERROR:  invalid integer value "true" for storage option "blocksize"
 set gp_default_storage_options = 'blocksize=8192,checksumblah=true';
 ERROR:  invalid storage option "checksumblah"
 show gp_default_storage_options;
-                   gp_default_storage_options                    
------------------------------------------------------------------
- blocksize=32768,compresstype=zlib,compresslevel=5,checksum=true
+                     gp_default_storage_options                      
+---------------------------------------------------------------------
+ blocksize=32768,compresstype=rle_type,compresslevel=5,checksum=true
 (1 row)
 
 -- negative tests - database level

--- a/src/test/regress/expected/rle.out
+++ b/src/test/regress/expected/rle.out
@@ -11329,3 +11329,53 @@ insert into sml_rle_hdr values (-1,-1.1);
 set client_min_messages=warning;
 update sml_rle_hdr set b = b + 10 where a = -1;
 commit;
+-- Some smoke tests against rle's levels using zstd
+create table co_rle_zstd1(i int encoding(compresstype=rle_type, compresslevel=5)) using ao_column;
+create table co_rle_zstd3(i int encoding(compresstype=rle_type, compresslevel=6)) using ao_column;
+\d+ co_rle_zstd1
+                                                         Table "public.co_rle_zstd1"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+----------+---------+---------+--------------+------------------+-------------------+------------+-------------
+ i      | integer |           |          |         | plain   |              | rle_type         | 5                 | 32768      | 
+Distributed by: (i)
+Options: blocksize=32768, compresslevel=0, compresstype=none, checksum=true
+
+\d+ co_rle_zstd3
+                                                         Table "public.co_rle_zstd3"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+----------+---------+---------+--------------+------------------+-------------------+------------+-------------
+ i      | integer |           |          |         | plain   |              | rle_type         | 6                 | 32768      | 
+Distributed by: (i)
+Options: blocksize=32768, compresslevel=0, compresstype=none, checksum=true
+
+insert into co_rle_zstd1 select generate_series(1, 100000);
+insert into co_rle_zstd3 select generate_series(1, 100000);
+select count(distinct i) from co_rle_zstd1;
+ count  
+--------
+ 100000
+(1 row)
+
+select count(distinct i) from co_rle_zstd3;
+ count  
+--------
+ 100000
+(1 row)
+
+create table co_rle_zlib_to_zstd(i int encoding(compresstype=rle_type, compresslevel=4)) using ao_column;
+insert into co_rle_zlib_to_zstd select generate_series(1, 100000);
+alter table co_rle_zlib_to_zstd alter column i set encoding(compresstype=rle_type, compresslevel=5);
+\d+ co_rle_zlib_to_zstd
+                                                      Table "public.co_rle_zlib_to_zstd"
+ Column |  Type   | Collation | Nullable | Default | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+----------+---------+---------+--------------+------------------+-------------------+------------+-------------
+ i      | integer |           |          |         | plain   |              | rle_type         | 5                 | 32768      | 
+Distributed by: (i)
+Options: blocksize=32768, compresslevel=0, compresstype=none, checksum=true
+
+select count(distinct i) from co_rle_zlib_to_zstd;
+ count  
+--------
+ 100000
+(1 row)
+

--- a/src/test/regress/sql/rle.sql
+++ b/src/test/regress/sql/rle.sql
@@ -4851,3 +4851,19 @@ insert into sml_rle_hdr values (-1,-1.1);
 set client_min_messages=warning;
 update sml_rle_hdr set b = b + 10 where a = -1;
 commit;
+
+-- Some smoke tests against rle's levels using zstd
+create table co_rle_zstd1(i int encoding(compresstype=rle_type, compresslevel=5)) using ao_column;
+create table co_rle_zstd3(i int encoding(compresstype=rle_type, compresslevel=6)) using ao_column;
+\d+ co_rle_zstd1
+\d+ co_rle_zstd3
+insert into co_rle_zstd1 select generate_series(1, 100000);
+insert into co_rle_zstd3 select generate_series(1, 100000);
+select count(distinct i) from co_rle_zstd1;
+select count(distinct i) from co_rle_zstd3;
+
+create table co_rle_zlib_to_zstd(i int encoding(compresstype=rle_type, compresslevel=4)) using ao_column;
+insert into co_rle_zlib_to_zstd select generate_series(1, 100000);
+alter table co_rle_zlib_to_zstd alter column i set encoding(compresstype=rle_type, compresslevel=5);
+\d+ co_rle_zlib_to_zstd
+select count(distinct i) from co_rle_zlib_to_zstd;


### PR DESCRIPTION
This addresses #12721.

Zstandard is superior to Zlib in terms of both compression speed and
disk footprint. So offer users the ability to rely on it. To enjoy the
benefits of Zstandard compression in column-oriented tables users can
create tables with compresslevel=5|6.

Example:
create table co_rle_zstd(i int encoding(compresstype=rle_type,
compresslevel=5)) using ao_column;

Alternatively, users can use ALTER TABLE ALTER COLUMN ENCODING to
convert existing tables to the new compress levels as well.

Compresslevels 5 and 6 invoke zstd compression with zstd levels 1 and 3
respectively. Since zstd level 3 is the default and the recommended
level, compresslevel = 6 should cover most cases and is highly
encouraged.

Notes:

(1) Since zstd level = 1 can readily beat zlib level = 9 in terms of
speed (and disk footprint), it can easily fit into our scheme for
compresslevels (lower implies higher speed)

(2) More levels can be provided in the future for zstd, as per demand.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/rle_zstd

Performance comparison (nice speed bump ~25%) with zstd as expected:

```
-- Setup: fsync=on, autovacuum=off, -O3 retail build, 3 segment mirrorless local workstation

Speed:

-- zlib level = 9
create table corle4(i int encoding(compresstype=rle_type, compresslevel=4)) using ao_column;
insert into corle4 select generate_series(1, 1000000000);
INSERT 0 1000000000
Time: 206574.577 ms (03:26.575)

--zstd level = 1
create table corle5(i int encoding(compresstype=rle_type, compresslevel=5)) using ao_column;
insert into corle5 select generate_series(1, 1000000000);
INSERT 0 1000000000
Time: 149266.421 ms (02:29.266)

-- zstd level = 3
create table corle6(i int encoding(compresstype=rle_type, compresslevel=6)) using ao_column;
insert into corle6 select generate_series(1, 1000000000);
INSERT 0 1000000000
Time: 145689.558 ms (02:25.690)

Footprint:

                          List of relations
 Schema |  Name  | Type  |  Owner  |  Storage  |  Size  | Description 
--------+--------+-------+---------+-----------+--------+-------------
 public | corle4 | table | pivotal | ao_column | 413 MB | 
 public | corle5 | table | pivotal | ao_column | 375 MB | 
 public | corle6 | table | pivotal | ao_column | 401 MB | 
(4 rows)
```

References:
[0] https://engineering.fb.com/2016/08/31/core-infra/smaller-and-faster-data-compression-with-zstandard/
[1] https://gregoryszorc.com/blog/2017/03/07/better-compression-with-zstandard/