### PR TITLE
Remove unused macro definition.

### DIFF
--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -361,8 +361,6 @@ typedef union Datum_U
 
 #define SIZEOF_DATUM 8
 
-typedef Datum *DatumPtr;
-
 #define GET_1_BYTE(datum)	(((Datum) (datum)) & 0x000000ff)
 #define GET_2_BYTES(datum)	(((Datum) (datum)) & 0x0000ffff)
 #define GET_4_BYTES(datum)	(((Datum) (datum)) & 0xffffffff)

--- a/src/include/postgres.h
+++ b/src/include/postgres.h
@@ -361,18 +361,6 @@ typedef union Datum_U
 
 #define SIZEOF_DATUM 8
 
-#define GET_1_BYTE(datum)	(((Datum) (datum)) & 0x000000ff)
-#define GET_2_BYTES(datum)	(((Datum) (datum)) & 0x0000ffff)
-#define GET_4_BYTES(datum)	(((Datum) (datum)) & 0xffffffff)
-#if SIZEOF_DATUM == 8
-#define GET_8_BYTES(datum)	((Datum) (datum))
-#endif
-#define SET_1_BYTE(value)	(((Datum) (value)) & 0x000000ff)
-#define SET_2_BYTES(value)	(((Datum) (value)) & 0x0000ffff)
-#define SET_4_BYTES(value)	(((Datum) (value)) & 0xffffffff)
-#if SIZEOF_DATUM == 8
-#define SET_8_BYTES(value)	((Datum) (value))
-#endif
 /*
  * A NullableDatum is used in places where both a Datum and its nullness needs
  * to be stored. This can be more efficient than storing datums and nullness


### PR DESCRIPTION
DatumPtr is unused in gp7 and is defined in pg_vector. 
When we compile pg_vector v0.6.0 with gp7, it throws the [double-definition error](https://github.com/pgvector/pgvector/blob/master/src/hnsw.h#L130). 
So we want to remove it. BTW, we removed GET_x_BYTE and SET_x_BYTES 
since they are unused.