### PR TITLE
WIP: a strategy of short-time JIT cache is implemented for partitions

### DIFF
--- a/src/backend/executor/execUtils.c
+++ b/src/backend/executor/execUtils.c
@@ -621,6 +621,11 @@ ExecConditionalAssignProjectionInfo(PlanState *planstate, TupleDesc inputDesc,
 							  inputDesc))
 	{
 		planstate->ps_ProjInfo = NULL;
+		if (planstate->state->es_jit_caches)
+		{
+			/* GPDB: update JIT cache */
+			planstate->state->es_jit_caches[JIT_CACHE_PROJ].valid = false;
+		}
 		planstate->resultopsset = planstate->scanopsset;
 		planstate->resultopsfixed = planstate->scanopsfixed;
 		planstate->resultops = planstate->scanops;

--- a/src/backend/jit/llvm/llvmjit.c
+++ b/src/backend/jit/llvm/llvmjit.c
@@ -143,7 +143,7 @@ _PG_jit_provider_init(JitProviderCallbacks *cb)
 {
 	cb->reset_after_error = llvm_reset_after_error;
 	cb->release_context = llvm_release_context;
-	cb->compile_expr = llvm_compile_expr;
+	cb->compile_expr = llvm_compile_expr_wrapper;
 }
 
 /*

--- a/src/include/jit/jit.h
+++ b/src/include/jit/jit.h
@@ -61,6 +61,20 @@ typedef struct JitContext
 	JitInstrumentation instr;
 } JitContext;
 
+typedef enum
+{
+	JIT_CACHE_PROJ,
+	JIT_CACHE_QUAL,
+	JIT_CACHE_N
+} JitCacheType;
+
+typedef struct JitCache
+{
+	bool			valid;
+	int			id;
+	struct ExprState	*exprstate;
+} JitCache;
+
 typedef struct JitProviderCallbacks JitProviderCallbacks;
 
 extern void _PG_jit_provider_init(JitProviderCallbacks *cb);

--- a/src/include/jit/llvmjit.h
+++ b/src/include/jit/llvmjit.h
@@ -116,6 +116,7 @@ extern void llvm_inline(LLVMModuleRef mod);
  * Code generation functions.
  ****************************************************************************
  */
+extern bool llvm_compile_expr_wrapper(struct ExprState *state);
 extern bool llvm_compile_expr(struct ExprState *state);
 struct TupleTableSlotOps;
 extern LLVMValueRef slot_compile_deform(struct LLVMJitContext *context, TupleDesc desc,

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -99,6 +99,9 @@ typedef struct ExprState
 	/* private state for an evalfunc */
 	void	   *evalfunc_private;
 
+	/* GPDB: JIT cache for partition table */
+	struct JitCache	   *jit_cache;
+
 	/*
 	 * XXX: following fields only needed during "compilation" (ExecInitExpr);
 	 * could be thrown away afterwards.
@@ -107,7 +110,7 @@ typedef struct ExprState
 	int			steps_len;		/* number of steps currently */
 	int			steps_alloc;	/* allocated length of steps array */
 
-#define FIELDNO_EXPRSTATE_PARENT 11
+#define FIELDNO_EXPRSTATE_PARENT 12
 	struct PlanState *parent;	/* parent PlanState node, if any */
 	ParamListInfo ext_params;	/* for compiling PARAM_EXTERN nodes */
 
@@ -681,7 +684,14 @@ typedef struct EState
 	 */
 	bool		gp_bypass_unique_check;
 
+	/* GPDB: refer to JIT cache from upper planstate */
+	struct JitCache	*es_jit_caches;
+	Plan		*es_jit_plan;
+
 } EState;
+
+#define IsJitCacheMatchPlan(estateptr, planptr) (estateptr && planptr && estateptr->es_jit_caches && estateptr->es_jit_plan == planptr) 
+
 
 struct PlanState;
 struct MotionState;
@@ -2141,6 +2151,8 @@ typedef struct DynamicSeqScanState
 	struct PartitionPruneState *as_prune_state; /* partition dynamic pruning state */
 	Bitmapset  *as_valid_subplans; /* used to determine partitions during dynamic pruning*/
 	bool 		did_pruning; /* flag that is set once dynamic pruning is performed */
+
+	struct JitCache	*jit_caches;
 } DynamicSeqScanState;
 
 /*


### PR DESCRIPTION
a strategy of short-time JIT cache is implemented for partition table, 
which would suppress duplicated runtime compilation as the partitions often have highly similar expression trees.
