### PR TITLE
[6x] pg_upgrade: add support func to check if view contains removed functions

### DIFF
--- a/contrib/pg_upgrade_support/pg_upgrade_support.c
+++ b/contrib/pg_upgrade_support/pg_upgrade_support.c
@@ -63,10 +63,12 @@ PG_FUNCTION_INFO_V1(set_next_preassigned_tablespace_oid);
 PG_FUNCTION_INFO_V1(view_has_anyarray_casts);
 PG_FUNCTION_INFO_V1(view_has_unknown_casts);
 PG_FUNCTION_INFO_V1(view_has_removed_operators);
+PG_FUNCTION_INFO_V1(view_has_removed_functions);
 
 static bool check_node_anyarray_walker(Node *node, void *context);
 static bool check_node_unknown_walker(Node *node, void *context);
 static bool check_node_removed_operators_walker(Node *node, void *context);
+static bool check_node_removed_functions_walker(Node *node, void *context);
 
 Datum
 set_next_pg_type_oid(PG_FUNCTION_ARGS)
@@ -460,3 +462,181 @@ check_node_removed_operators_walker(Node *node, void *context)
 	return expression_tree_walker(node, check_node_removed_operators_walker, context);
 }
 
+Datum
+view_has_removed_functions(PG_FUNCTION_ARGS)
+{
+	Oid		  view_oid = PG_GETARG_OID(0);
+	Relation  rel = try_relation_open(view_oid, AccessShareLock, false);
+	Query	 *viewquery;
+	bool	  found;
+
+	if (!RelationIsValid(rel))
+		elog(ERROR, "Could not open relation file for relation oid %u", view_oid);
+
+	if(rel->rd_rel->relkind == RELKIND_VIEW)
+	{
+		viewquery = get_view_query(rel);
+		found = query_tree_walker(viewquery, check_node_removed_functions_walker, NULL, 0);
+	}
+	else
+		found = false;
+
+	relation_close(rel, AccessShareLock);
+
+	PG_RETURN_BOOL(found);
+}
+
+static bool
+check_node_removed_functions_walker(Node *node, void *context)
+{
+	Assert(context == NULL);
+
+	if (node == NULL)
+		return false;
+
+	if (IsA(node, FuncExpr))
+	{
+		Oid func_oid = ((FuncExpr *)node)->funcid;
+		if (func_oid == 12512 || // gp_toolkit.__gp_get_ao_entry_from_cache
+			func_oid == 12511 || // gp_toolkit.__gp_remove_ao_entry_from_cache
+			func_oid == 12498 || // gp_toolkit.pg_resgroup_check_move_query
+			func_oid ==  7188 || // pg_catalog.bmbeginscan
+			func_oid ==  7193 || // pg_catalog.bmbuild
+			func_oid ==  7011 || // pg_catalog.bmbuildempty
+			func_oid ==  7194 || // pg_catalog.bmbulkdelete
+			func_oid ==  7196 || // pg_catalog.bmcostestimate
+			func_oid ==  7190 || // pg_catalog.bmendscan
+			func_oid ==  7051 || // pg_catalog.bmgetbitmap
+			func_oid ==  7050 || // pg_catalog.bmgettuple
+			func_oid ==  7187 || // pg_catalog.bminsert
+			func_oid ==  7191 || // pg_catalog.bmmarkpos
+			func_oid ==  7197 || // pg_catalog.bmoptions
+			func_oid ==  7189 || // pg_catalog.bmrescan
+			func_oid ==  7192 || // pg_catalog.bmrestrpos
+			func_oid ==  7195 || // pg_catalog.bmvacuumcleanup
+			func_oid ==   333 || // pg_catalog.btbeginscan
+			func_oid ==   338 || // pg_catalog.btbuild
+			func_oid ==   328 || // pg_catalog.btbuildempty
+			func_oid ==   332 || // pg_catalog.btbulkdelete
+			func_oid ==  6276 || // pg_catalog.btcanreturn
+			func_oid ==  1268 || // pg_catalog.btcostestimate
+			func_oid ==   335 || // pg_catalog.btendscan
+			func_oid ==   636 || // pg_catalog.btgetbitmap
+			func_oid ==   330 || // pg_catalog.btgettuple
+			func_oid ==   331 || // pg_catalog.btinsert
+			func_oid ==   336 || // pg_catalog.btmarkpos
+			func_oid ==  6785 || // pg_catalog.btoptions
+			func_oid ==   334 || // pg_catalog.btrescan
+			func_oid ==   337 || // pg_catalog.btrestrpos
+			func_oid ==   972 || // pg_catalog.btvacuumcleanup
+			func_oid ==  2733 || // pg_catalog.ginbeginscan
+			func_oid ==  2738 || // pg_catalog.ginbuild
+			func_oid ==   325 || // pg_catalog.ginbuildempty
+			func_oid ==  2739 || // pg_catalog.ginbulkdelete
+			func_oid ==  6741 || // pg_catalog.gincostestimate
+			func_oid ==  2735 || // pg_catalog.ginendscan
+			func_oid ==  2731 || // pg_catalog.gingetbitmap
+			func_oid ==  2732 || // pg_catalog.gininsert
+			func_oid ==  2736 || // pg_catalog.ginmarkpos
+			func_oid ==  2788 || // pg_catalog.ginoptions
+			func_oid ==  2734 || // pg_catalog.ginrescan
+			func_oid ==  2737 || // pg_catalog.ginrestrpos
+			func_oid ==  6740 || // pg_catalog.ginvacuumcleanup
+			func_oid ==   777 || // pg_catalog.gistbeginscan
+			func_oid ==  2579 || // pg_catalog.gist_box_compress
+			func_oid ==  2580 || // pg_catalog.gist_box_decompress
+			func_oid ==   782 || // pg_catalog.gistbuild
+			func_oid ==   326 || // pg_catalog.gistbuildempty
+			func_oid ==   776 || // pg_catalog.gistbulkdelete
+			func_oid ==   772 || // pg_catalog.gistcostestimate
+			func_oid ==   779 || // pg_catalog.gistendscan
+			func_oid ==   638 || // pg_catalog.gistgetbitmap
+			func_oid ==   774 || // pg_catalog.gistgettuple
+			func_oid ==   775 || // pg_catalog.gistinsert
+			func_oid ==   780 || // pg_catalog.gistmarkpos
+			func_oid ==  6787 || // pg_catalog.gistoptions
+			func_oid ==   778 || // pg_catalog.gistrescan
+			func_oid ==   781 || // pg_catalog.gistrestrpos
+			func_oid ==  2561 || // pg_catalog.gistvacuumcleanup
+			func_oid ==  5044 || // pg_catalog.gp_elog
+			func_oid ==  5045 || // pg_catalog.gp_elog
+			func_oid ==  9999 || // pg_catalog.gp_fault_inject
+			func_oid == 12531 || // pg_catalog.gp_quicklz_compress
+			func_oid == 12529 || // pg_catalog.gp_quicklz_constructor
+			func_oid == 12532 || // pg_catalog.gp_quicklz_decompress
+			func_oid == 12530 || // pg_catalog.gp_quicklz_destructor
+			func_oid == 12533 || // pg_catalog.gp_quicklz_validator
+			func_oid ==  7173 || // pg_catalog.gp_update_ao_master_stats
+			func_oid ==  3696 || // pg_catalog.gtsquery_decompress
+			func_oid ==   443 || // pg_catalog.hashbeginscan
+			func_oid ==   448 || // pg_catalog.hashbuild
+			func_oid ==   327 || // pg_catalog.hashbuildempty
+			func_oid ==   442 || // pg_catalog.hashbulkdelete
+			func_oid ==   438 || // pg_catalog.hashcostestimate
+			func_oid ==   445 || // pg_catalog.hashendscan
+			func_oid ==   637 || // pg_catalog.hashgetbitmap
+			func_oid ==   440 || // pg_catalog.hashgettuple
+			func_oid ==   441 || // pg_catalog.hashinsert
+			func_oid ==   398 || // pg_catalog.hashint2vector
+			func_oid ==   446 || // pg_catalog.hashmarkpos
+			func_oid ==  6786 || // pg_catalog.hashoptions
+			func_oid ==   444 || // pg_catalog.hashrescan
+			func_oid ==   447 || // pg_catalog.hashrestrpos
+			func_oid ==   425 || // pg_catalog.hashvacuumcleanup
+			func_oid ==  3556 || // pg_catalog.inet_gist_decompress
+			func_oid ==   315 || // pg_catalog.int2vectoreq
+			func_oid ==  7597 || // pg_catalog.numeric2point
+			func_oid ==  3157 || // pg_catalog.numeric_transform
+			func_oid ==  2852 || // pg_catalog.pg_current_xlog_insert_location
+			func_oid ==  2849 || // pg_catalog.pg_current_xlog_location
+			func_oid ==  5024 || // pg_catalog.pg_get_partition_def
+			func_oid ==  5034 || // pg_catalog.pg_get_partition_def
+			func_oid ==  5025 || // pg_catalog.pg_get_partition_def
+			func_oid ==  5028 || // pg_catalog.pg_get_partition_rule_def
+			func_oid ==  5027 || // pg_catalog.pg_get_partition_rule_def
+			func_oid ==  5037 || // pg_catalog.pg_get_partition_template_def
+			func_oid ==  3073 || // pg_catalog.pg_is_xlog_replay_paused
+			func_oid ==  3820 || // pg_catalog.pg_last_xlog_receive_location
+			func_oid ==  3821 || // pg_catalog.pg_last_xlog_replay_location
+			func_oid ==  2853 || // pg_catalog.pg_stat_get_backend_waiting
+			func_oid ==  7298 || // pg_catalog.pg_stat_get_backend_waiting_reason
+			func_oid ==  2848 || // pg_catalog.pg_switch_xlog
+			func_oid ==  2851 || // pg_catalog.pg_xlogfile_name
+			func_oid ==  2850 || // pg_catalog.pg_xlogfile_name_offset
+			func_oid ==  3165 || // pg_catalog.pg_xlog_location_diff
+			func_oid ==  3071 || // pg_catalog.pg_xlog_replay_pause
+			func_oid ==  3072 || // pg_catalog.pg_xlog_replay_resume
+			func_oid ==  3877 || // pg_catalog.range_gist_compress
+			func_oid ==  3878 || // pg_catalog.range_gist_decompress
+			func_oid ==  4004 || // pg_catalog.spgbeginscan
+			func_oid ==  4009 || // pg_catalog.spgbuild
+			func_oid ==  4010 || // pg_catalog.spgbuildempty
+			func_oid ==  4011 || // pg_catalog.spgbulkdelete
+			func_oid ==  4032 || // pg_catalog.spgcanreturn
+			func_oid ==  4013 || // pg_catalog.spgcostestimate
+			func_oid ==  4006 || // pg_catalog.spgendscan
+			func_oid ==  4002 || // pg_catalog.spggetbitmap
+			func_oid ==  4001 || // pg_catalog.spggettuple
+			func_oid ==  4003 || // pg_catalog.spginsert
+			func_oid ==  4007 || // pg_catalog.spgmarkpos
+			func_oid ==  4014 || // pg_catalog.spgoptions
+			func_oid ==  4005 || // pg_catalog.spgrescan
+			func_oid ==  4008 || // pg_catalog.spgrestrpos
+			func_oid ==  4012 || // pg_catalog.spgvacuumcleanup
+			func_oid ==  3917 || // pg_catalog.timestamp_transform
+			func_oid ==  3944 || // pg_catalog.time_transform
+			func_oid ==  3158 || // pg_catalog.varbit_transform
+			func_oid ==  3097)   // pg_catalog.varchar_transform
+			return true;
+
+		return false;
+	}
+	else if (IsA(node, Query))
+	{
+		/* recurse into subselects and ctes */
+		Query *query = (Query *) node;
+		return query_tree_walker(query, check_node_removed_functions_walker, context, 0);
+	}
+
+	return expression_tree_walker(node, check_node_removed_functions_walker, context);
+}


### PR DESCRIPTION
Views that use removed functions will cause upgrade to fail. This happens during metadata restore on the target cluster because pg_restore will error trying to create a view using functions that do not exist anymore. This is not ideal as we could be many hours into upgrade before a view using a removed function causes pg_upgrade to fail. In order to detect views with removed functions. A query_tree_walker is used to walk the nodes of all views. Each node is then checked to see if it is a function. If it is, we then check if the oid of the function matches one that is not present in GPDB7.

Currently we only notify end users of views that contain a removed function. We do not log what specific part of the view triggered the check for a removed function.

The following functions were excluded from being checked.
 - Overloaded functions that still existed but had their function signature changed.
 - Functions that were related to removed types. It is assumed that the removed types check will catch these functions.
 - Functions moved to another schema (pg_resgroup_move_query).

---

### Method for finding removed functions
**Note: comparing arguments is important because functions can be overloaded.**

**On a 7X cluster:**
connect to template1
```
create temp table sevenx as (select n.nspname || '.' || p.proname as proname, proretset, pronargs, prorettype::regtype::text, proargtypes::regtype[]::text[], proallargtypes::regtype[]::text[], proargmodes, proargnames from pg_proc p, pg_namespace n where p.pronamespace=n.oid);
copy sevenx to '/tmp/sevenx.csv' with csv header;
```

**On a 6X cluster:**
Connect to template1
```
create temp table sixx as (select n.nspname || '.' || p.proname as proname, proretset, pronargs, prorettype::regtype::text, proargtypes::regtype[]::text[], proallargtypes::regtype[]::text[], proargmodes, proargnames from pg_proc p, pg_namespace n where p.pronamespace=n.oid);
create table sevenx (like sixx);
copy sevenx from '/tmp/sevenx.csv' with csv header;

-- This a table we will join on later to get the oids of the removed functions on 6x. It is almost identical to temp table sixx:
create temp table sixx_oid as (select p.oid, n.nspname || '.' || p.proname as proname, prorettype::regtype::text, proargtypes::regtype[]::text[] from pg_proc p, pg_namespace n where p.pronamespace=n.oid);

-- Removed 6x functions/procedures. based on matching function name, return type, and argument types.
WITH diff AS (
    SELECT *
    FROM (
        SELECT * from sixx
        EXCEPT
        SELECT * FROM sevenx
        ORDER BY 1
    ) AS sub
)
SELECT f.oid, d.proname, d.prorettype, d.proargtypes
FROM diff d
JOIN sixx_oid f on f.proname = d.proname
AND f.prorettype = d.prorettype
AND f.proargtypes = d.proargtypes
ORDER BY 2;
```

https://github.com/greenplum-db/gpupgrade/pull/902
6x: https://github.com/greenplum-db/gpdb/pull/17152
7x: https://github.com/greenplum-db/gpdb/pull/17153 
