### PR TITLE
Remove GPDB_12_MERGE_FIXME in ic_tcp.c

### DIFF
--- a/src/backend/cdb/motion/ic_tcp.c
+++ b/src/backend/cdb/motion/ic_tcp.c
@@ -2655,8 +2655,6 @@ RecvTupleChunkFromAnyTCP(ChunkTransportState *transportStates,
 
 		}
 
-		// GPDB_12_MERGE_FIXME: should use WaitEventSetWait() instead of select()
-		// follow the routine in ic_udpifc.c
 		n = select(nfds + 1, (fd_set *) &rset, NULL, NULL, &timeout);
 		if (n < 0)
 		{


### PR DESCRIPTION
Fixme:
GPDB_12_MERGE_FIXME: should use WaitEventSetWait() instead of select() following the routine in ic_udpifc.c
This fixme was added in PR #13394 by @interma.
After discussing with @interma offline, initially, he intended to use WaitEventSetWait()
instead of poll in ic_udpifc.c. However, due to the modification of cdbdisp_getWaitSocketFd(CdbDispatcherState *ds)
to cdbdisp_getWaitSocketFds(CdbDispatcherState *ds, int *nsocks), cdbdisp_getWaitSocketFd is also called in ic_tcp.c.
As a result, a fixme was left in ic_tcp.c.

The advantage of using WaitEventSetWait instead of select is that we can monitor the specific
waitevent in the pg_stat_activity view. However, we believe the potential benefits may not be significant.
Therefore, we have decided to simply remove this fixme.


