### PR TITLE
ao/co: fix an issue with COPY zero-column CO table

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1229,6 +1229,13 @@ ReadNext:
 		/* If necessary, open next seg */
 		if (scan->cur_seg < 0 || err < 0)
 		{
+			/*
+			 * Bail out early if we do not have any column in the projection.
+			 * Placing here in order to have less impact on the hot path. 
+			 */
+			if (scan->columnScanInfo.num_proj_atts == 0)
+				return false;
+
 			err = open_next_scan_seg(scan);
 			if (err < 0)
 			{
@@ -1239,6 +1246,9 @@ ReadNext:
 			}
 			scan->segrowsprocessed = 0;
 		}
+
+		/* We shouldn't have a 0-column projection as we should've bailed out above */
+		Assert(scan->columnScanInfo.num_proj_atts > 0);
 
 		Assert(scan->cur_seg >= 0);
 		curseginfo = scan->seginfo[scan->cur_seg];

--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -547,7 +547,7 @@ aoco_beginscan_extractcolumns(Relation rel, Snapshot snapshot,
 		* extractcolumns_walker will return immediately, so no columns are specified.
 		* We always scan the first column.
 		*/
-		if (!found)
+		if (!found && natts > 0)
 			proj[0] = true;
 		needFree = true;
 	}

--- a/src/backend/access/aocs/aocssegfiles.c
+++ b/src/backend/access/aocs/aocssegfiles.c
@@ -521,9 +521,9 @@ GetAOCSSSegFilesTotalsWithProj(Relation parentrel,
 	/*
 	 * The projection list must be non-empty. If there are no columns projected,
 	 * i.e. all columns must be considered, then proj_atts should be an array
-	 * containing each and every column number.
+	 * containing each and every column number. Unless the table has 0 column.
 	 */
-	Assert(num_proj_atts > 0);
+	Assert(num_proj_atts > 0 || parentrel->rd_att->natts == 0);
 	Assert(proj_atts);
 
 	totals = (FileSegTotals *) palloc0(sizeof(FileSegTotals));

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3206,7 +3206,14 @@ CopyTo(CopyState cstate)
 							fmgr_info(out_func_oid, &cstate->out_functions[attnum - 1]);
 						}
 					}
-					scandesc = table_beginscan_es(rel, GetActiveSnapshot(), 0, NULL, proj, NULL);
+					/*
+					 * We specifically pass NULL proj if the table has no column, and leave it
+					 * to the underlying CO AM layer to handle it - the behavior should be same
+					 * as SELECT * which is to choose one column to scan.
+					 */
+					scandesc = table_beginscan_es(rel, GetActiveSnapshot(), 0, NULL, 
+													cstate->attnumlist ? proj : NULL, 
+													NULL);
 					slot = table_slot_create(rel, NULL);
 
 					while (table_scan_getnextslot(scandesc, ForwardScanDirection, slot))

--- a/src/test/regress/input/uao_ddl/alter_drop_allcol.source
+++ b/src/test/regress/input/uao_ddl/alter_drop_allcol.source
@@ -14,14 +14,17 @@ select * from alter_drop_allcoll order by a,b;
 ALTER TABLE alter_drop_allcoll DROP COLUMN c;
 select count(*) as c from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='c';
 select * from alter_drop_allcoll order by a,b;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll DROP COLUMN b;
 select count(*) as b from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='b';
 select * from alter_drop_allcoll order by a;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll DROP COLUMN a;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
 select * from alter_drop_allcoll;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll ADD COLUMN a1 int default 10;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -29,3 +32,4 @@ select * from alter_drop_allcoll;
 COMMIT;
 vacuum alter_drop_allcoll;
 select * from alter_drop_allcoll;
+copy alter_drop_allcoll to stdout;

--- a/src/test/regress/input/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/input/uao_ddl/create_ao_tables.source
@@ -205,3 +205,9 @@ set gp_select_invisible=false;
 select * into sto_heap_10 from sto_uao_8;
 select count(*) from sto_heap_10;
 COMMIT;
+
+-- Table with zero column
+create table sto_uao_0col();
+select * from sto_uao_0col;
+select count(*) from sto_uao_0col;
+copy sto_uao_0col to stdout;

--- a/src/test/regress/output/uao_ddl/alter_drop_allcol.source
+++ b/src/test/regress/output/uao_ddl/alter_drop_allcol.source
@@ -38,6 +38,12 @@ select * from alter_drop_allcoll order by a,b;
  5 | 5
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+1	1
+2	2
+3	3
+4	4
+5	5
 ALTER TABLE alter_drop_allcoll DROP COLUMN b;
 select count(*) as b from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='b';
  b 
@@ -55,6 +61,12 @@ select * from alter_drop_allcoll order by a;
  5
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+1
+2
+3
+4
+5
 ALTER TABLE alter_drop_allcoll DROP COLUMN a;
 NOTICE:  dropping a column that is part of the distribution policy forces a random distribution policy
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -66,6 +78,12 @@ select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oi
 select * from alter_drop_allcoll;
 --
 (5 rows)
+
+copy alter_drop_allcoll to stdout;
+
+
+
+
 
 ALTER TABLE alter_drop_allcoll ADD COLUMN a1 int default 10;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -96,3 +114,9 @@ select * from alter_drop_allcoll;
  10
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+10
+10
+10
+10
+10

--- a/src/test/regress/output/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/output/uao_ddl/create_ao_tables.source
@@ -323,3 +323,16 @@ select count(*) from sto_heap_10;
 (1 row)
 
 COMMIT;
+-- Table with zero column
+create table sto_uao_0col();
+select * from sto_uao_0col;
+--
+(0 rows)
+
+select count(*) from sto_uao_0col;
+ count 
+-------
+     0
+(1 row)
+
+copy sto_uao_0col to stdout;


### PR DESCRIPTION
The issue is that if the CO table once had column (and data), but later all columns are dropped, then COPY this table would hang:

```sql
create table co(a int) using ao_column;
insert into co select * from generate_series(1,10);
alter table co drop column a;

copy co to stdout; -- this hangs forever
```

The is because `aocs_getnext` is not handling this case well: it would open the segment files but skip the actually scanning (because no projected columns), write no tupleslot values, and finally return TRUE which doesn't make any sense as it did not read any tuple. So a loop to get next tuple would loop forever. If we return FALSE here, we would stop the loop early.

Note that, however, this does not make COPY's behavior for CO to be the same as heap or AO, where we would still copy out the same number of rows as in the table, just no data in the row (see added test case in the PR). In order to get it right, we can make a targeted change to `COPY TO` so it leave the decision to the CO AM layer regarding which column to project, which is also more consistent with `SELECT *`.

Then, the change to `aocs_getnext()` would serve as just defensive checks.

Also fixed an issue with `aoco_beginscan_extractcolumns()` where we shouldn't write `proj[0]` if `natts==0`, otherwise would overwrite invalid memory in case like:
```sql
postgres=# create table co() using ao_column;
CREATE TABLE
postgres=# select * from co;
WARNING:  detected write past chunk end in ExecutorState 0x55f234ea87c8  (seg1 slice1 127.0.1.1:7003 pid=10726)
WARNING:  detected write past chunk end in ExecutorState 0x555b0a692708  (seg2 slice1 127.0.1.1:7004 pid=10727)
WARNING:  detected write past chunk end in ExecutorState 0x562e118bf768  (seg0 slice1 127.0.1.1:7002 pid=10725)
--
(0 rows)
```

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/co-copy-0col

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
