### PR TITLE
fix compilation error

### DIFF
--- a/src/test/isolation2/Makefile
+++ b/src/test/isolation2/Makefile
@@ -57,7 +57,7 @@ data:
 scan_flaky_fault_injectors:
 	$(top_builddir)/src/test/regress/scan_flaky_fault_injectors.sh
 
-pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpq submake-libpgport
+pg_isolation2_regress$(X): isolation2_main.o pg_regress.o submake-libpgport submake-libpq
 	$(CC) $(CFLAGS) $(filter %.o,$^) $(libpq_pgport) $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@
 
 clean distclean:


### PR DESCRIPTION
This bug is caused by #17137: an error is thrown when compiling isolation2 in CI:
```
In file included from ../../../src/include/postgres.h:53:0,
                 from pqsignal.c:63:
../../../src/include/utils/elog.h:73:28: fatal error: utils/errcodes.h: No such file or directory
 #include "utils/errcodes.h"
```

This is because there is no `utils/errcodes.h` when `submake-libpq` is building. Let's build
`submake-libpgport` firstly, and then can build `submake-libpq`.

Co-authored-by: Chen Mulong <chenmulong@gmail.com>
Co-authored-by: Xing Guo <admin@higuoxing.com>
