### PR TITLE
[ORCA] Remove default parameter argument

### DIFF
--- a/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/operators/CLogicalGet.h
@@ -61,11 +61,11 @@ public:
 	explicit CLogicalGet(CMemoryPool *mp);
 
 	CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
-				CTableDescriptor *ptabdesc, BOOL hasSecurityQuals = false);
+				CTableDescriptor *ptabdesc, BOOL hasSecurityQuals);
 
 	CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 				CTableDescriptor *ptabdesc, CColRefArray *pdrgpcrOutput,
-				BOOL hasSecurityQuals = false);
+				BOOL hasSecurityQuals);
 
 	// dtor
 	~CLogicalGet() override;

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalForeignGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalForeignGet.cpp
@@ -47,7 +47,7 @@ CLogicalForeignGet::CLogicalForeignGet(CMemoryPool *mp) : CLogicalGet(mp)
 //---------------------------------------------------------------------------
 CLogicalForeignGet::CLogicalForeignGet(CMemoryPool *mp, const CName *pnameAlias,
 									   CTableDescriptor *ptabdesc)
-	: CLogicalGet(mp, pnameAlias, ptabdesc)
+	: CLogicalGet(mp, pnameAlias, ptabdesc, /*hasSecurityQuals*/ false)
 {
 }
 
@@ -62,7 +62,8 @@ CLogicalForeignGet::CLogicalForeignGet(CMemoryPool *mp, const CName *pnameAlias,
 CLogicalForeignGet::CLogicalForeignGet(CMemoryPool *mp, const CName *pnameAlias,
 									   CTableDescriptor *ptabdesc,
 									   CColRefArray *pdrgpcrOutput)
-	: CLogicalGet(mp, pnameAlias, ptabdesc, pdrgpcrOutput)
+	: CLogicalGet(mp, pnameAlias, ptabdesc, pdrgpcrOutput,
+				  /*hasSecurityQuals*/ false)
 {
 }
 

--- a/src/backend/gporca/libgpopt/src/operators/CLogicalGet.cpp
+++ b/src/backend/gporca/libgpopt/src/operators/CLogicalGet.cpp
@@ -58,30 +58,13 @@ CLogicalGet::CLogicalGet(CMemoryPool *mp)
 //---------------------------------------------------------------------------
 CLogicalGet::CLogicalGet(CMemoryPool *mp, const CName *pnameAlias,
 						 CTableDescriptor *ptabdesc, BOOL hasSecurityQuals)
-	: CLogical(mp),
-	  m_pnameAlias(pnameAlias),
-	  m_ptabdesc(GPOS_NEW(mp) CTableDescriptorHashSet(mp)),
-	  m_pdrgpcrOutput(nullptr),
-	  m_pdrgpdrgpcrPart(nullptr),
-	  m_pcrsDist(nullptr),
-	  m_has_security_quals(hasSecurityQuals)
+	: CLogicalGet(mp, pnameAlias, ptabdesc,
+				  PdrgpcrCreateMapping(mp, ptabdesc->Pdrgpcoldesc(),
+									   // XXX: UlOpId() isn't valid yet..
+									   COperator::m_aulOpIdCounter + 1,
+									   ptabdesc->MDId()),
+				  hasSecurityQuals)
 {
-	GPOS_ASSERT(nullptr != ptabdesc);
-	GPOS_ASSERT(nullptr != pnameAlias);
-
-	m_ptabdesc->Insert(ptabdesc);
-
-	// generate a default column set for the table descriptor
-	m_pdrgpcrOutput = PdrgpcrCreateMapping(mp, Ptabdesc()->Pdrgpcoldesc(),
-										   UlOpId(), Ptabdesc()->MDId());
-
-	if (Ptabdesc()->IsPartitioned())
-	{
-		m_pdrgpdrgpcrPart = PdrgpdrgpcrCreatePartCols(
-			mp, m_pdrgpcrOutput, Ptabdesc()->PdrgpulPart());
-	}
-
-	m_pcrsDist = CLogical::PcrsDist(mp, Ptabdesc(), m_pdrgpcrOutput);
 }
 
 //---------------------------------------------------------------------------

--- a/src/backend/gporca/server/src/unittest/CTestUtils.cpp
+++ b/src/backend/gporca/server/src/unittest/CTestUtils.cpp
@@ -310,8 +310,9 @@ CTestUtils::PexprLogicalGet(CMemoryPool *mp, CTableDescriptor *ptabdesc,
 {
 	GPOS_ASSERT(nullptr != ptabdesc);
 
-	CLogicalGet *pop = GPOS_NEW(mp) CLogicalGet(
-		mp, GPOS_NEW(mp) CName(mp, CName(pstrTableAlias)), ptabdesc);
+	CLogicalGet *pop = GPOS_NEW(mp)
+		CLogicalGet(mp, GPOS_NEW(mp) CName(mp, CName(pstrTableAlias)), ptabdesc,
+					/*hasSecurityQuals*/ false);
 
 	CExpression *result = GPOS_NEW(mp) CExpression(mp, pop);
 


### PR DESCRIPTION
Let's prefer to not use default parameters for a couple reasons:

1) It makes code reading harder because it essentially adds a new
   function signature. When there are multiple signatures with default
   parameters it takes longer to find out which one is actually used.

2) It makes it painful to add new parameters and can lead to subtle
   bugs. For example, if signature changes from: C(a, c=1) to C(a, b,
   c=1), then all the callers must be carefully updated. Otherwise, an
   old caller C(1, 2) may now pass unexpected arguments.

Also, refactor to use delegating constructor to remove code duplication.

---

Dev Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-orca-delegating-constructor-refactor-rocky8