### PR TITLE
Correctly pass down offset estimate in prelim limit

### DIFF
--- a/src/backend/optimizer/plan/planner.c
+++ b/src/backend/optimizer/plan/planner.c
@@ -7092,6 +7092,7 @@ create_preliminary_limit_path(PlannerInfo *root, RelOptInfo *rel,
 {
 	Node	   *precount = copyObject(limitCount);
 	Path	   *result_path;
+	int64 		precount_est = count_est;
 
 	/*
 	 * If we've specified an offset *and* a limit, we need to collect
@@ -7125,6 +7126,7 @@ create_preliminary_limit_path(PlannerInfo *root, RelOptInfo *rel,
 									precount,
 									NULL,
 									-1);
+		precount_est += offset_est;
 	}
 
 	if (precount != NULL)
@@ -7136,7 +7138,7 @@ create_preliminary_limit_path(PlannerInfo *root, RelOptInfo *rel,
 		result_path = (Path *) create_limit_path(root, rel, subpath,
 												 NULL, /* limitOffset */
 												 precount,	/* limitCount */
-												 -1, offset_est + count_est);
+												 0, precount_est);
 	}
 	else
 		result_path = subpath;


### PR DESCRIPTION
When we create a preliminary limit path (to be executed on the QEs), we
were not passing 0 as the estimate for OFFSET (like in 6X), and we were
passing -1 instead. Consequently, in adjust_limit_rows_costs() we were
triggering the 10% estimate calculation when offset isn't provided,
which led to 10% of the subpath's total cost getting added to the
startup cost of the prelim Limit path. I believe that this change was
inadvertently introduced as part of 9.6 merge commit:
98c86ecd2287896e017361ea10e0b08b9d378e8e

This bug led to incorrect costing for:
(*) Queries with no OFFSET clause. Here offset_est = 0 for
adjust_limit_rows_costs() and we incorrectly did the 10% estimation.
This issue was discovered when it was found that regular IndexScans
weren't getting picked as ordering operators for LIMIT-ORDER-BY queries
on AO tables (future work)

As an example, consider the query:
select * from lineitem order by l_shipdate limit 2;
-- l_shipdate has btree index with lineitem being an AO table

So if we had an IndexScan path with startup cost = 1 and a total cost of
180M (very high number since IndexScanning an AO table fully is very
expensive), we would unfairly tag on a cost of 18M to the prelim Limit
node on top of the IndexScan! Thus, we wouldn't pick the IndexScan.

Reviewed-by: Chris Hajas <chajas@vmware.com>
Reviewed-by: Zhang Mingli <avamingli@gmail.com>
Reviewed-by: Zhenghua Lyu <kainwen@gmail.com>

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/offset_fixv2/jobs/icw_planner_rocky8/builds/4