### PR TITLE
Remove GPDB_96_MERGE_FIXME in portalmem.c

### DIFF
--- a/src/backend/utils/mmgr/portalmem.c
+++ b/src/backend/utils/mmgr/portalmem.c
@@ -1045,13 +1045,6 @@ AtSubAbort_Portals(SubTransactionId mySubid,
 				portal->activeSubid = parentSubid;
 
 				/*
-				 * GPDB_96_MERGE_FIXME: We had this different comment here in GPDB.
-				 * Does this scenario happen in GPDB for some reason?
-				 *
-				 * Upper-level portals that failed while running in this
-				 * subtransaction must be forced into FAILED state, for the
-				 * same reasons discussed below.
-				 *
 				 * A MarkPortalActive() caller ran an upper-level portal in
 				 * this subtransaction and left the portal ACTIVE.  This can't
 				 * happen, but force the portal into FAILED state for the same


### PR DESCRIPTION
commit c5454f9 add deteled comment and commit 41baee7 remove the comment.

Currently, every MarkPortalActive() caller ensures it updates the portal status again before relinquishing control. When using an upper-level portal in a subtransaction, change to PORTAL_READY or when error happens change to PORTAL_FAILED, so ACTIVE can't happen here.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
