### PR TITLE
[7X] Initialize RowSampler.N to totaltupcount including dead tuples

### DIFF
--- a/src/backend/access/aocs/aocsam_handler.c
+++ b/src/backend/access/aocs/aocsam_handler.c
@@ -1724,9 +1724,9 @@ aoco_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,
 
 	/* Prepare for sampling tuple numbers */
 	RowSamplerData rs;
-	RowSampler_Init(&rs, *totalrows, targrows, random());
+	RowSampler_Init(&rs, totaltupcount, targrows, random());
 
-	while (RowSampler_HasMore(&rs))
+	while (RowSampler_HasMore(&rs) && (liverows < *totalrows))
 	{
 		aocoscan->targrow = RowSampler_Next(&rs);
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1284,12 +1284,13 @@ appendonly_getblock(AppendOnlyScanDesc scan, int64 targrow, int64 *startrow)
 	 */
 	while (true)
 	{
-		elog(DEBUG2, "appendonly_getblock(): [targrow: %ld, currow: %ld, diff: %ld, "
-			 "startrow: %ld, rowcount: %ld, segfirstrow: %ld, segrowsprocessed: %ld, "
-			 "blockRowsProcessed: %ld, blockRowCount: %d]", targrow, *startrow + rowcount - 1,
-			 *startrow + rowcount - 1 - targrow, *startrow, rowcount, scan->segfirstrow,
-			 scan->segrowsprocessed, varblock->blockRowsProcessed,
-			 varblock->rowCount);
+		elogif(Debug_appendonly_print_scan, LOG,
+			   "appendonly_getblock(): [targrow: %ld, currow: %ld, diff: %ld, "
+			   "startrow: %ld, rowcount: %ld, segfirstrow: %ld, segrowsprocessed: %ld, "
+			   "blockRowsProcessed: %ld, blockRowCount: %d]", targrow, *startrow + rowcount - 1,
+			   *startrow + rowcount - 1 - targrow, *startrow, rowcount, scan->segfirstrow,
+			   scan->segrowsprocessed, varblock->blockRowsProcessed,
+			   varblock->rowCount);
 
 		if (AppendOnlyExecutorReadBlock_GetBlockInfo(&scan->storageRead, varblock))
 		{
@@ -1381,10 +1382,11 @@ appendonly_blkdirscan_get_target_tuple(AppendOnlyScanDesc scan, int64 targrow, T
 									targrow,
 									&rowsprocessed);
 
-	elog(DEBUG2, "AOBlkDirScan_GetRowNum(segno: %d, col: %d, targrow: %ld): "
-		 "[segfirstrow: %ld, segrowsprocessed: %ld, rownum: %ld, cached_entry_no: %d]",
-		 segno, 0, targrow, scan->segfirstrow, scan->segrowsprocessed, rownum,
-		 blkdir->minipages[0].cached_entry_no);
+	elogif(Debug_appendonly_print_scan, LOG,
+		   "AOBlkDirScan_GetRowNum(segno: %d, col: %d, targrow: %ld): "
+		   "[segfirstrow: %ld, segrowsprocessed: %ld, rownum: %ld, cached_entry_no: %d]",
+		   segno, 0, targrow, scan->segfirstrow, scan->segrowsprocessed, rownum,
+		   blkdir->minipages[0].cached_entry_no);
 	
 	if (rownum < 0)
 		return false;
@@ -1451,7 +1453,8 @@ appendonly_get_target_tuple(AppendOnlyScanDesc aoscan, int64 targrow, TupleTable
 	Assert(rowsprocessed + varblock->rowCount - 1 >= targrow);
 	rownum = varblock->blockFirstRowNum + (targrow - rowsprocessed);
 
-	elog(DEBUG2, "appendonly_getblock() returns: [segno: %d, rownum: %ld]", segno, rownum);
+	elogif(Debug_appendonly_print_scan, LOG,
+		   "appendonly_getblock() returns: [segno: %d, rownum: %ld]", segno, rownum);
 
 	/* form the target tuple TID */
 	AOTupleIdInit(&aotid, segno, rownum);

--- a/src/backend/access/appendonly/appendonlyam_handler.c
+++ b/src/backend/access/appendonly/appendonlyam_handler.c
@@ -1524,9 +1524,9 @@ appendonly_acquire_sample_rows(Relation onerel, int elevel, HeapTuple *rows,
 
 	/* Prepare for sampling row numbers */
 	RowSamplerData rs;
-	RowSampler_Init(&rs, *totalrows, targrows, random());
+	RowSampler_Init(&rs, totaltupcount, targrows, random());
 
-	while (RowSampler_HasMore(&rs))
+	while (RowSampler_HasMore(&rs) && (liverows < *totalrows))
 	{
 		aoscan->targrow = RowSampler_Next(&rs);
 

--- a/src/test/isolation2/input/uao/fast_analyze.source
+++ b/src/test/isolation2/input/uao/fast_analyze.source
@@ -364,3 +364,50 @@ analyze analyze_@amname@_3;
 select attname, correlation from pg_stats where tablename='analyze_@amname@_3';
 
 drop table analyze_@amname@_3;
+
+--
+-- Test dead values returned in sampling CO tuples.
+-- Non-blkdir based sampling had the following bug:
+-- 
+-- If you have 3 rows: (i,j) = (1, 1), (1, 2) and (1,3),
+-- if (1, 2) is deleted, then we would return (1,1) and (1,2)
+-- instead of (1,1) and (1,3) as visible.
+--
+-- This is because we missed advancing the datum streams for
+-- non-first columns when the tuple was deleted.
+--
+
+-- partially same as Case 6 of tablesample.source
+create table test_dead_values_return_@amname@(i int, j int, k int) using @amname@;
+insert into test_dead_values_return_@amname@ select 1, j, j from generate_series(1, 10) j;
+delete from test_dead_values_return_@amname@ where j % 2 = 0;
+select * from test_dead_values_return_@amname@;
+select * from gp_acquire_sample_rows('test_dead_values_return_@amname@'::regclass, 10000, 'f') as
+  (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, i int, j int, k int);
+
+truncate test_dead_values_return_@amname@;
+
+1: begin;
+2: begin;
+
+1: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(1, 10) j;
+2: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(11, 20) j;
+
+2: abort;
+1: commit;
+
+1: begin;
+2: begin;
+
+1: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(21, 30) j;
+2: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(31, 40) j;
+2: commit;
+
+1: delete from test_dead_values_return_@amname@ where j % 2 = 1;
+1: commit;
+
+select * from test_dead_values_return_@amname@;
+select * from gp_acquire_sample_rows('test_dead_values_return_@amname@'::regclass, 10000, 'f') as
+  (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, i int, j int, k int);
+
+drop table test_dead_values_return_@amname@;

--- a/src/test/isolation2/output/uao/fast_analyze.source
+++ b/src/test/isolation2/output/uao/fast_analyze.source
@@ -658,3 +658,124 @@ select attname, correlation from pg_stats where tablename='analyze_@amname@_3';
 
 drop table analyze_@amname@_3;
 DROP TABLE
+
+--
+-- Test dead values returned in sampling CO tuples.
+-- Non-blkdir based sampling had the following bug:
+--
+-- If you have 3 rows: (i,j) = (1, 1), (1, 2) and (1,3),
+-- if (1, 2) is deleted, then we would return (1,1) and (1,2)
+-- instead of (1,1) and (1,3) as visible.
+--
+-- This is because we missed advancing the datum streams for
+-- non-first columns when the tuple was deleted.
+--
+
+-- partially same as Case 6 of tablesample.source
+create table test_dead_values_return_@amname@(i int, j int, k int) using @amname@;
+CREATE TABLE
+insert into test_dead_values_return_@amname@ select 1, j, j from generate_series(1, 10) j;
+INSERT 0 10
+delete from test_dead_values_return_@amname@ where j % 2 = 0;
+DELETE 5
+select * from test_dead_values_return_@amname@;
+ i | j | k 
+---+---+---
+ 1 | 1 | 1 
+ 1 | 3 | 3 
+ 1 | 5 | 5 
+ 1 | 7 | 7 
+ 1 | 9 | 9 
+(5 rows)
+select * from gp_acquire_sample_rows('test_dead_values_return_@amname@'::regclass, 10000, 'f') as (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, i int, j int, k int);
+ totalrows | totaldeadrows | oversized_cols_length | i | j | k 
+-----------+---------------+-----------------------+---+---+---
+ 0         | 0             |                       |   |   |   
+ 0         | 0             |                       |   |   |   
+           |               |                       | 1 | 1 | 1 
+           |               |                       | 1 | 3 | 3 
+           |               |                       | 1 | 5 | 5 
+           |               |                       | 1 | 7 | 7 
+           |               |                       | 1 | 9 | 9 
+ 5         | 5             |                       |   |   |   
+(8 rows)
+
+truncate test_dead_values_return_@amname@;
+TRUNCATE TABLE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+1: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(1, 10) j;
+INSERT 0 10
+2: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(11, 20) j;
+INSERT 0 10
+
+2: abort;
+ROLLBACK
+1: commit;
+COMMIT
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+
+1: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(21, 30) j;
+INSERT 0 10
+2: insert into test_dead_values_return_@amname@ select 2, j, j from generate_series(31, 40) j;
+INSERT 0 10
+2: commit;
+COMMIT
+
+1: delete from test_dead_values_return_@amname@ where j % 2 = 1;
+DELETE 15
+1: commit;
+COMMIT
+
+select * from test_dead_values_return_@amname@;
+ i | j  | k  
+---+----+----
+ 2 | 2  | 2  
+ 2 | 4  | 4  
+ 2 | 6  | 6  
+ 2 | 8  | 8  
+ 2 | 10 | 10 
+ 2 | 32 | 32 
+ 2 | 34 | 34 
+ 2 | 36 | 36 
+ 2 | 38 | 38 
+ 2 | 40 | 40 
+ 2 | 22 | 22 
+ 2 | 24 | 24 
+ 2 | 26 | 26 
+ 2 | 28 | 28 
+ 2 | 30 | 30 
+(15 rows)
+select * from gp_acquire_sample_rows('test_dead_values_return_@amname@'::regclass, 10000, 'f') as (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, i int, j int, k int);
+ totalrows | totaldeadrows | oversized_cols_length | i | j  | k  
+-----------+---------------+-----------------------+---+----+----
+ 0         | 0             |                       |   |    |    
+ 0         | 0             |                       |   |    |    
+           |               |                       | 2 | 2  | 2  
+           |               |                       | 2 | 4  | 4  
+           |               |                       | 2 | 6  | 6  
+           |               |                       | 2 | 8  | 8  
+           |               |                       | 2 | 10 | 10 
+           |               |                       | 2 | 32 | 32 
+           |               |                       | 2 | 34 | 34 
+           |               |                       | 2 | 36 | 36 
+           |               |                       | 2 | 38 | 38 
+           |               |                       | 2 | 40 | 40 
+           |               |                       | 2 | 22 | 22 
+           |               |                       | 2 | 24 | 24 
+           |               |                       | 2 | 26 | 26 
+           |               |                       | 2 | 28 | 28 
+           |               |                       | 2 | 30 | 30 
+ 15        | 15            |                       |   |    |    
+(18 rows)
+
+drop table test_dead_values_return_@amname@;
+DROP TABLE


### PR DESCRIPTION
to satisfy sampling rows when the sample size is greater than the
total row number of the table.

RowSampler returned samplerows that could be less than the requesting
sample size. Considering the following example:

```SQL
create table aorow(i int, j int, k int) using ao_row;
insert into aorow select 1, j, j from generate_series(1, 10) j;
delete from aorow where j % 2 = 0;
select * from aorow;

 i | j | k
---+---+---
 1 | 1 | 1
 1 | 3 | 3
 1 | 5 | 5
 1 | 7 | 7
 1 | 9 | 9
(5 rows)

select * from gp_acquire_sample_rows('aorow'::regclass, 10000, 'f') as
  (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8,
  oversized_cols_length pg_catalog._float8, i int, j int, k int);

 totalrows | totaldeadrows | oversized_cols_length | i | j | k
-----------+---------------+-----------------------+---+---+---
 0         | 0             |                       |   |   |
 0         | 0             |                       |   |   |
           |               |                       | 1 | 1 | 1
           |               |                       | 1 | 3 | 3
           |               |                       | 1 | 5 | 5
 5         | 5             |                       |   |   |
(6 rows)
```

It only returned 3 live rows instead of all 5 live rows. In this case
we do fully scan on the table so expect to sample all live rows as sample
size (10000 rows) is far greater than the table size (10 rows = 5 live + 5 dead).

This is because dead rows could be counted into the sample size hence
consume sample slots (refer to issue https://github.com/greenplum-db/gpdb/issues/15655).

Before providing a complete solution, for now we can simply fix this case
by initializing RowSampler.N to totaltupcount containing both live and dead
rows instead of live rows only.

Note this is only effective to the case of sample size being greater than
the table size, if sample size is smaller than the table size, it is possible
to return less samplerows than the requirement.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/hw-7X-aocs-analyze-rebase

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
