### PR TITLE
Fix issue: missing some information about logerrors in pg_exttable view.

### DIFF
--- a/gpcontrib/gp_exttable_fdw/gp_exttable_fdw.c
+++ b/gpcontrib/gp_exttable_fdw/gp_exttable_fdw.c
@@ -327,8 +327,13 @@ Datum pg_exttable(PG_FUNCTION_ARGS)
 		 * options. Since our document not contains the OPTION clause, so we
 		 * assume no external table options in used for now.  Except
 		 * gpextprotocol.c.
+		 * 
+		 * Besides, we need to provide extra information about error_log_persisitent here.
 		 */
-		nulls[5] = true;
+		if IS_LOG_ERRORS_PERSISTENTLY(extentry->logerrors)
+			values[5] = strListToArray(list_make1(makeString("error_log_persistent=true")));
+		else
+			nulls[5] = true;
 
 		/* command */
 		if (extentry->command)

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3670,9 +3670,9 @@ CREATE EXTERNAL TABLE ext_persistently (c INT)
 location ('file://@hostname@@abs_srcdir@/data/ext_persistently.tbl' )
 FORMAT 'text' (delimiter '|') LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 100;
 
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
 
 -- drop tables
 DROP EXTERNAL TABLE ext_false;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -4999,22 +4999,22 @@ FORMAT 'text' (delimiter '|') LOG ERRORS SEGMENT REJECT LIMIT 100;
 CREATE EXTERNAL TABLE ext_persistently (c INT) 
 location ('file://@hostname@@abs_srcdir@/data/ext_persistently.tbl' )
 FORMAT 'text' (delimiter '|') LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 100;
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
- logerrors 
------------
- f
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
+ logerrors | options 
+-----------+---------
+ f         | 
 (1 row)
 
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
- logerrors 
------------
- t
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
+ logerrors | options 
+-----------+---------
+ t         | 
 (1 row)
 
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
- logerrors 
------------
- t
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
+ logerrors |           options           
+-----------+-----------------------------
+ t         | {error_log_persistent=true}
 (1 row)
 
 -- drop tables

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -5001,22 +5001,22 @@ FORMAT 'text' (delimiter '|') LOG ERRORS SEGMENT REJECT LIMIT 100;
 CREATE EXTERNAL TABLE ext_persistently (c INT) 
 location ('file://@hostname@@abs_srcdir@/data/ext_persistently.tbl' )
 FORMAT 'text' (delimiter '|') LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 100;
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
- logerrors 
------------
- f
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_false';
+ logerrors | options 
+-----------+---------
+ f         | 
 (1 row)
 
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
- logerrors 
------------
- t
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_true';
+ logerrors | options 
+-----------+---------
+ t         | 
 (1 row)
 
-SELECT logerrors from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
- logerrors 
------------
- t
+SELECT logerrors, options from pg_exttable a, pg_class b where a.reloid = b.oid and b.relname = 'ext_persistently';
+ logerrors |           options           
+-----------+-----------------------------
+ t         | {error_log_persistent=true}
 (1 row)
 
 -- drop tables


### PR DESCRIPTION
This PR is to fix issue https://github.com/greenplum-db/gpdb/issues/17180.

We provide more detailed information about logerrors in pg_exttable view in GP7. This is to keep consistent with older GP version.

**DDL**
```
DROP EXTERNAL TABLE if exists public.test_ext;

CREATE READABLE EXTERNAL TABLE public.test_ext
(
  id int
)
LOCATION(
  'file://gp6/test.txt'
)
FORMAT 'TEXT' ( delimiter 'off')
LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 10 PERCENT;
```

**Before this PR:**
```
SELECT logerrors, options FROM pg_exttable WHERE reloid = 'public.test_ext'::regclass;
 logerrors | options
-----------+---------
 t         |
(1 row)
```

**After this PR:**
```
testdb=# SELECT logerrors, options FROM pg_exttable WHERE reloid = 'public.test_ext'::regclass;
 logerrors |           options
-----------+-----------------------------
 t         | {error_log_persistent=true}
(1 row)
```

Pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/gpdb-dev-yjw

