### PR TITLE
[6X] CO: Support RLE with Zstandard

### DIFF
--- a/src/backend/access/common/reloptions_gp.c
+++ b/src/backend/access/common/reloptions_gp.c
@@ -31,6 +31,7 @@
 #include "utils/memutils.h"
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
+#include "storage/gp_compress.h"
 
 /*
  * Confusingly, RELOPT_KIND_HEAP is also used for AO/CO tables. To reduce
@@ -1024,12 +1025,12 @@ validate_and_adjust_options(StdRdOptions *result,
 
 		if (result->compresstype[0] &&
 			(pg_strcasecmp(result->compresstype, "rle_type") == 0) &&
-			(result->compresslevel > 4))
+			(result->compresslevel > RLE_MAX_LEVEL))
 		{
 			if (validate)
 				ereport(ERROR,
 						(errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-						 errmsg("compresslevel=%d is out of range for rle_type (should be in the range 1 to 4)",
+						 errmsg("compresslevel=%d is out of range for rle_type (should be in the range 1 to 6)",
 								result->compresslevel)));
 
 			result->compresslevel = setDefaultCompressionLevel(result->compresstype);

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -434,7 +434,19 @@ init_datumstream_info(
 				ao_attr->compressType = "zlib";
 				ao_attr->compressLevel = 9;
 				break;
+#ifdef HAVE_LIBZSTD
+			case 5:
+				ao_attr->compress = true;
+				ao_attr->compressType = "zstd";
+				ao_attr->compressLevel = 1;
+				break;
 
+			case 6:
+				ao_attr->compress = true;
+				ao_attr->compressType = "zstd";
+				ao_attr->compressLevel = 3; /* zstd recommended default */
+				break;
+#endif
 			default:
 				ereport(ERROR,
 						(errmsg("Unexpected compresslevel %d",

--- a/src/include/storage/gp_compress.h
+++ b/src/include/storage/gp_compress.h
@@ -80,6 +80,12 @@ typedef struct
 extern void zstd_free_context(zstd_context *context);
 extern zstd_context *zstd_alloc_context(void);
 
+#define RLE_MAX_LEVEL	(6)
+
+#else
+
+#define RLE_MAX_LEVEL	(4)
+
 #endif	/* HAVE_LIBZSTD */
 
 

--- a/src/test/binary_swap/test_binary_swap_pre.sql
+++ b/src/test/binary_swap/test_binary_swap_pre.sql
@@ -51,6 +51,12 @@ DROP TABLE IF EXISTS public.mergeappend_test;
 DROP TABLE IF EXISTS public.multivarblock_parttab;
 DROP TABLE IF EXISTS public.aopart_lineitem CASCADE;
 
+-- Drop tables carrying rle with zstd compression. That is not available in
+-- earlier minor versions.
+DROP TABLE co_rle_zstd1;
+DROP TABLE co_rle_zstd3;
+DROP TABLE co6;
+
 \c isolation2test;
 DROP VIEW IF EXISTS locktest_segments;
 DROP VIEW IF EXISTS locktest_master;

--- a/src/test/regress/expected/dsp.out
+++ b/src/test/regress/expected/dsp.out
@@ -510,16 +510,15 @@ create table co6(
 	a int encoding (compresstype=rle_type),
 	b float encoding (blocksize=8192))
 	distributed by (a);
-ERROR:  compresslevel=5 is out of range for rle_type (should be in the range 1 to 4)
 create table co7(a int, b float,
 	default column encoding (compresstype=RLE_TYPE, compresslevel=7))
 	distributed by (a);
-ERROR:  compresslevel=7 is out of range for rle_type (should be in the range 1 to 4)
+ERROR:  compresslevel=7 is out of range for rle_type (should be in the range 1 to 6)
 -- negative tests - session level set
 set gp_default_storage_options="compresstype=zlib,compresslevel=11";
 ERROR:  compresslevel=11 is out of range for zlib (should be in the range 1 to 9)
 set gp_default_storage_options="compresslevel=5,compresstype=RLE_TYPE";
-ERROR:  compresslevel=5 is out of range for rle_type (should be in the range 1 to 4)
+ERROR:  rle_type cannot be used with Append Only relations row orientation
 set gp_default_storage_options="compresslevel=1,compresstype=rle";
 ERROR:  unknown compresstype "rle"
 set gp_default_storage_options="checksum=1234";

--- a/src/test/regress/expected/rle.out
+++ b/src/test/regress/expected/rle.out
@@ -11286,3 +11286,38 @@ insert into sml_rle_hdr values (-1,-1.1);
 set client_min_messages=warning;
 update sml_rle_hdr set b = b + 10 where a = -1;
 commit;
+-- Some smoke tests against rle's levels using zstd
+create table co_rle_zstd1(i int encoding(compresstype=rle_type, compresslevel=5)) with (appendonly=true, orientation=column);
+create table co_rle_zstd3(i int encoding(compresstype=rle_type, compresslevel=6)) with (appendonly=true, orientation=column);
+\d+ co_rle_zstd1
+                                    Append-Only Columnar Table "public.co_rle_zstd1"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ i      | integer |           | plain   |              | rle_type         | 5                 | 32768      | 
+Checksum: t
+Distributed by: (i)
+Options: appendonly=true, orientation=column
+
+\d+ co_rle_zstd3
+                                    Append-Only Columnar Table "public.co_rle_zstd3"
+ Column |  Type   | Modifiers | Storage | Stats target | Compression Type | Compression Level | Block Size | Description 
+--------+---------+-----------+---------+--------------+------------------+-------------------+------------+-------------
+ i      | integer |           | plain   |              | rle_type         | 6                 | 32768      | 
+Checksum: t
+Distributed by: (i)
+Options: appendonly=true, orientation=column
+
+insert into co_rle_zstd1 select generate_series(1, 100000);
+insert into co_rle_zstd3 select generate_series(1, 100000);
+select count(distinct i) from co_rle_zstd1;
+ count  
+--------
+ 100000
+(1 row)
+
+select count(distinct i) from co_rle_zstd3;
+ count  
+--------
+ 100000
+(1 row)
+

--- a/src/test/regress/sql/rle.sql
+++ b/src/test/regress/sql/rle.sql
@@ -4808,3 +4808,13 @@ insert into sml_rle_hdr values (-1,-1.1);
 set client_min_messages=warning;
 update sml_rle_hdr set b = b + 10 where a = -1;
 commit;
+
+-- Some smoke tests against rle's levels using zstd
+create table co_rle_zstd1(i int encoding(compresstype=rle_type, compresslevel=5)) with (appendonly=true, orientation=column);
+create table co_rle_zstd3(i int encoding(compresstype=rle_type, compresslevel=6)) with (appendonly=true, orientation=column);
+\d+ co_rle_zstd1
+\d+ co_rle_zstd3
+insert into co_rle_zstd1 select generate_series(1, 100000);
+insert into co_rle_zstd3 select generate_series(1, 100000);
+select count(distinct i) from co_rle_zstd1;
+select count(distinct i) from co_rle_zstd3;


### PR DESCRIPTION
This is a backport of 7X PR: #17147, with conflicts resolved:
(1) USE_ZSTD is replaced with HAVE_ZSTD
(2) Test changes:
    using ao_column -> with (appendonly=true, orientation=column)
    ALTER TABLE ALTER COLUMN ENCODING is not supported on 6X, so the
    test is taken out.

Original commit message follows:

This addresses #12721.

Zstandard is superior to Zlib in terms of both compression speed and
disk footprint. So offer users the ability to rely on it. To enjoy the
benefits of Zstandard compression in column-oriented tables users can
create tables with compresslevel=5|6.

Example:
create table co_rle_zstd(i int encoding(compresstype=rle_type,
compresslevel=5)) using ao_column;
convert existing tables to the new compress levels as well.

Compresslevels 5 and 6 invoke zstd compression with zstd levels 1 and 3
respectively. Since zstd level 3 is the default and the recommended
level, compresslevel = 6 should cover most cases and is highly
encouraged.

Notes:

(1) Since zstd level = 1 can readily beat zlib level = 9 in terms of
speed (and disk footprint), it can easily fit into our scheme for
compresslevels (lower implies higher speed)

(2) More levels can be provided in the future for zstd, as per demand.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/6X_rle_zstd