### PR TITLE
Fix pg_basebackup verbose message

### DIFF
--- a/.abi-check/6.26.4/postgres.symbols.ignore
+++ b/.abi-check/6.26.4/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesBool_gp

--- a/src/bin/pg_basebackup/pg_basebackup.c
+++ b/src/bin/pg_basebackup/pg_basebackup.c
@@ -2200,7 +2200,7 @@ BaseBackup(const char *argv0)
 	PQfinish(conn);
 
 	if (verbose)
-		fprintf(stderr, "%s: sync the target data direcotory\n", progname);
+		fprintf(stderr, "%s: sync the target data directory\n", progname);
 	syncTargetDirectory(argv0);
 
 	if (verbose)


### PR DESCRIPTION
This was found while running gpaddmirrors. The word "direcotory" should obviously have been "directory". Fix it accordingly.

