### PR TITLE
Use macors for accessing relation name.

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1922,7 +1922,7 @@ aocs_fetch_init(Relation relation,
 									   checksum,
 									   blksz,
 									   TupleDescAttr(tupleDesc, colno),
-									   relation->rd_rel->relname.data,
+									   NameStr(RelationGetRelationName(relation)),
 									    /* title */ titleBuf.data);
 
 		}

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -326,7 +326,7 @@ SetSegFileForRead(AppendOnlyScanDesc aoscan, int fsInfoIdx)
 static int
 errcontext_appendonly_insert_block_user_limit(AppendOnlyInsertDesc aoInsertDesc)
 {
-	char	   *relationName = NameStr(aoInsertDesc->aoi_rel->rd_rel->relname);
+	char	   *relationName = NameStr(RelationGetRelationName(aoInsertDesc->aoi_rel));
 
 	errcontext("Append-Only table '%s'", relationName);
 
@@ -2514,7 +2514,7 @@ appendonly_fetch_init(Relation relation,
 							   &aoFetchDesc->storageRead,
 							   aoFetchDesc->initContext,
 							   aoFetchDesc->usableBlockSize,
-							   NameStr(aoFetchDesc->relation->rd_rel->relname),
+							   NameStr(RelationGetRelationName(aoFetchDesc->relation)),
 							   aoFetchDesc->title,
 							   &aoFetchDesc->storageAttributes);
 


### PR DESCRIPTION
Hi gpdb hackers!

While inspecting gpdb AO/AOCS code i have noticed some places to enhance. 
I want to propose my little improvement. 
The change is to use macros for getting relation name, not direct struct access. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
