### PR TITLE
Fix issue: handle location uri including '|' for external table in GP7.

### DIFF
--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -77,12 +77,24 @@ TokenizeLocationUris(char *uris)
 {
 	char *uri = NULL;
 	List *result = NIL;
+	StringInfoData uri_buf;
+	initStringInfo(&uri_buf);
 
 	Assert(uris != NULL);
 
 	while ((uri = strsep(&uris, "|")) != NULL)
 	{
-		result = lappend(result, makeString(uri));
+		appendStringInfo(&uri_buf, "%s", uri);
+		if (!uris || *uris != '|')
+		{
+			result = lappend(result, makeString(pstrdup(uri_buf.data)));
+			resetStringInfo(&uri_buf);
+		}
+		else
+		{
+			appendStringInfo(&uri_buf, "|");
+			++uris;
+		}
 	}
 
 	return result;

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -3758,3 +3758,14 @@ select name::json from ext_fixed_width_table;
 SELECT errmsg, rawdata, rawbytes FROM gp_read_error_log('ext_fixed_width_table') order by cmdtime;
 
 DROP EXTERNAL TABLE ext_fixed_width_table;
+
+-- check uri with special character '|'
+CREATE EXTERNAL TABLE ext_special_uri (
+    c1 int,
+    c2 int) 
+location ('file://@hostname@@abs_srcdir@/data/special|1.tbl', 'file://@hostname@@abs_srcdir@/data/special||2.tbl')
+FORMAT 'text' (delimiter '|');
+SELECT urilocation FROM pg_exttable WHERE reloid = 'ext_special_uri'::regclass::oid;
+SELECT ftoptions FROM pg_foreign_table WHERE ftrelid = 'ext_special_uri'::regclass::oid;
+SELECT * FROM ext_special_uri ORDER BY c1;
+DROP EXTERNAL TABLE ext_special_uri;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -5185,3 +5185,32 @@ SELECT errmsg, rawdata, rawbytes FROM gp_read_error_log('ext_fixed_width_table')
 (6 rows)
 
 DROP EXTERNAL TABLE ext_fixed_width_table;
+-- check uri with special character '|'
+CREATE EXTERNAL TABLE ext_special_uri (
+    c1 int,
+    c2 int) 
+location ('file://@hostname@@abs_srcdir@/data/special|1.tbl', 'file://@hostname@@abs_srcdir@/data/special||2.tbl')
+FORMAT 'text' (delimiter '|');
+SELECT urilocation FROM pg_exttable WHERE reloid = 'ext_special_uri'::regclass::oid;
+                                                                                 urilocation                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {file://@hostname@@abs_srcdir@/data/special|1.tbl,file://@hostname@@abs_srcdir@/data/special||2.tbl}
+(1 row)
+
+SELECT ftoptions FROM pg_foreign_table WHERE ftrelid = 'ext_special_uri'::regclass::oid;
+                                                                                                                                                        ftoptions                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {format=text,delimiter=|,"null=\\N","escape=\\",location_uris=file://@hostname@@abs_srcdir@/data/special||1.tbl|file://@hostname@@abs_srcdir@/data/special||||2.tbl,execute_on=ALL_SEGMENTS,log_errors=disable,encoding=UTF8,is_writable=false}
+(1 row)
+
+SELECT * FROM ext_special_uri ORDER BY c1;
+ c1 | c2 
+----+----
+  1 | 11
+  2 | 22
+  3 | 33
+  4 | 44
+  5 | 55
+(5 rows)
+
+DROP EXTERNAL TABLE ext_special_uri;

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -5187,3 +5187,32 @@ SELECT errmsg, rawdata, rawbytes FROM gp_read_error_log('ext_fixed_width_table')
 (6 rows)
 
 DROP EXTERNAL TABLE ext_fixed_width_table;
+-- check uri with special character '|'
+CREATE EXTERNAL TABLE ext_special_uri (
+    c1 int,
+    c2 int) 
+location ('file://@hostname@@abs_srcdir@/data/special|1.tbl', 'file://@hostname@@abs_srcdir@/data/special||2.tbl')
+FORMAT 'text' (delimiter '|');
+SELECT urilocation FROM pg_exttable WHERE reloid = 'ext_special_uri'::regclass::oid;
+                                                                                 urilocation                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {file://@hostname@@abs_srcdir@/data/special|1.tbl,file://@hostname@@abs_srcdir@/data/special||2.tbl}
+(1 row)
+
+SELECT ftoptions FROM pg_foreign_table WHERE ftrelid = 'ext_special_uri'::regclass::oid;
+                                                                                                                                                        ftoptions                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {format=text,delimiter=|,"null=\\N","escape=\\",location_uris=file://@hostname@@abs_srcdir@/data/special||1.tbl|file://@hostname@@abs_srcdir@/data/special||||2.tbl,execute_on=ALL_SEGMENTS,log_errors=disable,encoding=UTF8,is_writable=false}
+(1 row)
+
+SELECT * FROM ext_special_uri ORDER BY c1;
+ c1 | c2 
+----+----
+  1 | 11
+  2 | 22
+  3 | 33
+  4 | 44
+  5 | 55
+(5 rows)
+
+DROP EXTERNAL TABLE ext_special_uri;


### PR DESCRIPTION
This PR is to fix issue https://github.com/greenplum-db/gpdb/issues/17179.
Refer to an closed PR: https://github.com/greenplum-db/gpdb/pull/15088.

To fix  issue https://github.com/greenplum-db/gpdb/issues/17179, we replace `"|"` with `"||"` in location uri. This can avoid mistaking `"|" in uri` for `separator "|"` In the function `transformLocationUris()`.

DDL:
```
bash-4.2$ echo "1" > /tmp/\|.txt
bash-4.2$ psql testdb
psql (12.12)
Type "help" for help.

testdb=# CREATE READABLE EXTERNAL TABLE public.test_ext
(
  id int
)
LOCATION(
  'file://localhost.localdomain/tmp/|.txt'
)
FORMAT 'TEXT' ( delimiter 'off')
ENCODING 'UTF8';
CREATE EXTERNAL TABLE
```

Before this PR:
```
SELECT * FROM public.test_ext;
ERROR:  invalid URI '.txt' : undefined structure

SELECT urilocation from pg_exttable WHERE reloid = 'public.test_ext'::regclass;
      urilocation
------------------------
 {file://localhost.localdomain/tmp/,.txt}
(1 row)
```

With this PR:
```
bash-4.2$ psql testdb
testdb=# SELECT * FROM public.test_ext;
 id
----
  1
(1 row)

testdb=# SELECT urilocation FROM pg_exttable WHERE  reloid = 'public.test_ext'::regclass;
               urilocation
------------------------------------------
 {file://localhost.localdomain/tmp/|.txt}
(1 row)

testdb=# SELECT ftoptions FROM pg_foreign_table WHERE ftrelid = 'public.test_ext'::regclass;
                                                                                      ftoptions

-----------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------
 {format=text,delimiter=off,"null=\\N","escape=\\",location_uris=file://localhost.localdomain/tmp/||.txt,execute_on=ALL_SEGMENTS,log_errors=dis
able,encoding=UTF8,is_writable=false}
(1 row)
```

Co-authored-by: Yongtao Huang <yongtaoh@vmware.com>