### PR TITLE
[6X_STABLE] gpcheckcat enhancement to report if there are tables created using mix distribution policy 

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2932,6 +2932,204 @@ def checkOrphanedToastTables():
                                issue_type="orphaned_toast_tables",
                                description='Repairing orphaned TOAST tables')
 
+def fetch_guc_value(guc):
+    qry = '''
+    show {}
+     '''.format(guc)
+    try:
+        conn = connect2(GV.cfg[GV.master_dbid])
+        curs = conn.query(qry)
+        rowcount = curs.ntuples()
+        if rowcount:
+            for row in curs.dictresult():
+                guc_value = row['gp_use_legacy_hashops']
+
+        return guc_value
+
+    except Exception as e:
+        setError(ERROR_NOREPAIR)
+        GV.checkStatus = False
+        myprint('[ERROR] executing test: mix_distribution_policy')
+        myprint('  Execution error: ' + str(e))
+
+def generateDistPolicyQueryFile():
+
+    query_sql = '''
+     -- all tables that use legacy policy:
+     with legacy_opclass_oids(oid_array) as (
+       select
+         array_agg(oid)
+       from
+         pg_opclass
+       where
+         opcfamily in (
+           select
+             amprocfamily
+           from
+             pg_amproc
+           where
+             amproc :: oid in (
+               6140, 6141, 6142, 6143, 6144, 6145, 6146,
+               6147, 6148, 6149, 6150, 6151, 6152,
+               6153, 6154, 6155, 6156, 6157, 6158,
+               6159, 6160, 6161, 6162, 6163, 6164,
+               6165, 6166, 6167, 6168, 6170, 6169,
+               6171
+             )
+         )
+     )
+    select
+         localoid :: regclass :: text as "Legacy Policy"
+    from
+         gp_distribution_policy,
+         legacy_opclass_oids
+     where
+         policytype = 'p'
+         and distclass :: oid[] && oid_array;
+ -- all tables that don't use any legacy policy:
+ with legacy_opclass_oids(oid_array) as (
+   select
+     array_agg(oid)
+   from
+     pg_opclass
+   where
+     opcfamily in (
+       select
+         amprocfamily
+       from
+         pg_amproc
+       where
+         amproc :: oid in (
+           6140, 6141, 6142, 6143, 6144, 6145, 6146,
+           6147, 6148, 6149, 6150, 6151, 6152,
+           6153, 6154, 6155, 6156, 6157, 6158,
+           6159, 6160, 6161, 6162, 6163, 6164,
+           6165, 6166, 6167, 6168, 6170, 6169,
+           6171
+         )
+     )
+ )
+select
+   localoid :: regclass :: text as "Non Legacy Policy"
+from
+   gp_distribution_policy,
+   legacy_opclass_oids
+where
+   policytype = 'p'
+   and not (distclass :: oid[] && oid_array);
+           '''
+    filename = 'gpcheckcat.distpolicy.sql'
+
+    if not os.path.exists(filename) :
+        try:
+            with open(filename, 'w') as fp:
+                fp.write(query_sql + "\n")
+        except Exception as e:
+            logger.warning('Unable to generate verify file for {}'.format(filename))
+
+# Test to check if there are tables that use both legacy opclass/non legacy opclass
+# in distribution policy
+def checkMixDistPolicy():
+
+    qry = '''
+        with legacy_opclass_oids(oid_array) as (
+        select
+          array_agg(oid)
+        from
+          pg_opclass
+        where
+          opcfamily in (
+            select
+              amprocfamily
+            from
+              pg_amproc
+            where
+              amproc :: oid in (
+                6140, 6141, 6142, 6143, 6144, 6145, 6146,
+                6147, 6148, 6149, 6150, 6151, 6152,
+                6153, 6154, 6155, 6156, 6157, 6158,
+                6159, 6160, 6161, 6162, 6163, 6164,
+                6165, 6166, 6167, 6168, 6170, 6169,
+                6171
+            )
+        )
+       ),
+       all_hash_ops(dc) as (
+        select
+          distinct unnest(distclass :: oid[])
+        from
+          gp_distribution_policy
+        )
+        select
+            count(1) filter(
+        where
+            array[x.dc] && oid_array
+            ) as n_legacy_dist_class,
+            count(1) as n_total_dist_class
+        from
+        all_hash_ops x,
+        legacy_opclass_oids y;
+    '''
+
+    try:
+        conn = connect2(GV.cfg[GV.master_dbid])
+        curs = conn.query(qry)
+
+        rowcount = curs.ntuples()
+
+        if rowcount:
+            for row in curs.dictresult():
+                n_legacy_dist_class = row['n_legacy_dist_class']
+                n_total_dist_class = row['n_total_dist_class']
+            GV.checkStatus = False
+
+            if n_legacy_dist_class > 0 and n_total_dist_class > n_legacy_dist_class :
+                generateDistPolicyQueryFile()
+                #if this condition is true then we have mix distribution Policy
+                myprint(
+                    '[ERROR]: Found tables created using both legacy and non legacy hashops'
+                    ' in distribution policy.'
+                    'Please run the gpcheckcat.distpolicy.sql file to list the tables.'
+                )
+            else:
+                if (n_legacy_dist_class == 0 or n_legacy_dist_class == n_total_dist_class):
+                #if this condition is true then we dont have mix distribution policy
+                    gp_use_legacy_hashops = fetch_guc_value("gp_use_legacy_hashops")
+                    printDistPolicyMsg(gp_use_legacy_hashops,
+                                         n_legacy_dist_class,
+                                         n_total_dist_class
+                                         )
+
+    except Exception as e:
+        setError(ERROR_NOREPAIR)
+        GV.checkStatus = False
+        myprint('[ERROR] executing test: mix_distribution_policy')
+        myprint('  Execution error: ' + str(e))
+
+def printDistPolicyMsg(gp_use_legacy_hashops,n_legacy_dist_class, n_total_dist_class):
+
+    GV.checkStatus = True
+
+    if n_total_dist_class - n_legacy_dist_class > 0  and gp_use_legacy_hashops == "on":
+        myprint(
+            '[ERROR]: GUC gp_use_legacy_hashops is on.'
+            ' all newly created tables will use legacy hash ops by default for hash distributed table, '
+            'but there are tables using non-legacy hash ops in the cluster. '
+            'Please run the gpcheckcat.distpolicy.sql file to list the tables.'
+            )
+        GV.checkStatus = False
+
+    elif n_legacy_dist_class == 0 and gp_use_legacy_hashops == "off":
+        GV.checkStatus = True
+
+    elif n_legacy_dist_class > 0 and gp_use_legacy_hashops == "off" :
+        myprint(
+            '[ERROR]: GUC gp_use_legacy_hashops is off.'
+            ' all newly created tables will use non legacy hash ops by default for hash distributed table, '
+            'but there are tables using legacy hash ops in the cluster. '
+            'Please run the gpcheckcat.distpolicy.sql file to list the tables.'
+            )
+        GV.checkStatus = False
 
 ############################################################################
 # Help populating repair part for all checked types
@@ -3074,7 +3272,17 @@ all_checks = {
             "version": 'main',
             "order": 15,
             "online": False 
+        },
+    "mix_distribution_policy":
+        {
+            "description": "Check for tables that use legacy opclass in distribution policy",
+            "fn": lambda: checkMixDistPolicy(),
+            "version": 'main',
+            "order": 17,
+            "online": True,
+            "defaultSkip": True
         }
+
 }
 
 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -654,4 +654,96 @@ Feature: gpcheckcat tests
           And "gpstop -m" should return a return code of 0
           And the user runs "gpstart -a"
 
+    Scenario: Validate if gpecheckcat throws error when there are tables created using mix distribution policy
+        Given database "hashops_db" is dropped and recreated
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql"
+        Then psql should return a return code of 0
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -R mix_distribution_policy hashops_db "
+        And gpcheckcat should print "Found tables created using both legacy and non legacy hashops in distribution policy." to stdout
+        And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And the user runs "dropdb hashops_db"
 
+    Scenario: Validate if gpcheckcat succeeds and there are no tables
+        Given database "hashops_db" is dropped and recreated
+        When the user runs "gpcheckcat -R mix_distribution_policy hashops_db"
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb hashops_db"
+
+    Scenario: Validate if gpcheckcat throws error when GUC gp_use_legacy_hashops is on and there are non legacy tables
+        Given database "hashops_db" is dropped and recreated
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
+        Then psql should return a return code of 0
+        And the user runs "gpconfig -c gp_use_legacy_hashops -v on --skipvalidation"
+        Then gpconfig should return a return code of 0
+        And the user runs "gpstop -a"
+        Then gpstop should return a return code of 0
+        And the user runs "gpstart -a"
+        When the user runs "gpcheckcat -R mix_distribution_policy hashops_db"
+        And gpcheckcat should print "GUC gp_use_legacy_hashops is on." to stdout
+        And gpcheckcat should print "all newly created tables will use legacy hash ops by default for hash distributed table," to stdout
+        And gpcheckcat should print "but there are tables using non-legacy hash ops in the cluster." to stdout
+        And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And the user runs "dropdb hashops_db"
+
+      Scenario: Validate if gpcheckcat succeeds when GUC gp_use_legacy_hashops is on and there are legacy tables
+        Given database "hashops_db" is dropped and recreated
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql"
+        Then psql should return a return code of 0
+        And the user runs "gpconfig -c gp_use_legacy_hashops -v on --skipvalidation"
+        Then gpconfig should return a return code of 0
+        And the user runs "gpstop -a"
+        Then gpstop should return a return code of 0
+        And the user runs "gpstart -a"
+        When the user runs "gpcheckcat -R mix_distribution_policy hashops_db"
+         And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb hashops_db"
+
+    Scenario: Validate if gpcheckcat throws error when GUC gp_use_legacy_hashops is off and there are legacy tables
+        Given database "hashops_db" is dropped and recreated
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql"
+        And the user runs "gpconfig -c gp_use_legacy_hashops -v off --skipvalidation"
+        Then gpconfig should return a return code of 0
+        And the user runs "gpstop -a"
+        Then gpstop should return a return code of 0
+        And the user runs "gpstart -a"
+        When the user runs "gpcheckcat -R mix_distribution_policy hashops_db"
+        And gpcheckcat should print "GUC gp_use_legacy_hashops is off." to stdout
+        And gpcheckcat should print "all newly created tables will use non legacy hash ops by default for hash distributed table," to stdout
+        And gpcheckcat should print "but there are tables using legacy hash ops in the cluster." to stdout
+        And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        And the user runs "dropdb hashops_db"
+
+    Scenario: Validate if gpcheckcat succeeds when GUC gp_use_legacy_hashops is off and there are non legacy tables
+        Given database "hashops_db" is dropped and recreated
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
+        And the user runs "gpconfig -c gp_use_legacy_hashops -v off --skipvalidation"
+        Then gpconfig should return a return code of 0
+        And the user runs "gpstop -a"
+        Then gpstop should return a return code of 0
+        And the user runs "gpstart -a"
+        When the user runs "gpcheckcat -R mix_distribution_policy hashops_db"
+        And gpcheckcat should print "Found no catalog issue" to stdout
+        And the user runs "dropdb hashops_db"
+
+    Scenario: gpcheckcat -l should report mix_distribution_policy to stdout
+        When the user runs "gpcheckcat -l "
+        And gpcheckcat should print "mix_distribution_policy" to stdout
+
+    Scenario: gpcheckcat report all tables created using legacy opclass on multiple database
+        Given database "hashops_db" is dropped and recreated
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql"
+        And the user runs "psql hashops_db -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
+        Then psql should return a return code of 0
+        Given database "hashops_db2" is dropped and recreated
+        And the user runs "psql hashops_db2 -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql"
+        And the user runs "psql hashops_db2 -f test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql"
+        Then psql should return a return code of 0
+        When the user runs "gpcheckcat -A -R mix_distribution_policy"
+        And gpcheckcat should print "Found tables created using both legacy and non legacy hashops in distribution policy." to stdout
+        And gpcheckcat should print "Please run the gpcheckcat.distpolicy.sql file to list the tables." to stdout
+        Then gpcheckcat should print "Completed 1 test(s) on database 'hashops_db'" to logfile with latest timestamp
+        Then gpcheckcat should print "Completed 1 test(s) on database 'hashops_db2'" to logfile with latest timestamp
+        And the user runs "dropdb hashops_db"
+        And the user runs "dropdb hashops_db2"

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_legacy_hash_ops_tables.sql
@@ -1,0 +1,32 @@
+set gp_use_legacy_hashops = 1;
+
+create table t_old(a int, b int, c int) distributed by (a, b);
+create table t1_old(a int, b int, c int) distributed by (a, b);
+create table t_replicate_old(a int , b int) distributed replicated;
+create table t_random_old(a int , b int) distributed randomly;
+
+CREATE TABLE rank_old (id int, rank int, year int, gender
+        char(1), count int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( START (2006) END (2016) EVERY (1),
+          DEFAULT PARTITION extra );
+
+
+CREATE OR REPLACE FUNCTION random_between(low INT ,high INT)
+   RETURNS INT AS
+$$
+BEGIN
+           RETURN floor(random()* (high-low + 1) + low);
+END;
+$$ language 'plpgsql' STRICT;
+
+insert into rank_old
+select i, i, random_between(2005, 2017), 'g', i
+from generate_series(1, 100000)i;
+
+-- some special characters in column names
+create table t_space("a col" int);
+create table t_dot("a.col" int);
+create table t_dash("a-col" int);
+create table t_multispecial("a col" int, "b.col" int, "c-col" int) distributed by ("a col", "b.col", "c-col");

--- a/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql
+++ b/gpMgmt/test/behave/mgmt_utils/steps/data/gpcheckcat/create_non_legacy_hashops_tables.sql
@@ -1,0 +1,26 @@
+set gp_use_legacy_hashops = 0;
+
+create table t_new(a int, b int, c int) distributed by (a, b);
+create table t1_new(a int, b int, c int) distributed by (a, b);
+create table t_replicate_new(a int , b int) distributed replicated;
+create table t_random_new(a int , b int) distributed randomly;
+
+CREATE TABLE rank_new (id int, rank int, year int, gender
+        char(1), count int)
+DISTRIBUTED BY (id)
+PARTITION BY RANGE (year)
+( START (2006) END (2016) EVERY (1),
+          DEFAULT PARTITION extra );
+
+
+CREATE OR REPLACE FUNCTION random_between(low INT ,high INT)
+   RETURNS INT AS
+$$
+BEGIN
+           RETURN floor(random()* (high-low + 1) + low);
+END;
+$$ language 'plpgsql' STRICT;
+
+insert into rank_new
+select i, i, random_between(2005, 2017), 'g', i
+from generate_series(1, 100000)i;

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -2899,6 +2899,18 @@ def impl(context, command, target):
     if not pat.search(contents):
         raise Exception("cannot find %s in %s" % (target, filename))
 
+@then('{command} should print "{target}" to logfile with latest timestamp')
+def impl(context, command, target):
+    log_dir = _get_gpAdminLogs_directory()
+    filenames = glob.glob('%s/%s_*.log' % (log_dir, command))
+    filename = max(filenames, key=os.path.getctime)
+    contents = ''
+    with open(filename) as fr:
+        for line in fr:
+            contents += line
+    if target not in contents:
+        raise Exception("cannot find %s in %s" % (target, filename))
+
 @given('verify that a role "{role_name}" exists in database "{dbname}"')
 @then('verify that a role "{role_name}" exists in database "{dbname}"')
 def impl(context, role_name, dbname):


### PR DESCRIPTION
Gpcheckcat is enhanced to report if there are tables created using legacy and non legacy hashops in distribution policy. This check is essential as ORCA fails back to planner if there is mix distribution policy found.

Option Added 
`gpcheckcat -R mix_distribution_policy
`

High level design of "gpcheckcat -R mix_distribution_policy" Check if there are tables created with both legacy and non legacy hashops in distribution policy.

1.      If there is Mix Distribution Policy
-       Report error that there is mix distribution policy.
-       Create an sql file containing the sql query using which the user can
            obtain the table names created with legacy and non legacy hashops

2.     In case there is no Mixed Policy
-      Check if gp_use_legacy_hashops is on and there are no tables created with legacy hashops
 		Report Error
-      Check if gp_use_legacy_hashops is off and there are no tables created with non legacy hashops
 		Report Error

Example run
 ```
gpcheckcat -R mix_distribution_policy ravoorsh
    Truncated batch size to number of primaries: 4

    Connected as user 'ravoorsh' to database 'ravoorsh', port '6000', gpdb version '6.26'
    -------------------------------------------------------------------
    Batch size: 4
    Performing test 'mix_distribution_policy'
    [ERROR]: GUC gp_use_legacy_hashops is off. all newly created tables will use non legacy hash ops by default for hash distributed table, but there are tables using legacy hash ops in the cluster. Please run the gpcheckcat.distpolicy.sql file to list the tables.
    Total runtime for test 'mix_distribution_policy': 0:00:00.04

    SUMMARY REPORT
    ===================================================================
    Completed 1 test(s) on database 'ravoorsh' at 2024-03-13 12:19:50 with elapsed time 0:00:00
    Failed test(s) that are not reported here: mix_distribution_policy
    See /Users/ravoorsh/gpAdminLogs/gpcheckcat_20240313.log for detail`
```

Test Cases Added:
Both Behave and unit test cases added covering the various scenarios with Mix distribution policy and with no mix distribution policy.

This is a cherry pick of https://github.com/greenplum-db/gpdb/pull/17158