### PR TITLE
Docs: document RLE with Zstd

### DIFF
--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-storage.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-storage.html.md
@@ -248,10 +248,10 @@ The following table details the types of storage directives and possible values 
             </tr>
             <tr class="row">
               <td class="entry" headers="topic43__im198636__entry__3"><code class="ph codeph">RLE_TYPE</code> compression: <code class="ph codeph">1</code> –
-                  <code class="ph codeph">4</code><p class="p"><code class="ph codeph">1</code> - apply RLE only</p><p class="p"><code class="ph codeph">2</code>
+                  <code class="ph codeph">6</code><p class="p"><code class="ph codeph">1</code> - apply RLE only</p><p class="p"><code class="ph codeph">2</code>
                   - apply RLE then apply zlib compression level 1</p><p class="p"><code class="ph codeph">3</code> - apply
                   RLE then apply zlib compression level 5</p><p class="p"><code class="ph codeph">4</code> - apply RLE then
-                  apply zlib compression level 9</p><p class="p"><code class="ph codeph">4</code> - apply RLE then apply zstd compression level 1</p><p class="p"><code class="ph codeph">4</code> - apply RLE then apply zstd compression level 3</p></td>
+                  apply zlib compression level 9</p><p class="p"><code class="ph codeph">5</code> - apply RLE then apply zstd compression level 1</p><p class="p"><code class="ph codeph">6</code> - apply RLE then apply zstd compression level 3</p></td>
               <td class="entry" headers="topic43__im198636__entry__4"><code class="ph codeph">1</code> is the fastest method with the least
                     compression.<p class="p"><code class="ph codeph">1</code> is the default method. Within each compression sub-type (RLE with zlib or RLE with zstd), higher compression levels yield higher compression ratios at the cost of speed. Since zstd outperforms zlib in terms of compression ratios and speed, we highly recommend using levels above 5.</p></td>
             </tr>

--- a/gpdb-doc/markdown/admin_guide/ddl/ddl-storage.html.md
+++ b/gpdb-doc/markdown/admin_guide/ddl/ddl-storage.html.md
@@ -251,10 +251,9 @@ The following table details the types of storage directives and possible values 
                   <code class="ph codeph">4</code><p class="p"><code class="ph codeph">1</code> - apply RLE only</p><p class="p"><code class="ph codeph">2</code>
                   - apply RLE then apply zlib compression level 1</p><p class="p"><code class="ph codeph">3</code> - apply
                   RLE then apply zlib compression level 5</p><p class="p"><code class="ph codeph">4</code> - apply RLE then
-                  apply zlib compression level 9</p></td>
+                  apply zlib compression level 9</p><p class="p"><code class="ph codeph">4</code> - apply RLE then apply zstd compression level 1</p><p class="p"><code class="ph codeph">4</code> - apply RLE then apply zstd compression level 3</p></td>
               <td class="entry" headers="topic43__im198636__entry__4"><code class="ph codeph">1</code> is the fastest method with the least
-                    compression.<p class="p"><code class="ph codeph">4</code> is the slowest method with the most
-                  compression. <code class="ph codeph">1</code> is the default.</p></td>
+                    compression.<p class="p"><code class="ph codeph">1</code> is the default method. Within each compression sub-type (RLE with zlib or RLE with zstd), higher compression levels yield higher compression ratios at the cost of speed. Since zstd outperforms zlib in terms of compression ratios and speed, we highly recommend using levels above 5.</p></td>
             </tr>
             <tr class="row">
               <td class="entry" headers="topic43__im198636__entry__1">

--- a/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TYPE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/ALTER_TYPE.html.md
@@ -101,7 +101,7 @@ storage\_directive
 
     > **Note** QuickLZ compression is available only in the commercial release of VMware Greenplum. Support for the QuickLZ compression algorithm is deprecated and will be removed in the next major release of VMware Greenplum.
 
-:   **COMPRESSLEVEL** — For Zstd compression, set to an integer value from 1 \(fastest compression\) to 19 \(highest compression ratio\). For zlib compression, the valid range is from 1 to 9. The QuickLZ compression level can only be set to 1. For `RLE_TYPE`, the compression level can be set to an integer value from 1 \(fastest compression\) to 4 \(highest compression ratio\). The default compression level is 1.
+:   **COMPRESSLEVEL** — For Zstd compression, set to an integer value from 1 \(fastest compression\) to 19 \(highest compression ratio\). For zlib compression, the valid range is from 1 to 9. The QuickLZ compression level can only be set to 1. For `RLE_TYPE`, the compression level can be set to an integer value from 1 \(fastest compression\) to 6 \(highest compression ratio\). The default compression level is 1.
 
 :   **BLOCKSIZE** — Set to the size, in bytes, for each block in the column. The `BLOCKSIZE` must be between 8192 and 2097152 bytes, and be a multiple of 8192. The default block size is 32768.
 

--- a/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TYPE.html.md
+++ b/gpdb-doc/markdown/ref_guide/sql_commands/CREATE_TYPE.html.md
@@ -198,7 +198,7 @@ compression\_type
 
 
 compression\_level
-:   For Zstd compression, set to an integer value from 1 \(fastest compression\) to 19 \(highest compression ratio\). For zlib compression, the valid range is from 1 to 9. The QuickLZ compression level can only be set to 1. For `RLE_TYPE`, the compression level can be set to an integer value from 1 \(fastest compression\) to 4 \(highest compression ratio\). The default compression level is 1.
+:   For Zstd compression, set to an integer value from 1 \(fastest compression\) to 19 \(highest compression ratio\). For zlib compression, the valid range is from 1 to 9. The QuickLZ compression level can only be set to 1. For `RLE_TYPE`, the compression level can be set to an integer value from 1 \(fastest compression\) to 6 \(highest compression ratio\). The default compression level is 1.
 
 blocksize
 :   Set to the size, in bytes, for each block in the column. The `BLOCKSIZE` must be between 8192 and 2097152 bytes, and be a multiple of 8192. The default block size is 32768.


### PR DESCRIPTION
This PR documents the newly introduced support for RLE with zstd.
Staging site:
https://docs-staging.vmware.com/en/draft/VMware-Tanzu-Greenplum/mireia-linux/greenplum-database/admin_guide-ddl-ddl-storage.html
Note that this PR is against 6X_STABLE and needs to be cherry-picked to main when approved.