### PR TITLE
Fix external table location escape for delimiter '|'

### DIFF
--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -109,6 +109,7 @@ strsep_uri(char **uris)
 			 */
 			else if (*index == '\0')
 			{
+				result[j++] = '\\';
 				continue;
 			}
 			/* This is only possible for previous version data without escape.

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -83,7 +83,7 @@ strsep_uri(char **uris)
                 return NULL;
 
         size_t len = strlen(index);
-        result = (char *)malloc(len + 1);
+        result = (char *)palloc(len + 1);
         int j = 0;
         for (;;)
         {
@@ -93,21 +93,27 @@ strsep_uri(char **uris)
                         *uris = index;
                         break;
                 }
-                if (*index == '|')
+		else if (*index == '\\')
                 {
                         index++;
-                        if (*index == '|')
+                        if (*index == '\\' || *index == '|')
                         {
-                                result[j++] = '|';
-                                index++;
-                                continue;
+                                result[j++] = *index;
                         }
-                        else
+                        else if (*index != '\0')
                         {
-                                result[j++] = '\0';
-                                *uris = index;
-                                break;
+                                result[j++] = '\\';
+                                result[j++] = *index;
                         }
+                        index++;
+                        continue;
+                }
+                else if (*index == '|')
+                {
+                        index++;
+                        result[j++] = '\0';
+                        *uris = index;
+                        break;
                 }
                 else
                 {

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -70,58 +70,72 @@ gfile_free(void *a)
 {
 	pfree(a);
 }
- 
+
+/*  Split the uris string which may contain escape */
 static char*
 strsep_uri(char **uris)
 {
-        char *index;
-        char *result;
+	char *index;
+	char *result;
 
-        if ((index = *uris) == NULL)
-                return NULL;
-        if (*index == '\0')
-                return NULL;
+	if ((index = *uris) == NULL)
+		return NULL;
+	if (*index == '\0')
+		return NULL;
 
-        size_t len = strlen(index);
-        result = (char *)palloc(len + 1);
-        int j = 0;
-        for (;;)
-        {
-                if (*index == '\0')
-                {
-                        result[j++] = '\0';
-                        *uris = index;
-                        break;
-                }
+	size_t len = strlen(index);
+	result = (char *)palloc(len + 1);
+	int j = 0;
+	for (;;)
+	{
+		if (*index == '\0')
+		{
+			result[j++] = '\0';
+			*uris = index;
+			break;
+		}
+		/* If escape is found */
 		else if (*index == '\\')
-                {
-                        index++;
-                        if (*index == '\\' || *index == '|')
-                        {
-                                result[j++] = *index;
-                        }
-                        else if (*index != '\0')
-                        {
-                                result[j++] = '\\';
-                                result[j++] = *index;
-                        }
-                        index++;
-                        continue;
-                }
-                else if (*index == '|')
-                {
-                        index++;
-                        result[j++] = '\0';
-                        *uris = index;
-                        break;
-                }
-                else
-                {
-                        result[j++] = *index;
-                        index++;
-                }
-        }
-        return result;
+		{
+			/* Check the next character after escape. */
+			index++;
+			/* If it is a separator or another escape, skip the previous escape. */
+			if (*index == '\\' || *index == '|')
+			{
+				result[j++] = *index;
+			}
+			/* This is only possible for previous version data without escape.
+			 * If it is the end, continue and the next loop will handle it.
+			 */
+			else if (*index == '\0')
+			{
+				continue;
+			}
+			/* This is only possible for previous version data without escape.
+			 * If it is a common char, keep the original format.
+			 */
+			else
+			{
+				result[j++] = '\\';
+				result[j++] = *index;
+			}
+			index++;
+		}
+		/* For correct data, only delimiter have not escape before. */
+		else if (*index == '|')
+		{
+			index++;
+			result[j++] = '\0';
+			*uris = index;
+			break;
+		}
+		else
+		{
+			result[j++] = *index;
+			index++;
+		}
+	}
+	return result;
 }
 
 /* transform the locations string to a list */

--- a/src/backend/access/external/external.c
+++ b/src/backend/access/external/external.c
@@ -70,6 +70,53 @@ gfile_free(void *a)
 {
 	pfree(a);
 }
+ 
+static char*
+strsep_uri(char **uris)
+{
+        char *index;
+        char *result;
+
+        if ((index = *uris) == NULL)
+                return NULL;
+        if (*index == '\0')
+                return NULL;
+
+        size_t len = strlen(index);
+        result = (char *)malloc(len + 1);
+        int j = 0;
+        for (;;)
+        {
+                if (*index == '\0')
+                {
+                        result[j++] = '\0';
+                        *uris = index;
+                        break;
+                }
+                if (*index == '|')
+                {
+                        index++;
+                        if (*index == '|')
+                        {
+                                result[j++] = '|';
+                                index++;
+                                continue;
+                        }
+                        else
+                        {
+                                result[j++] = '\0';
+                                *uris = index;
+                                break;
+                        }
+                }
+                else
+                {
+                        result[j++] = *index;
+                        index++;
+                }
+        }
+        return result;
+}
 
 /* transform the locations string to a list */
 List*
@@ -80,7 +127,7 @@ TokenizeLocationUris(char *uris)
 
 	Assert(uris != NULL);
 
-	while ((uri = strsep(&uris, "|")) != NULL)
+	while ((uri = strsep_uri(&uris)) != NULL)
 	{
 		result = lappend(result, makeString(uri));
 	}

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -358,6 +358,7 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 		Uri		   *uri;
 		char	   *uri_str_orig;
 		char	   *uri_str_final;
+		char	   *uri_str_escape;
 		Value	   *v = lfirst(cell);
 
 		/* get the current URI string from the command */
@@ -464,18 +465,20 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 							uri_str_final),
 					 errhint("Specify the explicit path and file name to write into.")));
 
+		uri_str_escape = escape_uri(uri_str_final);
+		pfree(uri_str_final);
 		if (first_uri)
 		{
-			appendStringInfo(&buf, "%s", escape_uri(uri_str_final));
+			appendStringInfo(&buf, "%s", uri_str_escape);
 			first_uri = false;
 		}
 		else
 		{
-			appendStringInfo(&buf, "|%s", escape_uri(uri_str_final));
+			appendStringInfo(&buf, "|%s", uri_str_escape);
 		}
 
 		FreeExternalTableUri(uri);
-		pfree(uri_str_final);
+		pfree(uri_str_escape);
 	}
 
 	return buf.data;

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -39,6 +39,7 @@
 #include "cdb/cdbsreh.h"
 
 static char* transformLocationUris(List *locs, bool isweb, bool iswritable);
+static char* escape_uri(char *uri);
 static char* transformExecOnClause(List *on_clause);
 static char transformFormatType(char *formatname);
 static List * transformFormatOpts(char formattype, List *formatOpts, int numcols, bool iswritable);
@@ -465,12 +466,12 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 
 		if (first_uri)
 		{
-			appendStringInfo(&buf, "%s", uri_str_final);
+			appendStringInfo(&buf, "%s", escape_uri(uri_str_final));
 			first_uri = false;
 		}
 		else
 		{
-			appendStringInfo(&buf, "|%s", uri_str_final);
+			appendStringInfo(&buf, "|%s", escape_uri(uri_str_final));
 		}
 
 		FreeExternalTableUri(uri);
@@ -478,6 +479,25 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 	}
 
 	return buf.data;
+}
+static char*
+escape_uri(char *uri) {
+	size_t len = strlen(uri);
+	char *output = (char *)palloc((len * 2) + 1);
+    	int i, j = 0;
+    	for (i = 0; uri[i] != '\0'; i++) {
+		if (uri[i] == '|')
+		{
+			output[j++] = '|';
+			output[j++] = '|';
+		}
+		else
+		{
+                	output[j++] = uri[i];
+		}
+        }
+	output[j] = '\0';
+	return output;
 }
 
 static char*

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -481,12 +481,15 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 	return buf.data;
 }
 
+/* Since | is used as a delimiter, need to escape the | in the data,
+ * use \ as escape, and \ itself also needs to be escaped.
+ */
 static char*
 escape_uri(char *uri) {
 	size_t len = strlen(uri);
 	char *output = (char *)palloc((len * 2) + 1);
-    	int i, j = 0;
-    	for (i = 0; uri[i] != '\0'; i++) {
+	int i, j = 0;
+	for (i = 0; uri[i] != '\0'; i++) {
 		if (uri[i] == '|' || uri[i] == '\\')
 		{
 			output[j++] = '\\';
@@ -494,9 +497,9 @@ escape_uri(char *uri) {
 		}
 		else
 		{
-                	output[j++] = uri[i];
+			output[j++] = uri[i];
 		}
-        }
+ 	}
 	output[j] = '\0';
 	return output;
 }

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -485,11 +485,13 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
  * use \ as escape, and \ itself also needs to be escaped.
  */
 static char*
-escape_uri(char *uri) {
+escape_uri(char *uri)
+{
 	size_t len = strlen(uri);
 	char *output = (char *)palloc((len * 2) + 1);
 	int i, j = 0;
-	for (i = 0; uri[i] != '\0'; i++) {
+	for (i = 0; uri[i] != '\0'; i++)
+	{
 		if (uri[i] == '|' || uri[i] == '\\')
 		{
 			output[j++] = '\\';

--- a/src/backend/commands/exttablecmds.c
+++ b/src/backend/commands/exttablecmds.c
@@ -480,16 +480,17 @@ transformLocationUris(List *locs, bool isweb, bool iswritable)
 
 	return buf.data;
 }
+
 static char*
 escape_uri(char *uri) {
 	size_t len = strlen(uri);
 	char *output = (char *)palloc((len * 2) + 1);
     	int i, j = 0;
     	for (i = 0; uri[i] != '\0'; i++) {
-		if (uri[i] == '|')
+		if (uri[i] == '|' || uri[i] == '\\')
 		{
-			output[j++] = '|';
-			output[j++] = '|';
+			output[j++] = '\\';
+			output[j++] = uri[i];
 		}
 		else
 		{

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -304,7 +304,8 @@ CREATE READABLE EXTERNAL TABLE public.test_ext
   id integer
 )
 LOCATION(
-  'file://gpdev/tmp/test1|.|txt'
+  'file://gpdev/tmp/test1|.|tx||t|||',
+  'file://gpdev/tmp/test2|.|tx||t||||'
 )
 FORMAT 'TEXT' (
   delimiter 'off' null E'\\N' escape E'\\'

--- a/src/test/regress/input/external_table.source
+++ b/src/test/regress/input/external_table.source
@@ -297,6 +297,22 @@ SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist:/
 DROP FOREIGN TABLE issue_9727;
 RESET client_encoding;
 
+-- Test external table location escape
+-- GitHub Issue #17179: https://github.com/greenplum-db/gpdb/issues/17179
+CREATE READABLE EXTERNAL TABLE public.test_ext
+(
+  id integer
+)
+LOCATION(
+  'file://gpdev/tmp/test1|.|txt'
+)
+FORMAT 'TEXT' (
+  delimiter 'off' null E'\\N' escape E'\\'
+)
+ENCODING 'UTF8'
+LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 10 PERCENT;
+SELECT urilocation FROM pg_exttable WHERE reloid = 'public.test_ext'::regclass;
+DROP EXTERNAL TABLE public.test_ext;
 --
 -- WET tests
 --

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -390,7 +390,8 @@ CREATE READABLE EXTERNAL TABLE public.test_ext
   id integer
 )
 LOCATION(
-  'file://gpdev/tmp/test1|.|txt'
+  'file://gpdev/tmp/test1|.|tx||t|||',
+  'file://gpdev/tmp/test2|.|tx||t||||'
 )
 FORMAT 'TEXT' (
   delimiter 'off' null E'\\N' escape E'\\'
@@ -398,9 +399,9 @@ FORMAT 'TEXT' (
 ENCODING 'UTF8'
 LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 10 PERCENT;
 SELECT urilocation FROM pg_exttable WHERE reloid = 'public.test_ext'::regclass;
-          urilocation           
---------------------------------
- {file://gpdev/tmp/test1|.|txt}
+                              urilocation                               
+------------------------------------------------------------------------
+ {file://gpdev/tmp/test1|.|tx||t|||,file://gpdev/tmp/test2|.|tx||t||||}
 (1 row)
 
 DROP EXTERNAL TABLE public.test_ext;

--- a/src/test/regress/output/external_table.source
+++ b/src/test/regress/output/external_table.source
@@ -383,6 +383,27 @@ SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist:/
 
 DROP FOREIGN TABLE issue_9727;
 RESET client_encoding;
+-- Test external table location escape
+-- GitHub Issue #17179: https://github.com/greenplum-db/gpdb/issues/17179
+CREATE READABLE EXTERNAL TABLE public.test_ext
+(
+  id integer
+)
+LOCATION(
+  'file://gpdev/tmp/test1|.|txt'
+)
+FORMAT 'TEXT' (
+  delimiter 'off' null E'\\N' escape E'\\'
+)
+ENCODING 'UTF8'
+LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 10 PERCENT;
+SELECT urilocation FROM pg_exttable WHERE reloid = 'public.test_ext'::regclass;
+          urilocation           
+--------------------------------
+ {file://gpdev/tmp/test1|.|txt}
+(1 row)
+
+DROP EXTERNAL TABLE public.test_ext;
 --
 -- WET tests
 --

--- a/src/test/regress/output/external_table_optimizer.source
+++ b/src/test/regress/output/external_table_optimizer.source
@@ -383,6 +383,28 @@ SELECT encoding from gp_dist_random('pg_exttable') where urilocation='{gpfdist:/
 
 DROP FOREIGN TABLE issue_9727;
 RESET client_encoding;
+-- Test external table location escape
+-- GitHub Issue #17179: https://github.com/greenplum-db/gpdb/issues/17179
+CREATE READABLE EXTERNAL TABLE public.test_ext
+(
+  id integer
+)
+LOCATION(
+  'file://gpdev/tmp/test1|.|tx||t|||',
+  'file://gpdev/tmp/test2|.|tx||t||||'
+)
+FORMAT 'TEXT' (
+  delimiter 'off' null E'\\N' escape E'\\'
+)
+ENCODING 'UTF8'
+LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 10 PERCENT;
+SELECT urilocation FROM pg_exttable WHERE reloid = 'public.test_ext'::regclass;
+                              urilocation                               
+------------------------------------------------------------------------
+ {file://gpdev/tmp/test1|.|tx||t|||,file://gpdev/tmp/test2|.|tx||t||||}
+(1 row)
+
+DROP EXTERNAL TABLE public.test_ext;
 --
 -- WET tests
 --


### PR DESCRIPTION
This PR is to fix issue https://github.com/greenplum-db/gpdb/issues/17179.

In pg_foreign_table.ftoptions location is stored as connected string with delimiter '|', so when uri contain '|' should be escaped, and when read it should be reverse escaped. 

DDL:
```
bash-4.2$ echo "1" > /tmp/\|.txt
bash-4.2$ psql testdb
psql (12.12)
Type "help" for help.

testdb=# CREATE READABLE EXTERNAL TABLE public.test_ext
(
  id int
)
LOCATION(
  'file://localhost.localdomain/tmp/|.txt'
)
FORMAT 'TEXT' ( delimiter 'off')
ENCODING 'UTF8';
CREATE EXTERNAL TABLE
```
Before this PR:
```
SELECT * FROM public.test_ext;
ERROR:  invalid URI '.txt' : undefined structure

SELECT urilocation from pg_exttable WHERE reloid = 'public.test_ext'::regclass;
      urilocation
------------------------
 {file://localhost.localdomain/tmp/,.txt}
(1 row)
```
With this PR:
```
bash-4.2$ psql testdb
testdb=# SELECT * FROM public.test_ext;
 id
----
  1
(1 row)

testdb=# SELECT urilocation FROM pg_exttable WHERE  reloid = 'public.test_ext'::regclass;
               urilocation
------------------------------------------
 {file://localhost.localdomain/tmp/|.txt}
(1 row)

testdb=# SELECT ftoptions FROM pg_foreign_table WHERE ftrelid = 'public.test_ext'::regclass;
                                                                                      ftoptions

-----------------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------
 {format=text,delimiter=off,"null=\\N","escape=\\",location_uris=file://localhost.localdomain/tmp/\\|.txt,execute_on=ALL_SEGMENTS,log_errors=dis
able,encoding=UTF8,is_writable=false}
(1 row)
```