### PR TITLE
pg_upgrade: version guard checks that use 6X support functions

### DIFF
--- a/src/bin/pg_upgrade/greenplum/check_gp.c
+++ b/src/bin/pg_upgrade/greenplum/check_gp.c
@@ -824,6 +824,9 @@ teardown_GPDB6_data_type_checks(ClusterInfo *cluster)
 static void
 check_views_with_removed_operators()
 {
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
 	char  output_path[MAXPGPATH];
 	FILE *script = NULL;
 	bool  found = false;
@@ -906,6 +909,9 @@ check_views_with_removed_operators()
 static void
 check_views_with_removed_functions()
 {
+	if (GET_MAJOR_VERSION(old_cluster.major_version) > 904)
+		return;
+
 	char  output_path[MAXPGPATH];
 	FILE *script = NULL;
 	bool  found = false;


### PR DESCRIPTION
As part of 6 > 7 upgrade we check for views using objects that have been removed in GPDB7. To prevent our 7 > 7 CI tests from failing, version guard the upgrade checks using pg_upgrade support functions that only exist on 6X.

pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/kyeap-version_guard_removed_operators
