### PR TITLE
gpcheckperf: Fix for error when the time command has comma in the output

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -443,6 +443,7 @@ def parseMultiDDResult(out):
         if o.find('real') >= 0:
             h = line[1:i]
             o = o.split()
+            o[1] = o[1].replace(',', '.')
             m = re.search("(^\d+.\d+)", o[1])
             if m is None:
                 sys.exit('[Error] expected %s to be a floating point number' % o[1])

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckperf.py
@@ -61,6 +61,41 @@ class GpCheckPerf(GpTestCase):
         self.subject.parseCommandLine()
         self.assertEqual(self.subject.GV.opt['-S'], 246.0)
 
+    def test_parseMultiDDResult_when_output_regular(self):
+        inputText = """[localhost] dd if=/dev/zero of=/tmp/gpcheckperf_gpadmin/ddfile count=131072 bs=32768
+[localhost] 131072+0 records in
+[localhost] 131072+0 records out
+[localhost] 4294967296 bytes transferred in 2.973025 secs (1444645536 bytes/sec)
+[localhost]
+[localhost] multidd total bytes  4294967296
+[localhost] real 3.65
+[localhost] user 0.18
+[localhost] sys 2.52
+    """
+        actual_result = self.subject.parseMultiDDResult(inputText)
+        (mbps, time, bytes) = actual_result["localhost"]
+        exp_mbps, exp_time, exp_bytes = (1122.1917808219177, 3.65, 4294967296)
+        self.assertEqual(mbps, exp_mbps)
+        self.assertEqual(time, exp_time)
+        self.assertEqual(bytes, exp_bytes)
+
+    def test_parseMultiDDResult_when_output_comma(self):
+        inputText = """[localhost] dd if=/dev/zero of=/tmp/gpcheckperf_gpadmin/ddfile count=131072 bs=32768
+[localhost] 131072+0 records in
+[localhost] 131072+0 records out
+[localhost] 4294967296 bytes transferred in 2.973025 secs (1444645536 bytes/sec)
+[localhost]
+[localhost] multidd total bytes  4294967296
+[localhost] real 3,65
+[localhost] user 0,18
+[localhost] sys 2,52
+    """
+        actual_result = self.subject.parseMultiDDResult(inputText)
+        (mbps, time, bytes) = actual_result["localhost"]
+        exp_mbps, exp_time, exp_bytes = (1122.1917808219177, 3.65, 4294967296)
+        self.assertEqual(mbps, exp_mbps)
+        self.assertEqual(time, exp_time)
+        self.assertEqual(bytes, exp_bytes)
 
 if __name__ == '__main__':
     run_tests()


### PR DESCRIPTION
This is to fix gpcheckperf fails with an exception when sometime `time` commmand output has a comma separator instead of a dot. This issue happens in case of certain locale due to decimal number format change. 

Steps to reproduce issue:
```
$export LC_ALL=de_DE_utf8
$time sleep 1
real	0m1,021s
user	0m0,001s
sys	0m0,005s
```

**Fix**: added check if comma present in the time output, replace it with a dot and continue parsing.

**Testing**: Added unit tests to check the output of `parseMultiDDResult()` in case of comma and dot.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
