### PR TITLE
[6X] Fix wrong result of numeric window sum agg

### DIFF
--- a/src/test/regress/expected/numeric.out
+++ b/src/test/regress/expected/numeric.out
@@ -1457,3 +1457,31 @@ select 10.0 ^ 2147483647 as overflows;
 ERROR:  value overflows numeric format
 select 117743296169.0 ^ 1000000000 as overflows;
 ERROR:  value overflows numeric format
+--
+-- Test window sum agg on numeric with ndigits > 34
+--
+CREATE TABLE test_win_sum_agg_numeric (c1 numeric, c2 text, c3 date);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c1' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+INSERT INTO test_win_sum_agg_numeric VALUES ('100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895079.16', 'test', '20200112');
+INSERT INTO test_win_sum_agg_numeric VALUES ('21.91', 'test', '20200113');
+INSERT INTO test_win_sum_agg_numeric values ('30.12', 'test', '20200114');
+-- test SUM
+select SUM(c1) OVER (PARTITION BY c2 ORDER BY c3 ASC) as sum from test_win_sum_agg_numeric;
+                                                                 sum                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------
+ 100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895079.16
+ 100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895101.07
+ 100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895131.19
+(3 rows)
+
+-- test AVG
+select AVG(c1) OVER (PARTITION BY c2 ORDER BY c3 ASC) as sum from test_win_sum_agg_numeric;
+                                                                 sum                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------
+  33338314053341003711280849652747455941908476747203569267899910684515021329888023222117379270760291709861614090037520919366631710.40
+  50007471080011505566921274479121183912862715120805353901849866026772531994832034833176068906140437564792421135056281379049947550.54
+ 100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895079.16
+(3 rows)
+
+DROP TABLE test_win_sum_agg_numeric;

--- a/src/test/regress/sql/numeric.sql
+++ b/src/test/regress/sql/numeric.sql
@@ -857,3 +857,19 @@ select 10.0 ^ -2147483648 as rounds_to_zero;
 select 10.0 ^ -2147483647 as rounds_to_zero;
 select 10.0 ^ 2147483647 as overflows;
 select 117743296169.0 ^ 1000000000 as overflows;
+
+--
+-- Test window sum agg on numeric with ndigits > 34
+--
+CREATE TABLE test_win_sum_agg_numeric (c1 numeric, c2 text, c3 date);
+INSERT INTO test_win_sum_agg_numeric VALUES ('100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895079.16', 'test', '20200112');
+INSERT INTO test_win_sum_agg_numeric VALUES ('21.91', 'test', '20200113');
+INSERT INTO test_win_sum_agg_numeric values ('30.12', 'test', '20200114');
+-- test SUM
+select SUM(c1) OVER (PARTITION BY c2 ORDER BY c3 ASC) as sum from test_win_sum_agg_numeric;
+
+-- test AVG
+select AVG(c1) OVER (PARTITION BY c2 ORDER BY c3 ASC) as sum from test_win_sum_agg_numeric;
+
+DROP TABLE test_win_sum_agg_numeric;
+


### PR DESCRIPTION
For numeric type fucntion `add_abs`, if the result's `ndigits` > 34, it will allocate heap memory to store the digits. And if`numeric_sum` is called in the subsequent execution, it will invoke `make_result` to get a finalized agg result, and will free the digits buffer allocated before at the end of `make_result`. However, this var is still in used in the following computation, which will further caused wrong results.

A typical reproduce case is:
```
    CREATE TABLE test_win_sum_agg_numeric (c1 numeric, c2 text, c3
date);
    INSERT INTO test_win_sum_agg_numeric VALUES
('100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895079.16',
'test', '20200112');
    INSERT INTO test_win_sum_agg_numeric VALUES ('21.91', 'test',
'20200113');
    INSERT INTO test_win_sum_agg_numeric values ('30.12', 'test',
'20200114');
    select SUM(c1) OVER (PARTITION BY c2 ORDER BY c3 ASC) as sum
from test_win_sum_agg_numeric;
```

Without the fix, the output will be a random wrong result:
```
    postgres=# select SUM(c1) OVER (PARTITION BY c2 ORDER BY c3 ASC) as sum
    from test_win_sum_agg_numeric;
                                                                       sum
    ------------------------------------------------------------------------------------------------------------------------------------------
         100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895079.16
         100014942160023011133842548958242367825725430241610707803699732053545063989664069666352137812280875129584842270112562758099895101.07
     1F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F640F670.G8
    (3 rows)
```

And 7X doesn't have such problem.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
