### PR TITLE
Let function 'gp_toolkit.__gp_check_orphaned_files_func()' properly execute while Global Deadlock Detector (GDD) is running.

### DIFF
--- a/gpcontrib/gp_toolkit/gp_toolkit--1.4--1.5.sql
+++ b/gpcontrib/gp_toolkit/gp_toolkit--1.4--1.5.sql
@@ -23,6 +23,7 @@ BEGIN
         WHERE
         sess_id <> -1 AND backend_type IN ('client backend', 'unknown process type') -- exclude background worker types
         AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
+        AND query <> 'SELECT * FROM pg_catalog.gp_dist_wait_status()' -- Exclude gdd check query
     ) THEN
         RAISE EXCEPTION 'There is a client session running on one or more segment. Aborting...';
     END IF;

--- a/src/test/isolation2/expected/lockmodes.out
+++ b/src/test/isolation2/expected/lockmodes.out
@@ -1158,6 +1158,12 @@ ALTER SYSTEM
  on                                 
 (1 row)
 
+-- Check tookit for gp_check_orphaned_files works as expected.
+1: select * from gp_toolkit.gp_check_orphaned_files;
+ gp_segment_id | tablespace | filename | filepath 
+---------------+------------+----------+----------
+(0 rows)
+
 1: set optimizer = off;
 SET
 

--- a/src/test/isolation2/expected/lockmodes_optimizer.out
+++ b/src/test/isolation2/expected/lockmodes_optimizer.out
@@ -1157,6 +1157,12 @@ ALTER SYSTEM
  on                                 
 (1 row)
 
+-- Check tookit for gp_check_orphaned_files works as expected.
+1: select * from gp_toolkit.gp_check_orphaned_files;
+ gp_segment_id | tablespace | filename | filepath 
+---------------+------------+----------+----------
+(0 rows)
+
 1: set optimizer = off;
 SET
 

--- a/src/test/isolation2/sql/lockmodes.sql
+++ b/src/test/isolation2/sql/lockmodes.sql
@@ -396,6 +396,9 @@ ALTER SYSTEM SET gp_enable_global_deadlock_detector TO on;
 
 1: show gp_enable_global_deadlock_detector;
 
+-- Check tookit for gp_check_orphaned_files works as expected.
+1: select * from gp_toolkit.gp_check_orphaned_files;
+
 1: set optimizer = off;
 
 2: show gp_enable_global_deadlock_detector;


### PR DESCRIPTION
The function 'gp_toolkit.__gp_check_orphaned_files_func()'  will use the sql above to check no other active/idle transaction is running.
```
        SELECT 1
        FROM gp_stat_activity
        WHERE
        sess_id <> -1 AND backend_type IN ('client backend', 'unknown process type') -- exclude background worker types
        AND sess_id <> current_setting('gp_session_id')::int -- Exclude the current session
```
But when Global Deadlock Detector is on. It may show the GDD backend as the check sql `select * from gp_dist_wait_status()`  is executed in SPI_execute mode. It will be shown in gp_stat_activity as a backend type and can not  exclude as background worker types.

So add the filter condition 'AND query <> 'SELECT * FROM pg_catalog.gp_dist_wait_status()' -- Exclude gdd check query' to make it works.

And add regress in `lockmodes` to test it.