### PR TITLE
Remove udf_setenv() for tests

### DIFF
--- a/src/test/regress/input/guc_env_var.source
+++ b/src/test/regress/input/guc_env_var.source
@@ -13,14 +13,16 @@ select CASE WHEN d::text < 10::text THEN 1 ELSE 2 END from guc_env_tbl;
 -- ensure no Gang is reused
 set gp_vmem_idle_resource_timeout = 1;
 
-create or replace function udf_setenv(cstring, cstring) returns bool as
-'@abs_builddir@/regress@DLSUFFIX@', 'udf_setenv' LANGUAGE C;
+CREATE FUNCTION putenv(text)
+   RETURNS void
+   AS '@libdir@/regress@DLSUFFIX@', 'regress_putenv'
+   LANGUAGE C STRICT;
 
 create or replace function udf_unsetenv(cstring) returns bool as
 '@abs_builddir@/regress@DLSUFFIX@', 'udf_unsetenv' LANGUAGE C;
 
 -- set QD environment variable
-select udf_setenv('PGDATESTYLE', 'ISO, YMD');
+select putenv('PGDATESTYLE="ISO, YMD"');
 
 -- sleep to ensure the existing Gang has been destroyed
 \! sleep 0.5

--- a/src/test/regress/output/guc_env_var.source
+++ b/src/test/regress/output/guc_env_var.source
@@ -22,15 +22,17 @@ select CASE WHEN d::text < 10::text THEN 1 ELSE 2 END from guc_env_tbl;
 
 -- ensure no Gang is reused
 set gp_vmem_idle_resource_timeout = 1;
-create or replace function udf_setenv(cstring, cstring) returns bool as
-'@abs_srcdir@/regress.so', 'udf_setenv' LANGUAGE C;
+CREATE FUNCTION putenv(text)
+   RETURNS void
+   AS '@libdir@/regress@DLSUFFIX@', 'regress_putenv'
+   LANGUAGE C STRICT;
 create or replace function udf_unsetenv(cstring) returns bool as
 '@abs_srcdir@/regress.so', 'udf_unsetenv' LANGUAGE C;
 -- set QD environment variable
-select udf_setenv('PGDATESTYLE', 'ISO, YMD');
- udf_setenv 
-------------
- t
+select putenv('PGDATESTYLE="ISO, YMD"');
+ putenv 
+--------
+ 
 (1 row)
 
 -- sleep to ensure the existing Gang has been destroyed

--- a/src/test/regress/regress_gp.c
+++ b/src/test/regress/regress_gp.c
@@ -91,7 +91,6 @@ extern Datum hasBackendsExist(PG_FUNCTION_ARGS);
 extern Datum assign_new_record(PG_FUNCTION_ARGS);
 
 /* guc_env_var */
-extern Datum udf_setenv(PG_FUNCTION_ARGS);
 extern Datum udf_unsetenv(PG_FUNCTION_ARGS);
 
 /* Auth Constraints */
@@ -593,26 +592,13 @@ assign_new_record(PG_FUNCTION_ARGS)
 	}
 }
 
-/*
- * GPDB_95_MERGE_FIXME: Commit d7cdf6ee36a introduce a similar function to this
- * one with regress_putenv().  When we catch to 9.5 we should switch over to
- * using that.
- */
-PG_FUNCTION_INFO_V1(udf_setenv);
-Datum
-udf_setenv(PG_FUNCTION_ARGS)
-{
-	const char *name = (const char *) PG_GETARG_CSTRING(0);
-	const char *value = (const char *) PG_GETARG_CSTRING(1);
-	int ret = setenv(name, value, 1);
-
-	PG_RETURN_BOOL(ret == 0);
-}
-
 PG_FUNCTION_INFO_V1(udf_unsetenv);
 Datum
 udf_unsetenv(PG_FUNCTION_ARGS)
 {
+	if (!superuser())
+		elog(ERROR, "must be superuser to change environment variables");
+
 	const char *name = (const char *) PG_GETARG_CSTRING(0);
 	int ret = unsetenv(name);
 	PG_RETURN_BOOL(ret == 0);


### PR DESCRIPTION
Commit d7cdf6ee36a introduced a similar function to this one with regress_putenv(), switch to it.

## Here are some reminders before you submit the pull request
- [x] Pass `make installcheck`
