### PR TITLE
[7X] gprecoverseg: progress logging improvement

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -477,6 +477,9 @@ class GpRecoverSegmentProgram:
                 self.logger.info("Not able to terminate the recovery process since it has been completed successfully.")
 
             self.logger.info("********************************")
+            self.logger.info("Future gprecoverseg executions might remove the currently created pg_basebackup/pg_rewind/rsync "
+                             "progress files, please save these files if needed.")
+            self.logger.info("********************************")
             self.logger.info("Segments successfully recovered.")
             self.logger.info("********************************")
 

--- a/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpmovemirrors.feature
@@ -488,7 +488,7 @@ Feature: Tests for gpmovemirrors
         And gprecoverseg should print "Initiating segment recovery." to stdout
 
         And check if mirrors on content 0,1,2 are moved to new location on input file
-        And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+        And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 0,1,2
         And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
         And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
@@ -524,7 +524,7 @@ Feature: Tests for gpmovemirrors
         And check if mirrors on content 0 are in their original configuration
         And check if mirrors on content 1,2 are moved to new location on input file
         And verify that mirror on content 1,2,3,4,5 is up
-        And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 0
+        And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 0,1,2
         And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
         And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -53,6 +53,7 @@ Feature: gprecoverseg tests
           And a tablespace is created with data
          When the user runs "gprecoverseg <args>"
          Then gprecoverseg should return a return code of 0
+          And gprecoverseg should print "Future gprecoverseg executions might remove the currently created pg_basebackup/pg_rewind/rsync progress files, please save these files if needed." to stdout
           And the segments are synchronized
           And verify replication slot internal_wal_replication_slot is available on all the segments
           And the tablespace is valid
@@ -286,8 +287,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "pg_basebackup: base backup completed" to stdout for each mirror
         And gprecoverseg should print "Segments successfully recovered" to stdout
-        And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-        And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+        And gpAdminLogs directory has "pg_basebackup*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files
         And gpAdminLogs directory has "gpsegsetuprecovery*" files
         And all the segments are running
@@ -335,8 +335,8 @@ Feature: gprecoverseg tests
       And gprecoverseg should print "Segments successfully recovered" to stdout
       And check if gprecoverseg ran gpsegsetuprecovery.py 1 times with the expected args
       And check if gprecoverseg ran gpsegrecovery.py 1 times with the expected args
-      And gpAdminLogs directory has no "pg_basebackup*" files
-      And gpAdminLogs directory has no "pg_rewind*" files
+      And gpAdminLogs directory has "pg_basebackup*" files
+      And gpAdminLogs directory has "pg_rewind*" files
       And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
       And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
       And the old data directories are cleaned up for content 0
@@ -357,7 +357,7 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -a -s"
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "pg_rewind: Done!" to stdout for each mirror
-        And gpAdminLogs directory has no "pg_rewind*" files
+        And gpAdminLogs directory has "pg_rewind*" files
         And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
 
@@ -375,7 +375,7 @@ Feature: gprecoverseg tests
         Then gprecoverseg should return a return code of 0
         And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should not print "pg_basebackup: base backup completed" to stdout
-        And gpAdminLogs directory has no "pg_basebackup*" files
+        And gpAdminLogs directory has "pg_basebackup*" files
         And all the segments are running
         And the segments are synchronized
 
@@ -417,9 +417,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should print "total size" to stdout for each mirror
         And gprecoverseg should print "Segments successfully recovered" to stdout
-        And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-        And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
-        And gpAdminLogs directory has no "rsync*" files on all segment hosts
+        And gpAdminLogs directory has "rsync*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files
         And gpAdminLogs directory has "gpsegsetuprecovery*" files
         And all the segments are running
@@ -439,9 +437,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Initiating segment recovery. Upon completion, will start the successfully recovered segments" to stdout
         And gprecoverseg should not print "total size is .*  speedup is .*" to stdout
         And gprecoverseg should print "Segments successfully recovered" to stdout
-        And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-        And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
-        And gpAdminLogs directory has no "rsync*" files on all segment hosts
+        And gpAdminLogs directory has "rsync*" files on all segment hosts
         And gpAdminLogs directory has "gpsegrecovery*" files
         And gpAdminLogs directory has "gpsegsetuprecovery*" files
         And all the segments are running
@@ -520,7 +516,7 @@ Feature: gprecoverseg tests
         When the user runs "gprecoverseg -a -s"
         And gprecoverseg should print "skipping pg_rewind on mirror as standby.signal is present" to stdout
         Then gprecoverseg should return a return code of 0
-        And gpAdminLogs directory has no "pg_rewind*" files
+        And gpAdminLogs directory has "pg_rewind*" files
         And all the segments are running
         And the segments are synchronized
         And the cluster is rebalanced
@@ -1004,8 +1000,8 @@ Feature: gprecoverseg tests
     And verify that lines from recovery_progress.file are present in segment progress files in gpAdminLogs
     And the user reset the walsender on the primary on content 0
     And the user waits until saved async process is completed
-    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-    And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+    And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 0,1
+    And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 2
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And the cluster is recovered in full and rebalanced
@@ -1190,7 +1186,7 @@ Feature: gprecoverseg tests
     And check if incremental recovery failed for mirrors with content 0 for gprecoverseg
     And gprecoverseg should print "Failed to recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all incremental failures" to stdout
     And check if incremental recovery was successful for mirrors with content 1,2
-    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+    And gpAdminLogs directory has "pg_rewind*" files on all segment hosts
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
 
@@ -1215,7 +1211,7 @@ Feature: gprecoverseg tests
     And gprecoverseg should print "Failed to recover the following segments. You must run either gprecoverseg --differential or gprecoverseg -F for all differential failures" to stdout
     And verify that mirror on content 1,2 is up
     And the segments are synchronized for content 1,2
-    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
+    And gpAdminLogs directory has "rsync*" files on all segment hosts
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And the temporary directory is removed
@@ -1475,8 +1471,8 @@ Feature: gprecoverseg tests
     And check if incremental recovery was successful for mirrors with content 2
     And check if mirrors on content 0 are moved to new location on input file
     And check if mirrors on content 1,2 are in their original configuration
-    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-    And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+    And gpAdminLogs directory has "pg_basebackup*" files on respective hosts only for content 0,1
+    And gpAdminLogs directory has "pg_rewind*" files on respective hosts only for content 2
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And verify there are no recovery backout files
@@ -1485,6 +1481,7 @@ Feature: gprecoverseg tests
     And the mode of all the created data directories is changed to 0700
     Then the user runs "gprecoverseg -a"
     And gprecoverseg should return a return code of 0
+    And all previous progress files are removed from gpAdminLogs directory on respective hosts only for content 0
     And user can start transactions
     And the segments are synchronized
     And the cluster is rebalanced
@@ -1521,8 +1518,7 @@ Feature: gprecoverseg tests
     And verify that mirror on content 0,1,2 is down
 
     And check if mirrors on content 0,1,2 are moved to new location on input file
-    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-    And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+    And gpAdminLogs directory has "pg_basebackup*" files on all segment hosts
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And verify there are no recovery backout files

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg_newhost.feature
@@ -51,8 +51,7 @@ Feature: gprecoverseg tests involving migrating to a new host
 #    And pg_hba file "/data/gpdata/mirror/gpseg0/pg_hba.conf" on host "sdw2" contains entries for "sdw5"
     And check if start failed for full recovery for mirrors with hostname sdw5
     And gprecoverseg should print "error:.*data directory.* has invalid permissions" to stdout
-    And gpAdminLogs directory has no "pg_basebackup*" files on all segment hosts
-    And gpAdminLogs directory has no "pg_rewind*" files on all segment hosts
+    And gpAdminLogs directory has "pg_basebackup*" files on sdw5
     And gpAdminLogs directory has "gpsegsetuprecovery*" files on all segment hosts
     And gpAdminLogs directory has "gpsegrecovery*" files on all segment hosts
     And datadirs from "before" configuration for "sdw1" are created on "sdw5" with mode 700

--- a/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/recoverseg_mgmt_utils.py
@@ -321,7 +321,6 @@ def recovery_fail_check(context, recovery_type, content_ids, utility):
     And gprecoverseg should print "{print_msg}" to stdout for mirrors with content {content_ids}
     And gprecoverseg should print "Failed to recover the following segments" to stdout
     And gprecoverseg should print "{recovery_type}" errors to stdout for content {content_ids}
-    And gpAdminLogs directory has "{logfile_name}" files on respective hosts only for content {content_ids}
     And verify that mirror on content {content_ids} is down
     And gprecoverseg should not print "Segments successfully recovered" to stdout
     '''.format(return_code=return_code, print_msg=print_msg, content_ids=content_ids, recovery_type=recovery_type,


### PR DESCRIPTION
 **Fix1:**
- The logging format has been changed to display date and time along with hostname and dbid when showing progress of pg_rewind/pg_basebackup/rsync process.

       Previous format:
       <hostname> (dbid 22): 701679/1421743313 kB (0%), 0/1 tablespace (...test2/gpseg20/pg_log/xxx)

       New format:
       2024-03-19 16:05:38.202000: <hostname> (dbid 22): 701679/1421743313 kB (0%), 0/1 tablespace (...test2/gpseg20/pg_log/xxx)

**Fix2:**
- Do not remove progress files of pg_basebackup/pg_rewind/rsync process from logdir even if the recovery was successful. The current behaviour is to remove these progess logs if gprecoverseg completes successfully. Having these progress files will help troubleshoot  slow running instances of pg_rewind/pg_basebackup/rsync. But the problem here is, these files can consume the whole disk space if not removed after use. Removing these files manually time to time is a hectic job and user might forget to do the same. 
- As a temporary solution, current gprecoverseg execution will clean up the gpAdminLogs directory by removing the existing progress files(created by previous gprecoverseg executions) of segments to be recovered.
- In future, it will be good to have a tool which can summarize the status of each process by consuming the generated progress files and remove the files if not required anymore.

Reviewed-by: Ashwin Agrawal


## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
