### PR TITLE
[6X] ao/co: fix an issue with COPY zero-column CO table

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -682,6 +682,13 @@ ReadNext:
 		/* If necessary, open next seg */
 		if (scan->cur_seg < 0 || err < 0)
 		{
+			/*
+			 * Bail out early if we do not have any column in the projection.
+			 * Placing here in order to have less impact on the hot path. 
+			 */
+			if (scan->num_proj_atts == 0)
+				return false;
+
 			err = open_next_scan_seg(scan);
 			if (err < 0)
 			{
@@ -692,6 +699,9 @@ ReadNext:
 			}
 			scan->cur_seg_row = 0;
 		}
+
+		/* We shouldn't have a 0-column projection as we should've bailed out above */
+		Assert(scan->num_proj_atts > 0);
 
 		Assert(scan->cur_seg >= 0);
 		curseginfo = scan->seginfo[scan->cur_seg];

--- a/src/backend/commands/copy.c
+++ b/src/backend/commands/copy.c
@@ -3115,6 +3115,16 @@ CopyTo(CopyState cstate)
 					proj[attnum-1] = true;
 				}
 
+				/*
+				 * If the table has no column, we project the first
+				 * one, just like count(*). This is except for the
+				 * case where the table is created with no column,
+				 * in which case we'll return false in aocs_getnext
+				 * because there's no data.
+				 */
+				if (!cstate->attnumlist && nvp > 0)
+					proj[0] = true;
+
 				scan = aocs_beginscan(rel, GetActiveSnapshot(),
 									  GetActiveSnapshot(),
 									  NULL /* relationTupleDesc */, proj);

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -390,7 +390,7 @@ InitAOCSScanOpaque(SeqScanState *scanstate, Relation currentRelation)
 	 * In some cases (for example, count(*)), no columns are specified.
 	 * We always scan the first column.
 	 */
-	if (i == ncol)
+	if (i == ncol && ncol > 0)
 		proj[0] = true;
 
 	scanstate->ss_aocs_ncol = ncol;

--- a/src/test/regress/input/uao_ddl/alter_drop_allcol.source
+++ b/src/test/regress/input/uao_ddl/alter_drop_allcol.source
@@ -14,14 +14,17 @@ select * from alter_drop_allcoll order by a,b;
 ALTER TABLE alter_drop_allcoll DROP COLUMN c;
 select count(*) as c from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='c';
 select * from alter_drop_allcoll order by a,b;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll DROP COLUMN b;
 select count(*) as b from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='b';
 select * from alter_drop_allcoll order by a;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll DROP COLUMN a;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
 select * from alter_drop_allcoll;
+copy alter_drop_allcoll to stdout;
 
 ALTER TABLE alter_drop_allcoll ADD COLUMN a1 int default 10;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -29,3 +32,4 @@ select * from alter_drop_allcoll;
 COMMIT;
 vacuum alter_drop_allcoll;
 select * from alter_drop_allcoll;
+copy alter_drop_allcoll to stdout;

--- a/src/test/regress/input/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/input/uao_ddl/create_ao_tables.source
@@ -205,3 +205,9 @@ set gp_select_invisible=false;
 select * into sto_heap_10 from sto_uao_8;
 select count(*) from sto_heap_10;
 COMMIT;
+
+-- Table with zero column
+create table sto_uao_0col();
+select * from sto_uao_0col;
+select count(*) from sto_uao_0col;
+copy sto_uao_0col to stdout;

--- a/src/test/regress/output/uao_ddl/alter_drop_allcol.source
+++ b/src/test/regress/output/uao_ddl/alter_drop_allcol.source
@@ -38,6 +38,12 @@ select * from alter_drop_allcoll order by a,b;
  5 | 5
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+1	1
+2	2
+3	3
+4	4
+5	5
 ALTER TABLE alter_drop_allcoll DROP COLUMN b;
 select count(*) as b from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='b';
  b 
@@ -55,6 +61,12 @@ select * from alter_drop_allcoll order by a;
  5
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+1
+2
+3
+4
+5
 ALTER TABLE alter_drop_allcoll DROP COLUMN a;
 NOTICE:  dropping a column that is part of the distribution policy forces a NULL distribution policy
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -66,6 +78,12 @@ select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oi
 select * from alter_drop_allcoll;
 --
 (5 rows)
+
+copy alter_drop_allcoll to stdout;
+
+
+
+
 
 ALTER TABLE alter_drop_allcoll ADD COLUMN a1 int default 10;
 select count(*) as a from pg_attribute pa, pg_class pc where pa.attrelid = pc.oid and pc.relname='alter_drop_allcoll' and attname='a';
@@ -96,3 +114,9 @@ select * from alter_drop_allcoll;
  10
 (5 rows)
 
+copy alter_drop_allcoll to stdout;
+10
+10
+10
+10
+10

--- a/src/test/regress/output/uao_ddl/create_ao_tables.source
+++ b/src/test/regress/output/uao_ddl/create_ao_tables.source
@@ -323,3 +323,16 @@ select count(*) from sto_heap_10;
 (1 row)
 
 COMMIT;
+-- Table with zero column
+create table sto_uao_0col();
+select * from sto_uao_0col;
+--
+(0 rows)
+
+select count(*) from sto_uao_0col;
+ count 
+-------
+     0
+(1 row)
+
+copy sto_uao_0col to stdout;


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/17157.

Slight difference with 7X:
* In 6X, the logic to choose first column for count(*) of 0-column table is done in InitAOCSScanOpaque, instead of the common *beginscan* path as 7X. So we cannot leverage that logic in 6X for CopyTo. So instead, we place a similar logic in CopyTo to choose the first column in that case.
* 6X has the same memory overwriting issue in InitAOCSScanOpaque as the aoco_beginscan_extractcolumns function in 7X. But it doesn't have the same bug repro (the added test in uao/ddl/create_ao_tables), at least in my env. But it is the right thing to fix it. Same test added too.

Original commit message
---------------

The issue is that if the CO table once had column (and data), but later all columns are dropped, then COPY this table would hang:

```
create table co(a int) using ao_column;
insert into co select * from generate_series(1,10);
alter table co drop column a;

copy co to stdout; -- this hangs forever
```

The is because aocs_getnext is not handling this case well: it would open the segment files but skip the actually scanning (because no projected columns), write no tupleslot values, and finally return TRUE which doesn't make any sense as it did not read any tuple. So a loop to get next tuple would loop forever. If we return FALSE here, we would stop the loop early.

Note that, however, this does not make COPY's behavior for CO to be the same as heap or AO, where we would still copy out the same number of rows as in the table, just no data in the row. In order to get it right, we can make a targeted change to COPY TO so it leave the decision to the CO AM layer regarding which column to project, which is also more consistent with SELECT *.

The change to aocs_getnext() would serve as just defensive checks.

Also fixed an issue with aoco_beginscan_extractcolumns() where we shouldn't write proj[0] if natts==0, otherwise would overwrite invalid memory:
```
postgres=# create table co() using ao_column;
CREATE TABLE
postgres=# select * from co;
WARNING:  detected write past chunk end in ExecutorState 0x55f234ea87c8  (seg1 slice1 127.0.1.1:7003 pid=10726)
WARNING:  detected write past chunk end in ExecutorState 0x555b0a692708  (seg2 slice1 127.0.1.1:7004 pid=10727)
WARNING:  detected write past chunk end in ExecutorState 0x562e118bf768  (seg0 slice1 127.0.1.1:7002 pid=10725)
--
(0 rows)
```

Dev pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/co-copy-0col-6x

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
