### PR TITLE
Fail the SplitUpdate if table's any child has update triggers

### DIFF
--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -1,3 +1,4 @@
 pgarch_start
 ConfigureNamesInt_gp
 child_triggers
+has_update_triggers

--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -1,2 +1,3 @@
 pgarch_start
 ConfigureNamesInt_gp
+child_triggers

--- a/src/backend/cdb/cdbpath.c
+++ b/src/backend/cdb/cdbpath.c
@@ -2632,7 +2632,7 @@ make_splitupdate_path(PlannerInfo *root, Path *subpath, Index rti)
 	 * So an update trigger is not allowed when updating the
 	 * distribution key.
 	 */
-	if (has_update_triggers(rte->relid))
+	if (has_update_triggers(rte->relid, false))
 		ereport(ERROR,
 				(errcode(ERRCODE_GP_FEATURE_NOT_YET),
 				 errmsg("UPDATE on distributed key column not allowed on relation with update triggers")));

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -2092,7 +2092,7 @@ gpdb::HasUpdateTriggers(Oid relid)
 {
 	GP_WRAP_START;
 	{
-		return has_update_triggers(relid);
+		return has_update_triggers(relid, true);
 	}
 	GP_WRAP_END;
 	return false;

--- a/src/backend/utils/cache/lsyscache.c
+++ b/src/backend/utils/cache/lsyscache.c
@@ -1591,15 +1591,14 @@ get_oprjoin(Oid opno)
 /*				---------- TRIGGER CACHE ----------					 */
 
 
-/* Does table have update triggers? */
+/* Does table and its directly or indirectly children have update triggers? */
 bool
 has_update_triggers(Oid relid)
 {
 	Relation	relation;
 	bool		result = false;
 
-	/* Assume the caller already holds a suitable lock. */
-	relation = table_open(relid, NoLock);
+	relation = RelationIdGetRelation(relid);
 
 	if (relation->rd_rel->relhastriggers)
 	{
@@ -1616,15 +1615,33 @@ has_update_triggers(Oid relid)
 				found = trigger_enabled(trigger.tgoid) &&
 					(get_trigger_type(trigger.tgoid) & TRIGGER_TYPE_UPDATE) == TRIGGER_TYPE_UPDATE;
 				if (found)
+				{
+					result = true;
 					break;
+				}
+			}
+		}
+	}
+
+	if (!result && relation->rd_rel->relkind == RELKIND_PARTITIONED_TABLE)
+	{
+		List	   *partitions = find_inheritance_children(relid, NoLock);
+		ListCell   *lc;
+
+		foreach(lc, partitions)
+		{
+			Oid			partrelid = lfirst_oid(lc);
+			if (has_update_triggers(partrelid))
+			{
+				result = true;
+				break;
 			}
 		}
 
-		/* GPDB_96_MERGE_FIXME: Why is this not allowed? */
-		if (found || child_triggers(relation->rd_id, TRIGGER_TYPE_UPDATE))
-			result = true;
+		list_free(partitions);
 	}
-	table_close(relation, NoLock);
+
+	RelationClose(relation);
 
 	return result;
 }
@@ -4559,63 +4576,3 @@ child_distribution_mismatch(Relation rel)
 	return false;
 }
 
-/*
- *  child_triggers
- *  Return true if the table is partitioned and any of the child partitions
- *  have a trigger of the given type.
- */
-bool
-child_triggers(Oid relationId, int32 triggerType)
-{
-/* GPDB_12_MERGE_FIXME */
-	return false;
-#if 0
-	Assert(InvalidOid != relationId);
-	if (PART_STATUS_NONE == rel_part_status(relationId))
-	{
-		/* not a partitioned table */
-		return false;
-	}
-
-	List *childOids = find_all_inheritors(relationId, NoLock, NULL);
-	ListCell *lc;
-
-	bool found = false;
-	foreach (lc, childOids)
-	{
-		Oid oidChild = lfirst_oid(lc);
-		Relation relChild = RelationIdGetRelation(oidChild);
-		Assert(NULL != relChild);
-
-		if (relChild->rd_rel->relhastriggers && NULL == relChild->trigdesc)
-		{
-			RelationBuildTriggers(relChild);
-			if (NULL == relChild->trigdesc)
-			{
-				relChild->rd_rel->relhastriggers = false;
-			}
-		}
-
-		if (relChild->rd_rel->relhastriggers)
-		{
-			for (int i = 0; i < relChild->trigdesc->numtriggers && !found; i++)
-			{
-				Trigger trigger = relChild->trigdesc->triggers[i];
-				found = trigger_enabled(trigger.tgoid) &&
-						(get_trigger_type(trigger.tgoid) & triggerType) == triggerType;
-			}
-		}
-
-		RelationClose(relChild);
-		if (found)
-		{
-			break;
-		}
-	}
-
-	list_free(childOids);
-	
-	/* no child triggers matching the given type */
-	return found;
-#endif
-}

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -237,7 +237,6 @@ Oid get_check_constraint_relid(Oid oidCheckconstraint);
 extern bool has_subclass_slow(Oid relationId);
 extern GpPolicy *relation_policy(Relation rel);
 extern bool child_distribution_mismatch(Relation rel);
-extern bool child_triggers(Oid relationId, int32 triggerType);
 
 extern bool get_cast_func(Oid oidSrc, Oid oidDest, bool *is_binary_coercible, Oid *oidCastFunc, CoercionPathType *pathtype);
 

--- a/src/include/utils/lsyscache.h
+++ b/src/include/utils/lsyscache.h
@@ -133,7 +133,7 @@ extern Oid	get_commutator(Oid opno);
 extern Oid	get_negator(Oid opno);
 extern RegProcedure get_oprrest(Oid opno);
 extern RegProcedure get_oprjoin(Oid opno);
-extern bool has_update_triggers(Oid relid);
+extern bool has_update_triggers(Oid relid, bool including_children);
 extern int32 get_trigger_type(Oid triggerid);
 extern bool trigger_enabled(Oid triggerid);
 extern char *get_func_name(Oid funcid);

--- a/src/test/regress/expected/triggers_gp.out
+++ b/src/test/regress/expected/triggers_gp.out
@@ -66,7 +66,11 @@ create table parted_trig2 partition of parted_trig for values in (2);
 NOTICE:  table has parent, setting distribution columns to match parent table
 create table parted_trig3 partition of parted_trig for values in (3);
 NOTICE:  table has parent, setting distribution columns to match parent table
-create table parted_trig4 partition of parted_trig for values in (4);
+create table parted_trig4 partition of parted_trig for values in (4,5) partition by list (partkey);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table parted_trig4_1 partition of parted_trig4 for values in (4);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table parted_trig4_2 partition of parted_trig4 for values in (5);
 NOTICE:  table has parent, setting distribution columns to match parent table
 /* Could create similar structure with this legacy GPDB syntax:
 create table parted_trig (partkey int, nonkey int, distkey int)
@@ -82,20 +86,42 @@ insert into parted_trig values (1, 1, 1);
 NOTICE:  insert trigger fired on parted_trig1 for INSERT  (seg1 127.0.0.1:40001 pid=10560)
 insert into parted_trig values (2, 2, 2);
 NOTICE:  insert trigger fired on parted_trig2 for INSERT  (seg0 127.0.0.1:40000 pid=10559)
--- Have an UPDATE trigger on a child.
-create trigger trig_upd_after after update on parted_trig2
+insert into parted_trig values (5, 5, 5);
+NOTICE:  insert trigger fired on parted_trig4_2 for INSERT  (seg2 127.0.0.1:40002 pid=250082)
+-- Have an UPDATE trigger on the middle level partition.
+create trigger trig_upd_after after update on parted_trig4
   for each row execute procedure update_notice_trig();
--- Update distribution key column. Throws an error, currently.
-update parted_trig set distkey = 3 where distkey = 1;
+-- Update distribution key column on each level partition. Throws an error, currently.
+update parted_trig set distkey = 4 where distkey = 5;
 ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
-drop trigger trig_upd_after on parted_trig2;
+update parted_trig4 set distkey = 4 where distkey = 5;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+update parted_trig4_1 set distkey = 4 where distkey = 5;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+drop trigger trig_upd_after on parted_trig4;
+-- Have an UPDATE trigger on a leaf partition.
+create trigger trig_upd_after after update on parted_trig4_1
+  for each row execute procedure update_notice_trig();
+-- Update distribution key column on each level partition. Throws an error, currently.
+update parted_trig set distkey = 3 where distkey = 4;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+update parted_trig4 set distkey = 3 where distkey = 4;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+update parted_trig4_1 set distkey = 3 where distkey = 4;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+drop trigger trig_upd_after on parted_trig4_1;
+-- Have an UPDATE trigger on the top level partition.
 create trigger trig_upd_after after update on parted_trig
   for each row execute procedure update_notice_trig();
 -- Update non-key column. Should fire the UPDATE trigger.
 update parted_trig set nonkey = 3 where nonkey = 1;
 NOTICE:  update trigger fired on parted_trig1 for UPDATE  (seg1 127.0.0.1:40001 pid=10560)
--- Update distribution key column. Throws an error, currently.
+-- Update distribution key column on each level partition. Throws an error, currently.
 update parted_trig set distkey = 3 where distkey = 1;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+update parted_trig4 set distkey = 3 where distkey = 1;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+update parted_trig4_1 set distkey = 3 where distkey = 1;
 ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
 -- Update partitioning key column. Should fire the DELETE+INSERT triggers,
 -- like in PostgreSQL.

--- a/src/test/regress/expected/triggers_gp.out
+++ b/src/test/regress/expected/triggers_gp.out
@@ -75,8 +75,6 @@ create table parted_trig (partkey int, nonkey int, distkey int)
 */
 create trigger trig_ins_after after insert on parted_trig
   for each row execute procedure insert_notice_trig();
-create trigger trig_upd_after after update on parted_trig
-  for each row execute procedure update_notice_trig();
 create trigger trig_del_after after delete on parted_trig
   for each row execute procedure delete_notice_trig();
 -- Inserts. Should fire the INSERT trigger.
@@ -84,6 +82,15 @@ insert into parted_trig values (1, 1, 1);
 NOTICE:  insert trigger fired on parted_trig1 for INSERT  (seg1 127.0.0.1:40001 pid=10560)
 insert into parted_trig values (2, 2, 2);
 NOTICE:  insert trigger fired on parted_trig2 for INSERT  (seg0 127.0.0.1:40000 pid=10559)
+-- Have an UPDATE trigger on a child.
+create trigger trig_upd_after after update on parted_trig2
+  for each row execute procedure update_notice_trig();
+-- Update distribution key column. Throws an error, currently.
+update parted_trig set distkey = 3 where distkey = 1;
+ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
+drop trigger trig_upd_after on parted_trig2;
+create trigger trig_upd_after after update on parted_trig
+  for each row execute procedure update_notice_trig();
 -- Update non-key column. Should fire the UPDATE trigger.
 update parted_trig set nonkey = 3 where nonkey = 1;
 NOTICE:  update trigger fired on parted_trig1 for UPDATE  (seg1 127.0.0.1:40001 pid=10560)
@@ -96,7 +103,7 @@ update parted_trig set partkey = 3 where partkey = 1;
 NOTICE:  delete trigger fired on parted_trig1 for DELETE  (seg1 127.0.0.1:40001 pid=10560)
 NOTICE:  insert trigger fired on parted_trig3 for INSERT  (seg1 127.0.0.1:40001 pid=10560)
 -- Update everything in one statement. Throws an error, currently, because
--- updating the distributon key is not allowed.
+-- updating the distribution key is not allowed.
 update parted_trig set partkey = partkey + 1, distkey = distkey + 1;
 ERROR:  UPDATE on distributed key column not allowed on relation with update triggers
 -- Should fire the DELETE trigger.

--- a/src/test/regress/sql/triggers_gp.sql
+++ b/src/test/regress/sql/triggers_gp.sql
@@ -69,7 +69,9 @@ create table parted_trig (partkey int, nonkey int, distkey int)
 create table parted_trig1 partition of parted_trig for values in (1);
 create table parted_trig2 partition of parted_trig for values in (2);
 create table parted_trig3 partition of parted_trig for values in (3);
-create table parted_trig4 partition of parted_trig for values in (4);
+create table parted_trig4 partition of parted_trig for values in (4,5) partition by list (partkey);
+create table parted_trig4_1 partition of parted_trig4 for values in (4);
+create table parted_trig4_2 partition of parted_trig4 for values in (5);
 
 /* Could create similar structure with this legacy GPDB syntax:
 create table parted_trig (partkey int, nonkey int, distkey int)
@@ -85,24 +87,41 @@ create trigger trig_del_after after delete on parted_trig
 -- Inserts. Should fire the INSERT trigger.
 insert into parted_trig values (1, 1, 1);
 insert into parted_trig values (2, 2, 2);
+insert into parted_trig values (5, 5, 5);
 
--- Have an UPDATE trigger on a child.
-create trigger trig_upd_after after update on parted_trig2
+-- Have an UPDATE trigger on the middle level partition.
+create trigger trig_upd_after after update on parted_trig4
   for each row execute procedure update_notice_trig();
 
--- Update distribution key column. Throws an error, currently.
-update parted_trig set distkey = 3 where distkey = 1;
+-- Update distribution key column on each level partition. Throws an error, currently.
+update parted_trig set distkey = 4 where distkey = 5;
+update parted_trig4 set distkey = 4 where distkey = 5;
+update parted_trig4_1 set distkey = 4 where distkey = 5;
 
-drop trigger trig_upd_after on parted_trig2;
+drop trigger trig_upd_after on parted_trig4;
 
+-- Have an UPDATE trigger on a leaf partition.
+create trigger trig_upd_after after update on parted_trig4_1
+  for each row execute procedure update_notice_trig();
+
+-- Update distribution key column on each level partition. Throws an error, currently.
+update parted_trig set distkey = 3 where distkey = 4;
+update parted_trig4 set distkey = 3 where distkey = 4;
+update parted_trig4_1 set distkey = 3 where distkey = 4;
+
+drop trigger trig_upd_after on parted_trig4_1;
+
+-- Have an UPDATE trigger on the top level partition.
 create trigger trig_upd_after after update on parted_trig
   for each row execute procedure update_notice_trig();
 
 -- Update non-key column. Should fire the UPDATE trigger.
 update parted_trig set nonkey = 3 where nonkey = 1;
 
--- Update distribution key column. Throws an error, currently.
+-- Update distribution key column on each level partition. Throws an error, currently.
 update parted_trig set distkey = 3 where distkey = 1;
+update parted_trig4 set distkey = 3 where distkey = 1;
+update parted_trig4_1 set distkey = 3 where distkey = 1;
 
 -- Update partitioning key column. Should fire the DELETE+INSERT triggers,
 -- like in PostgreSQL.

--- a/src/test/regress/sql/triggers_gp.sql
+++ b/src/test/regress/sql/triggers_gp.sql
@@ -79,14 +79,24 @@ create table parted_trig (partkey int, nonkey int, distkey int)
 
 create trigger trig_ins_after after insert on parted_trig
   for each row execute procedure insert_notice_trig();
-create trigger trig_upd_after after update on parted_trig
-  for each row execute procedure update_notice_trig();
 create trigger trig_del_after after delete on parted_trig
   for each row execute procedure delete_notice_trig();
 
 -- Inserts. Should fire the INSERT trigger.
 insert into parted_trig values (1, 1, 1);
 insert into parted_trig values (2, 2, 2);
+
+-- Have an UPDATE trigger on a child.
+create trigger trig_upd_after after update on parted_trig2
+  for each row execute procedure update_notice_trig();
+
+-- Update distribution key column. Throws an error, currently.
+update parted_trig set distkey = 3 where distkey = 1;
+
+drop trigger trig_upd_after on parted_trig2;
+
+create trigger trig_upd_after after update on parted_trig
+  for each row execute procedure update_notice_trig();
 
 -- Update non-key column. Should fire the UPDATE trigger.
 update parted_trig set nonkey = 3 where nonkey = 1;
@@ -99,7 +109,7 @@ update parted_trig set distkey = 3 where distkey = 1;
 update parted_trig set partkey = 3 where partkey = 1;
 
 -- Update everything in one statement. Throws an error, currently, because
--- updating the distributon key is not allowed.
+-- updating the distribution key is not allowed.
 update parted_trig set partkey = partkey + 1, distkey = distkey + 1;
 
 -- Should fire the DELETE trigger.


### PR DESCRIPTION
Check `make_splitupdate_path()`, it is supposed to fail, but Greenplum
skipped the check on the table's children while merging PostgreSQL 12.

This commit gets the check back.
