### PR TITLE
Fix result is wrong when outer query has order by after LATERAL subquery

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -277,9 +277,6 @@ static MergeJoin *make_mergejoin(List *tlist,
 								 Plan *lefttree, Plan *righttree,
 								 JoinType jointype, bool inner_unique,
 								 bool skip_mark_restore);
-static Sort *make_sort(Plan *lefttree, int numCols,
-					   AttrNumber *sortColIdx, Oid *sortOperators,
-					   Oid *collations, bool *nullsFirst);
 static Plan *prepare_sort_from_pathkeys(Plan *lefttree, List *pathkeys,
 										Relids relids,
 										const AttrNumber *reqColIdx,
@@ -6736,7 +6733,7 @@ make_mergejoin(List *tlist,
  * Caller must have built the sortColIdx, sortOperators, collations, and
  * nullsFirst arrays already.
  */
-static Sort *
+Sort *
 make_sort(Plan *lefttree, int numCols,
 		  AttrNumber *sortColIdx, Oid *sortOperators,
 		  Oid *collations, bool *nullsFirst)
@@ -8092,13 +8089,9 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 									hashOpfamilies,
 									numHashSegments);
 	}
-	else if (CdbPathLocus_IsOuterQuery(path->path.locus))
-	{
-		motion = make_union_motion(subplan);
-		motion->motionType = MOTIONTYPE_OUTER_QUERY;
-	}
 	/* Send all tuples to a single process? */
-	else if (CdbPathLocus_IsBottleneck(path->path.locus))
+	else if (CdbPathLocus_IsBottleneck(path->path.locus)
+			|| CdbPathLocus_IsOuterQuery(path->path.locus))
 	{
 		if (path->path.pathkeys)
 		{
@@ -8153,6 +8146,13 @@ cdbpathtoplan_create_motion_plan(PlannerInfo *root,
 		{
 			motion = make_union_motion(subplan);
 		}
+		/*
+		 * When path.locus is CdbLocusType_OuterQuery, We will miss the pathkeys
+		 * if use make_union_motion. So use make_sorted_union_motion instead of
+		 * make_union_motion if path has pathkeys.
+		 */
+		if (CdbPathLocus_IsOuterQuery(path->path.locus))
+			motion->motionType = MOTIONTYPE_OUTER_QUERY;
 	}
 
 	/* Send all of the tuples to all of the QEs in gang above... */

--- a/src/include/optimizer/planmain.h
+++ b/src/include/optimizer/planmain.h
@@ -79,6 +79,9 @@ extern Plan *add_sort_cost(PlannerInfo *root, Plan *input,
 extern Sort *make_sort_from_pathkeys(Plan *lefttree, List *pathkeys, Relids relids);
 extern Sort *make_sort_from_sortclauses(List *sortcls,
 						   Plan *lefttree);
+extern Sort *make_sort(Plan *lefttree, int numCols,
+					   AttrNumber *sortColIdx, Oid *sortOperators,
+					   Oid *collations, bool *nullsFirst);
 extern Agg *make_agg(List *tlist, List *qual,
 					 AggStrategy aggstrategy, AggSplit aggsplit,
 					 bool streaming,

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3904,3 +3904,95 @@ select (select b from bar)[(select 1)][1:3] from bar;
 (1 row)
 
 drop table bar;
+create table outer_foo(a int primary key, b int);
+create table inner_bar(a int, b int) distributed randomly;
+insert into outer_foo values (generate_series(1,20), generate_series(11,30));
+insert into inner_bar values (generate_series(1,20), generate_series(25,44));
+set optimizer to off;
+explain (costs off) select t1.a from outer_foo t1,  LATERAL(SELECT  distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: t1.a
+         ->  Index Scan using outer_foo_pkey on outer_foo t1
+   ->  Materialize
+         ->  HashAggregate
+               Group Key: t2.a
+               ->  Result
+                     Filter: (t1.b = t2.b)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on inner_bar t2
+ Optimizer: Postgres-based planner
+(13 rows)
+
+explain (costs off) select t1.a from outer_foo t1,  LATERAL(SELECT  distinct t2.a from inner_bar t2 where t1.b=t2.b) q;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on outer_foo t1
+   ->  Materialize
+         ->  HashAggregate
+               Group Key: t2.a
+               ->  Result
+                     Filter: (t1.b = t2.b)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on inner_bar t2
+ Optimizer: Postgres-based planner
+(12 rows)
+
+select t1.a from outer_foo t1,  LATERAL(SELECT  distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1;
+ a  
+----
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(6 rows)
+
+create table t(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off) with cte(x) as (select t1.a from outer_foo t1, LATERAL(SELECT distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1)
+select * from t where a > (select count(1) from cte where x > t.a + random());
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t
+         Filter: (a > (SubPlan 1))
+         SubPlan 1
+           ->  Aggregate
+                 ->  Result
+                       Filter: ((t1.a)::double precision > ((t.a)::double precision + random()))
+                       ->  Nested Loop
+                             ->  Materialize
+                                   ->  Sort
+                                         Sort Key: t1.a
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                               ->  Index Scan using outer_foo_pkey on outer_foo t1
+                             ->  Materialize
+                                   ->  HashAggregate
+                                         Group Key: t2.a
+                                         ->  Result
+                                               Filter: (t1.b = t2.b)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                           ->  Seq Scan on inner_bar t2
+ Optimizer: Postgres-based planner
+(22 rows)
+
+with cte(x) as (select t1.a from outer_foo t1, LATERAL(SELECT distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1)
+select * from t where a > (select count(1) from cte where x > t.a + random());
+ a | b 
+---+---
+(0 rows)
+
+reset optimizer;
+drop table outer_foo;
+drop table inner_bar;
+drop table t;

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3970,3 +3970,95 @@ select (select b from bar)[(select 1)][1:3] from bar;
 (1 row)
 
 drop table bar;
+create table outer_foo(a int primary key, b int);
+create table inner_bar(a int, b int) distributed randomly;
+insert into outer_foo values (generate_series(1,20), generate_series(11,30));
+insert into inner_bar values (generate_series(1,20), generate_series(25,44));
+set optimizer to off;
+explain (costs off) select t1.a from outer_foo t1,  LATERAL(SELECT  distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         Merge Key: t1.a
+         ->  Index Scan using outer_foo_pkey on outer_foo t1
+   ->  Materialize
+         ->  HashAggregate
+               Group Key: t2.a
+               ->  Result
+                     Filter: (t1.b = t2.b)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on inner_bar t2
+ Optimizer: Postgres-based planner
+(13 rows)
+
+explain (costs off) select t1.a from outer_foo t1,  LATERAL(SELECT  distinct t2.a from inner_bar t2 where t1.b=t2.b) q;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Nested Loop
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on outer_foo t1
+   ->  Materialize
+         ->  HashAggregate
+               Group Key: t2.a
+               ->  Result
+                     Filter: (t1.b = t2.b)
+                     ->  Materialize
+                           ->  Gather Motion 3:1  (slice2; segments: 3)
+                                 ->  Seq Scan on inner_bar t2
+ Optimizer: Postgres-based planner
+(12 rows)
+
+select t1.a from outer_foo t1,  LATERAL(SELECT  distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1;
+ a  
+----
+ 15
+ 16
+ 17
+ 18
+ 19
+ 20
+(6 rows)
+
+create table t(a int, b int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off) with cte(x) as (select t1.a from outer_foo t1, LATERAL(SELECT distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1)
+select * from t where a > (select count(1) from cte where x > t.a + random());
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on t
+         Filter: (a > (SubPlan 1))
+         SubPlan 1
+           ->  Aggregate
+                 ->  Result
+                       Filter: ((t1.a)::double precision > ((t.a)::double precision + random()))
+                       ->  Nested Loop
+                             ->  Materialize
+                                   ->  Sort
+                                         Sort Key: t1.a
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                               ->  Index Scan using outer_foo_pkey on outer_foo t1
+                             ->  Materialize
+                                   ->  HashAggregate
+                                         Group Key: t2.a
+                                         ->  Result
+                                               Filter: (t1.b = t2.b)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                           ->  Seq Scan on inner_bar t2
+ Optimizer: Postgres-based planner
+(22 rows)
+
+with cte(x) as (select t1.a from outer_foo t1, LATERAL(SELECT distinct t2.a from inner_bar t2 where t1.b=t2.b) q order by 1)
+select * from t where a > (select count(1) from cte where x > t.a + random());
+ a | b 
+---+---
+(0 rows)
+
+reset optimizer;
+drop table outer_foo;
+drop table inner_bar;
+drop table t;


### PR DESCRIPTION
Fix issue: #14682

The following codes in cdbpathtoplan_create_motion_plan will ignore path->path.pathkeys,
Which lead to incorrect results.
``` 
else if (CdbPathLocus_IsOuterQuery(path->path.locus))
{
	motion = make_union_motion(subplan);
	motion->motionType = MOTIONTYPE_OUTER_QUERY;
}
```
So use make_sorted_union_motion instead of make_union_motion if path has pathkeys.