### PR TITLE
Handle Invalid Return Value For Opfamily Mdid.

### DIFF
--- a/src/backend/gporca/data/dxl/minidump/ParallelUnionAllWithJson.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ParallelUnionAllWithJson.mdp
@@ -1,0 +1,445 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dxl:DXLMessage xmlns:dxl="http://greenplum.com/dxl/2010/12/">
+  <dxl:Comment><![CDATA[
+        Objective: To check parallel union all with 'json' type 1st column in project list
+        Setup:
+         set optimizer_parallel_union to on;
+         create table my_table ( id serial  primary key, json_data json);
+         insert into my_table (json_data) values ('{"name": "Name1", "age": 10}');
+         insert into my_table (json_data) values ('{"name": "Name2", "age": 20}');
+         insert into my_table (json_data) values ('{"name": "Name3", "age": 30}');
+         insert into my_table (json_data) values ('{"name": "Name4", "age": 40}');
+         explain select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+                                              QUERY PLAN
+         -------------------------------------------------------------------------------------------------------
+         Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=29)
+           ->  Append  (cost=0.00..431.00 rows=1 width=29)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=29)
+                       ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=29)
+                             Hash Key: my_table.id
+                             ->  Result  (cost=0.00..431.00 rows=1 width=33)
+                                   ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=33)
+                                         Filter: ((json_data ->> 'age'::text) = '30'::text)
+                 ->  Result  (cost=0.00..431.00 rows=1 width=29)
+                       ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=29)
+                             Hash Key: my_table_1.id
+                             ->  Result  (cost=0.00..431.00 rows=1 width=33)
+                                   ->  Seq Scan on my_table my_table_1  (cost=0.00..431.00 rows=1 width=33)
+                                         Filter: ((json_data ->> 'age'::text) = '40'::text)
+          Optimizer: Pivotal Optimizer (GPORCA)
+         (15 rows)
+        Output for ref:
+         select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+                   json_data
+         ------------------------------
+          {"name": "Name3", "age": 30}
+          {"name": "Name4", "age": 40}
+         (2 rows)
+   ]]>
+  </dxl:Comment>
+  <dxl:Thread Id="0">
+    <dxl:OptimizerConfig>
+      <dxl:EnumeratorConfig Id="0" PlanSamples="0" CostThreshold="0"/>
+      <dxl:StatisticsConfig DampingFactorFilter="0.750000" DampingFactorJoin="0.000000" DampingFactorGroupBy="0.750000" MaxStatsBuckets="100"/>
+      <dxl:CTEConfig CTEInliningCutoff="0"/>
+      <dxl:WindowOids RowNumber="3100" Rank="3101"/>
+      <dxl:CostModelConfig CostModelType="1" SegmentsForCosting="3">
+        <dxl:CostParams>
+          <dxl:CostParam Name="NLJFactor" Value="1024.000000" LowerBound="1023.500000" UpperBound="1024.500000"/>
+        </dxl:CostParams>
+      </dxl:CostModelConfig>
+      <dxl:Hint JoinArityForAssociativityCommutativity="18" ArrayExpansionThreshold="100" JoinOrderDynamicProgThreshold="10" BroadcastThreshold="100000" EnforceConstraintsOnDML="false" PushGroupByBelowSetopThreshold="10" XformBindThreshold="0" SkewFactor="0"/>
+      <dxl:TraceFlags Value="101013,102074,102120,102146,102155,102156,103001,103014,103022,103027,103029,103038,103041,104002,104003,104004,104005,106000"/>
+    </dxl:OptimizerConfig>
+    <dxl:Metadata SystemIds="0.GPDB">
+      <dxl:GPDBFunc Mdid="0.16385.1.0" Name="any_func" ReturnsSet="false" Stability="Immutable" DataAccess="ContainsSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.1082.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:Type Mdid="0.16.1.0" Name="bool" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="1" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2222.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7124.1.0"/>
+        <dxl:EqualityOp Mdid="0.91.1.0"/>
+        <dxl:InequalityOp Mdid="0.85.1.0"/>
+        <dxl:LessThanOp Mdid="0.58.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1694.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.59.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1695.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1693.1.0"/>
+        <dxl:ArrayType Mdid="0.1000.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.23.1.0" Name="int4" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7100.1.0"/>
+        <dxl:EqualityOp Mdid="0.96.1.0"/>
+        <dxl:InequalityOp Mdid="0.518.1.0"/>
+        <dxl:LessThanOp Mdid="0.97.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.523.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.521.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.525.1.0"/>
+        <dxl:ComparisonOp Mdid="0.351.1.0"/>
+        <dxl:ArrayType Mdid="0.1007.1.0"/>
+        <dxl:MinAgg Mdid="0.2132.1.0"/>
+        <dxl:MaxAgg Mdid="0.2116.1.0"/>
+        <dxl:AvgAgg Mdid="0.2101.1.0"/>
+        <dxl:SumAgg Mdid="0.2108.1.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.26.1.0" Name="oid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.1990.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7109.1.0"/>
+        <dxl:EqualityOp Mdid="0.607.1.0"/>
+        <dxl:InequalityOp Mdid="0.608.1.0"/>
+        <dxl:LessThanOp Mdid="0.609.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.611.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.610.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.612.1.0"/>
+        <dxl:ComparisonOp Mdid="0.356.1.0"/>
+        <dxl:ArrayType Mdid="0.1028.1.0"/>
+        <dxl:MinAgg Mdid="0.2134.1.0"/>
+        <dxl:MaxAgg Mdid="0.2118.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.27.1.0" Name="tid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="6" PassByValue="false">
+        <dxl:DistrOpfamily Mdid="0.7077.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7110.1.0"/>
+        <dxl:EqualityOp Mdid="0.387.1.0"/>
+        <dxl:InequalityOp Mdid="0.402.1.0"/>
+        <dxl:LessThanOp Mdid="0.2799.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.2801.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.2800.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.2802.1.0"/>
+        <dxl:ComparisonOp Mdid="0.2794.1.0"/>
+        <dxl:ArrayType Mdid="0.1010.1.0"/>
+        <dxl:MinAgg Mdid="0.2798.1.0"/>
+        <dxl:MaxAgg Mdid="0.2797.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.29.1.0" Name="cid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2226.1.0"/>
+        <dxl:EqualityOp Mdid="0.385.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1012.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:Type Mdid="0.28.1.0" Name="xid" IsRedistributable="true" IsHashable="true" IsMergeJoinable="false" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.2225.1.0"/>
+        <dxl:EqualityOp Mdid="0.352.1.0"/>
+        <dxl:InequalityOp Mdid="0.0.0.0"/>
+        <dxl:LessThanOp Mdid="0.0.0.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanOp Mdid="0.0.0.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.0.0.0"/>
+        <dxl:ComparisonOp Mdid="0.0.0.0"/>
+        <dxl:ArrayType Mdid="0.1011.1.0"/>
+        <dxl:MinAgg Mdid="0.0.0.0"/>
+        <dxl:MaxAgg Mdid="0.0.0.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBFunc Mdid="0.16438.1.0" Name="ret_date" ReturnsSet="false" Stability="Stable" DataAccess="NoSQL" IsStrict="false" IsNDVPreserving="false" IsAllowedForPS="false">
+        <dxl:ResultType Mdid="0.1082.1.0"/>
+      </dxl:GPDBFunc>
+      <dxl:ColumnStatistics Mdid="1.45667.1.0.1" Name="dtrepdate" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:ColumnStatistics Mdid="1.45667.1.0.0" Name="nagreementid" Width="4.000000" NullFreq="0.000000" NdvRemain="0.000000" FreqRemain="0.000000" ColStatsMissing="true"/>
+      <dxl:Type Mdid="0.1082.1.0" Name="date" IsRedistributable="true" IsHashable="true" IsMergeJoinable="true" IsComposite="false" IsTextRelated="false" IsFixedLength="true" Length="4" PassByValue="true">
+        <dxl:DistrOpfamily Mdid="0.435.1.0"/>
+        <dxl:LegacyDistrOpfamily Mdid="0.7113.1.0"/>
+        <dxl:EqualityOp Mdid="0.1093.1.0"/>
+        <dxl:InequalityOp Mdid="0.1094.1.0"/>
+        <dxl:LessThanOp Mdid="0.1095.1.0"/>
+        <dxl:LessThanEqualsOp Mdid="0.1096.1.0"/>
+        <dxl:GreaterThanOp Mdid="0.1097.1.0"/>
+        <dxl:GreaterThanEqualsOp Mdid="0.1098.1.0"/>
+        <dxl:ComparisonOp Mdid="0.1092.1.0"/>
+        <dxl:ArrayType Mdid="0.1182.1.0"/>
+        <dxl:MinAgg Mdid="0.2138.1.0"/>
+        <dxl:MaxAgg Mdid="0.2122.1.0"/>
+        <dxl:AvgAgg Mdid="0.0.0.0"/>
+        <dxl:SumAgg Mdid="0.0.0.0"/>
+        <dxl:CountAgg Mdid="0.2147.1.0"/>
+      </dxl:Type>
+      <dxl:GPDBScalarOp Mdid="0.1093.1.0" Name="=" ComparisonType="Eq" ReturnsNullOnNullInput="true" IsNDVPreserving="false">
+        <dxl:LeftType Mdid="0.1082.1.0"/>
+        <dxl:RightType Mdid="0.1082.1.0"/>
+        <dxl:ResultType Mdid="0.16.1.0"/>
+        <dxl:OpFunc Mdid="0.1086.1.0"/>
+        <dxl:Commutator Mdid="0.1093.1.0"/>
+        <dxl:InverseOp Mdid="0.1094.1.0"/>
+        <dxl:HashOpfamily Mdid="0.435.1.0"/>
+        <dxl:LegacyHashOpfamily Mdid="0.7113.1.0"/>
+        <dxl:Opfamilies>
+          <dxl:Opfamily Mdid="0.434.1.0"/>
+          <dxl:Opfamily Mdid="0.435.1.0"/>
+          <dxl:Opfamily Mdid="0.7022.1.0"/>
+          <dxl:Opfamily Mdid="0.7113.1.0"/>
+        </dxl:Opfamilies>
+      </dxl:GPDBScalarOp>
+      <dxl:RelationStatistics Mdid="2.45667.1.0" Name="test_partitioned_2024" Rows="0.000000" RelPages="0" RelAllVisible="0" EmptyRelation="true"/>
+      <dxl:Relation Mdid="6.45667.1.0" Name="test_partitioned_2024" IsTemporary="false" HasOids="false" StorageType="Heap" DistributionPolicy="Hash" DistributionColumns="0" Keys="7,8,2" PartitionColumns="1" PartitionTypes="r" NumberLeafPartitions="12">
+        <dxl:Columns>
+          <dxl:Column Name="nagreementid" Attno="1" Mdid="0.23.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="dtrepdate" Attno="2" Mdid="0.1082.1.0" Nullable="true" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="ctid" Attno="-1" Mdid="0.27.1.0" Nullable="false" ColWidth="6">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmin" Attno="-3" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmin" Attno="-4" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="xmax" Attno="-5" Mdid="0.28.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="cmax" Attno="-6" Mdid="0.29.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="tableoid" Attno="-7" Mdid="0.26.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+          <dxl:Column Name="gp_segment_id" Attno="-8" Mdid="0.23.1.0" Nullable="false" ColWidth="4">
+            <dxl:DefaultValue/>
+          </dxl:Column>
+        </dxl:Columns>
+        <dxl:IndexInfoList/>
+        <dxl:Triggers/>
+        <dxl:CheckConstraints/>
+        <dxl:DistrOpfamilies>
+          <dxl:DistrOpfamily Mdid="0.1977.1.0"/>
+        </dxl:DistrOpfamilies>
+      </dxl:Relation>
+      <dxl:GPDBAgg Mdid="0.2138.1.0" Name="min" IsSplittable="true" HashAggCapable="true">
+        <dxl:ResultType Mdid="0.1082.1.0"/>
+        <dxl:IntermediateResultType Mdid="0.1082.1.0"/>
+      </dxl:GPDBAgg>
+    </dxl:Metadata>
+    <dxl:Query>
+      <dxl:OutputColumns>
+        <dxl:Ident ColId="12" ColName="min" TypeMdid="0.1082.1.0"/>
+      </dxl:OutputColumns>
+      <dxl:CTEList/>
+      <dxl:LogicalProject>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="12" Alias="min">
+            <dxl:ScalarSubquery ColId="11">
+              <dxl:LogicalGroupBy>
+                <dxl:GroupingColumns/>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="11" Alias="min">
+                    <dxl:AggFunc AggMdid="0.2138.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                      <dxl:ValuesList ParamType="aggargs">
+                        <dxl:Ident ColId="3" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                      </dxl:ValuesList>
+                      <dxl:ValuesList ParamType="aggdirectargs"/>
+                      <dxl:ValuesList ParamType="aggorder"/>
+                      <dxl:ValuesList ParamType="aggdistinct"/>
+                    </dxl:AggFunc>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:LogicalSelect>
+                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
+                    <dxl:Ident ColId="3" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                    <dxl:ConstValue TypeMdid="0.1082.1.0" Value="eiIAAA==" LintValue="8826"/>
+                  </dxl:Comparison>
+                  <dxl:LogicalGet>
+                    <dxl:TableDescriptor Mdid="6.45667.1.0" TableName="test_partitioned_2024">
+                      <dxl:Columns>
+                        <dxl:Column ColId="2" Attno="1" ColName="nagreementid" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="3" Attno="2" ColName="dtrepdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="4" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="5" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="10" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:LogicalGet>
+                </dxl:LogicalSelect>
+              </dxl:LogicalGroupBy>
+            </dxl:ScalarSubquery>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:LogicalConstTable>
+          <dxl:Columns>
+            <dxl:Column ColId="1" Attno="1" ColName="" TypeMdid="0.16.1.0"/>
+          </dxl:Columns>
+          <dxl:ConstTuple>
+            <dxl:Datum TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:ConstTuple>
+        </dxl:LogicalConstTable>
+      </dxl:LogicalProject>
+    </dxl:Query>
+    <dxl:Plan Id="0" SpaceSize="24">
+      <dxl:Result>
+        <dxl:Properties>
+          <dxl:Cost StartupCost="0" TotalCost="882688.088536" Rows="1.000000" Width="4"/>
+        </dxl:Properties>
+        <dxl:ProjList>
+          <dxl:ProjElem ColId="11" Alias="min">
+            <dxl:Ident ColId="10" ColName="min" TypeMdid="0.1082.1.0"/>
+          </dxl:ProjElem>
+        </dxl:ProjList>
+        <dxl:Filter/>
+        <dxl:OneTimeFilter/>
+        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:Properties>
+            <dxl:Cost StartupCost="0" TotalCost="882688.088532" Rows="2.000000" Width="4"/>
+          </dxl:Properties>
+          <dxl:ProjList>
+            <dxl:ProjElem ColId="10" Alias="min">
+              <dxl:Ident ColId="10" ColName="min" TypeMdid="0.1082.1.0"/>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:JoinFilter>
+            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+          </dxl:JoinFilter>
+          <dxl:Result>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="0" Alias="">
+                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:OneTimeFilter/>
+          </dxl:Result>
+          <dxl:Materialize Eager="false">
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="431.000040" Rows="1.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList>
+              <dxl:ProjElem ColId="10" Alias="min">
+                <dxl:Ident ColId="10" ColName="min" TypeMdid="0.1082.1.0"/>
+              </dxl:ProjElem>
+            </dxl:ProjList>
+            <dxl:Filter/>
+            <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000036" Rows="1.000000" Width="4"/>
+              </dxl:Properties>
+              <dxl:GroupingColumns/>
+              <dxl:ProjList>
+                <dxl:ProjElem ColId="10" Alias="min">
+                  <dxl:AggFunc AggMdid="0.2138.1.0" AggDistinct="false" AggStage="Normal" AggKind="n">
+                    <dxl:ValuesList ParamType="aggargs">
+                      <dxl:Ident ColId="2" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                    </dxl:ValuesList>
+                    <dxl:ValuesList ParamType="aggdirectargs"/>
+                    <dxl:ValuesList ParamType="aggorder"/>
+                    <dxl:ValuesList ParamType="aggdistinct"/>
+                  </dxl:AggFunc>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="431.000035" Rows="1.000000" Width="4"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="2" Alias="dtrepdate">
+                    <dxl:Ident ColId="2" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:SortingColumnList/>
+                <dxl:Sequence>
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="2" Alias="dtrepdate">
+                      <dxl:Ident ColId="2" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:PartitionSelector RelationMdid="6.45667.1.0" PartitionLevels="1" ScanId="1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="10" TotalCost="100" Rows="100" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList/>
+                    <dxl:PartEqFilters>
+                      <dxl:PartEqFilterElems>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="eiIAAA==" LintValue="8826"/>
+                      </dxl:PartEqFilterElems>
+                    </dxl:PartEqFilters>
+                    <dxl:PartFilters>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:PartFilters>
+                    <dxl:ResidualFilter>
+                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                    </dxl:ResidualFilter>
+                    <dxl:PropagationExpression>
+                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                    </dxl:PropagationExpression>
+                    <dxl:PrintableFilter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
+                        <dxl:Ident ColId="2" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="eiIAAA==" LintValue="8826"/>
+                      </dxl:Comparison>
+                    </dxl:PrintableFilter>
+                  </dxl:PartitionSelector>
+                  <dxl:DynamicTableScan PartIndexId="1">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000020" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="2" Alias="dtrepdate">
+                        <dxl:Ident ColId="2" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter>
+                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.1093.1.0">
+                        <dxl:Ident ColId="2" ColName="dtrepdate" TypeMdid="0.1082.1.0"/>
+                        <dxl:ConstValue TypeMdid="0.1082.1.0" Value="eiIAAA==" LintValue="8826"/>
+                      </dxl:Comparison>
+                    </dxl:Filter>
+                    <dxl:TableDescriptor Mdid="6.45667.1.0" TableName="test_partitioned_2024">
+                      <dxl:Columns>
+                        <dxl:Column ColId="1" Attno="1" ColName="nagreementid" TypeMdid="0.23.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="2" Attno="2" ColName="dtrepdate" TypeMdid="0.1082.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                        <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                        <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:DynamicTableScan>
+                </dxl:Sequence>
+              </dxl:GatherMotion>
+            </dxl:Aggregate>
+          </dxl:Materialize>
+        </dxl:NestedLoopJoin>
+      </dxl:Result>
+    </dxl:Plan>
+  </dxl:Thread>
+</dxl:DXLMessage>

--- a/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CDistributionSpecHashed.cpp
@@ -114,7 +114,15 @@ CDistributionSpecHashed::PopulateDefaultOpfamilies()
 		IMDId *mdid_type = CScalar::PopConvert(expr->Pop())->MdidType();
 		IMDId *mdid_opfamily =
 			mda->RetrieveType(mdid_type)->GetDistrOpfamilyMdid();
-		GPOS_ASSERT(NULL != mdid_opfamily && mdid_opfamily->IsValid());
+		if (NULL == mdid_opfamily || !mdid_opfamily->IsValid())
+		{
+			// For a data type the retrieved opfamily can be 'InvalidOid'.
+			// Eg - For 'json', the distribution opfamily is 'InvalidOid'.
+			// Using an InvalidOid can lead to crash.
+			m_opfamilies->Release();
+			m_opfamilies = NULL;
+			return;
+		}
 		mdid_opfamily->AddRef();
 		m_opfamilies->Append(mdid_opfamily);
 	}

--- a/src/backend/gporca/server/CMakeLists.txt
+++ b/src/backend/gporca/server/CMakeLists.txt
@@ -262,7 +262,7 @@ CSetop4Test:
 PushSelectDownUnionAllOfCTG Push-Subplan-Below-Union Intersect-OuterRefs
 PushSelectWithOuterRefBelowUnion PushGbBelowUnion UnionGbSubquery MS-UnionAll-4
 AnyPredicate-Over-UnionOfConsts EquivClassesUnion EquivClassesIntersect
-IndexScanWithNestedCTEAndSetOp Blocking-Spool-Parallel-Union-All;
+IndexScanWithNestedCTEAndSetOp Blocking-Spool-Parallel-Union-All ParallelUnionAllWithJson;
 
 CEquivClassTest:
 Equiv-HashedDistr-1 Equiv-HashedDistr-2 EquivClassesAndOr EquivClassesLimit IndexNLJoin_Cast_NoMotion;

--- a/src/test/regress/expected/union.out
+++ b/src/test/regress/expected/union.out
@@ -799,3 +799,54 @@ select * from
 reset optimizer_trace_fallback;
 drop table t3;
 drop function expensivefunc(int);
+-------------------------------------------------------------------------------
+--Test case to check parallel union all with 'json' type 1st column in project list
+-------------------------------------------------------------------------------
+set optimizer_parallel_union to on;
+drop table if exists my_table;
+NOTICE:  table "my_table" does not exist, skipping
+create table my_table ( id serial  primary key, json_data json);
+insert into my_table (json_data) values ('{"name": "Name1", "age": 10}');
+insert into my_table (json_data) values ('{"name": "Name2", "age": 20}');
+insert into my_table (json_data) values ('{"name": "Name3", "age": 30}');
+insert into my_table (json_data) values ('{"name": "Name4", "age": 40}');
+explain select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.05 rows=2 width=29)
+   ->  Append  (cost=0.00..2.05 rows=1 width=29)
+         ->  Seq Scan on my_table  (cost=0.00..1.01 rows=1 width=29)
+               Filter: ((json_data ->> 'age'::text) = '30'::text)
+         ->  Seq Scan on my_table my_table_1  (cost=0.00..1.01 rows=1 width=29)
+               Filter: ((json_data ->> 'age'::text) = '40'::text)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+          json_data           
+------------------------------
+ {"name": "Name3", "age": 30}
+ {"name": "Name4", "age": 40}
+(2 rows)
+
+explain select json_data,id from my_table  where json_data->>'age' = '30' union all select json_data,id from my_table where json_data->>'age' = '40' ;
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..2.05 rows=2 width=33)
+   ->  Append  (cost=0.00..2.05 rows=1 width=33)
+         ->  Seq Scan on my_table  (cost=0.00..1.01 rows=1 width=33)
+               Filter: ((json_data ->> 'age'::text) = '30'::text)
+         ->  Seq Scan on my_table my_table_1  (cost=0.00..1.01 rows=1 width=33)
+               Filter: ((json_data ->> 'age'::text) = '40'::text)
+ Optimizer: Postgres query optimizer
+(7 rows)
+
+select json_data,id from my_table  where json_data->>'age' = '30' union all select json_data,id from my_table where json_data->>'age' = '40' ;
+          json_data           | id 
+------------------------------+----
+ {"name": "Name3", "age": 30} |  3
+ {"name": "Name4", "age": 40} |  4
+(2 rows)
+
+set optimizer_parallel_union to off;
+drop table if exists my_table;

--- a/src/test/regress/expected/union_optimizer.out
+++ b/src/test/regress/expected/union_optimizer.out
@@ -865,3 +865,68 @@ select * from
 reset optimizer_trace_fallback;
 drop table t3;
 drop function expensivefunc(int);
+-------------------------------------------------------------------------------
+--Test case to check parallel union all with 'json' type 1st column in project list
+-------------------------------------------------------------------------------
+set optimizer_parallel_union to on;
+drop table if exists my_table;
+NOTICE:  table "my_table" does not exist, skipping
+create table my_table ( id serial  primary key, json_data json);
+insert into my_table (json_data) values ('{"name": "Name1", "age": 10}');
+insert into my_table (json_data) values ('{"name": "Name2", "age": 20}');
+insert into my_table (json_data) values ('{"name": "Name3", "age": 30}');
+insert into my_table (json_data) values ('{"name": "Name4", "age": 40}');
+explain select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+                                              QUERY PLAN                                               
+-------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=29)
+   ->  Append  (cost=0.00..431.00 rows=1 width=29)
+         ->  Result  (cost=0.00..431.00 rows=1 width=29)
+               ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=29)
+                     Hash Key: my_table.id
+                     ->  Result  (cost=0.00..431.00 rows=1 width=33)
+                           ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=33)
+                                 Filter: ((json_data ->> 'age'::text) = '30'::text)
+         ->  Result  (cost=0.00..431.00 rows=1 width=29)
+               ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=29)
+                     Hash Key: my_table_1.id
+                     ->  Result  (cost=0.00..431.00 rows=1 width=33)
+                           ->  Seq Scan on my_table my_table_1  (cost=0.00..431.00 rows=1 width=33)
+                                 Filter: ((json_data ->> 'age'::text) = '40'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(15 rows)
+
+select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+          json_data           
+------------------------------
+ {"name": "Name3", "age": 30}
+ {"name": "Name4", "age": 40}
+(2 rows)
+
+explain select json_data,id from my_table  where json_data->>'age' = '30' union all select json_data,id from my_table where json_data->>'age' = '40' ;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..431.00 rows=2 width=33)
+   ->  Append  (cost=0.00..431.00 rows=1 width=33)
+         ->  Redistribute Motion 3:3  (slice1; segments: 3)  (cost=0.00..431.00 rows=1 width=33)
+               Hash Key: my_table.id
+               ->  Result  (cost=0.00..431.00 rows=1 width=33)
+                     ->  Seq Scan on my_table  (cost=0.00..431.00 rows=1 width=33)
+                           Filter: ((json_data ->> 'age'::text) = '30'::text)
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=33)
+               Hash Key: my_table_1.id
+               ->  Result  (cost=0.00..431.00 rows=1 width=33)
+                     ->  Seq Scan on my_table my_table_1  (cost=0.00..431.00 rows=1 width=33)
+                           Filter: ((json_data ->> 'age'::text) = '40'::text)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(13 rows)
+
+select json_data,id from my_table  where json_data->>'age' = '30' union all select json_data,id from my_table where json_data->>'age' = '40' ;
+          json_data           | id 
+------------------------------+----
+ {"name": "Name3", "age": 30} |  3
+ {"name": "Name4", "age": 40} |  4
+(2 rows)
+
+set optimizer_parallel_union to off;
+drop table if exists my_table;

--- a/src/test/regress/sql/union.sql
+++ b/src/test/regress/sql/union.sql
@@ -367,3 +367,23 @@ reset optimizer_trace_fallback;
 
 drop table t3;
 drop function expensivefunc(int);
+
+-------------------------------------------------------------------------------
+--Test case to check parallel union all with 'json' type 1st column in project list
+-------------------------------------------------------------------------------
+set optimizer_parallel_union to on;
+drop table if exists my_table;
+create table my_table ( id serial  primary key, json_data json);
+insert into my_table (json_data) values ('{"name": "Name1", "age": 10}');
+insert into my_table (json_data) values ('{"name": "Name2", "age": 20}');
+insert into my_table (json_data) values ('{"name": "Name3", "age": 30}');
+insert into my_table (json_data) values ('{"name": "Name4", "age": 40}');
+
+explain select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+select json_data from my_table  where json_data->>'age' = '30' union all select json_data from my_table where json_data->>'age' = '40' ;
+
+explain select json_data,id from my_table  where json_data->>'age' = '30' union all select json_data,id from my_table where json_data->>'age' = '40' ;
+select json_data,id from my_table  where json_data->>'age' = '30' union all select json_data,id from my_table where json_data->>'age' = '40' ;
+
+set optimizer_parallel_union to off;
+drop table if exists my_table;


### PR DESCRIPTION
It was observed that while populating default opfamilies in PopulateDefaultOpfamilies(), for some of the operator the retrieved opfamily can be 'InvalidOid'. Eg - For 'json', the distribution opfamily is 'InvalidOid'. 

Using this invalid value for further processing leads to crash in ORCA. To prevent this condition, a check is added before using the mdid of opfamily.

This is a back port of [PR 17165 ](https://github.com/greenplum-db/gpdb/pull/17165)
