### PR TITLE
skip pg_description and pg_shdescription tables with gpcheckcat missing/extra tests

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -1340,14 +1340,15 @@ def _checkAllTablesForMissingEntries():
     catalog_issues = {}
     tables = GV.catalog.getCatalogTables()
     for catalog_table_obj in tables:
-        issues = checkTableMissingEntry(catalog_table_obj)
-        if not issues:
-            continue
         catalog_name = catalog_table_obj.getTableName()
-        _, pk_name = getPrimaryKeyColumn(catalog_name, catalog_table_obj.getPrimaryKey())
-        # We do this check in this function rather than getPrimaryKeyColumn as
-        # it is used in checkACL and we do not want to modify that functionality
-        catalog_issues[(catalog_table_obj, pk_name)] = issues
+        if catalog_name != "pg_description" and catalog_name != "pg_shdescription":
+            issues = checkTableMissingEntry(catalog_table_obj)
+            if not issues:
+                continue
+            _, pk_name = getPrimaryKeyColumn(catalog_name, catalog_table_obj.getPrimaryKey())
+            # We do this check in this function rather than getPrimaryKeyColumn as
+            # it is used in checkACL and we do not want to modify that functionality
+            catalog_issues[(catalog_table_obj, pk_name)] = issues
     return catalog_issues
 # -------------------------------------------------------------------------------
 

--- a/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
+++ b/gpMgmt/bin/gppylib/test/unit/test_unit_gpcheckcat.py
@@ -255,10 +255,15 @@ class GpCheckCatTestCase(GpTestCase):
         self.subject.checkForeignKey.assert_called_once_with([cat_obj_mock])
 
     @patch('gpcheckcat.checkTableMissingEntry', return_value = None)
-    def test_checkMissingEntry__no_issues(self, mock1):
+    @patch('gpcheckcat.GV.catalog' )
+    def test_checkMissingEntry__no_issues(self, mock1, mock_getCatalog):
         cat_mock = Mock()
-        cat_tables = ["input1", "input2"]
-        cat_mock.getCatalogTables.return_value = cat_tables
+        mock_tables = [
+            MockCatalogTable("input1"),
+            MockCatalogTable("input2"),
+        ]
+        # Set the return value of the mocked method
+        cat_mock.getCatalogTables.return_value = mock_tables
         self.subject.GV.catalog = cat_mock
 
         self.subject.runOneCheck("missing_extraneous")
@@ -298,6 +303,23 @@ class GpCheckCatTestCase(GpTestCase):
 
         self.assertEqual(aTable.getPrimaryKey.call_count, 1)
         self.subject.setError.assert_called_once_with(self.subject.ERROR_REMOVE)
+
+    @patch('gpcheckcat.checkTableMissingEntry', return_value = None)
+    @patch('gpcheckcat.GV.catalog' )
+    def test_checkMissingEntry__ignores_pg_description(self, mock1, mock2):
+        cat_mock = Mock()
+        mock_tables = [
+            MockCatalogTable("pg_description"),
+            MockCatalogTable("pg_shdescription"),
+        ]
+        # Set the return value of the mocked method
+        cat_mock.getCatalogTables.return_value = mock_tables
+        self.subject.GV.catalog = cat_mock
+
+        self.subject.runOneCheck("missing_extraneous")
+
+        self.assertTrue(self.subject.GV.missingEntryStatus)
+        self.subject.setError.assert_not_called()
 
     def test_getReportConfiguration_uses_contentid(self):
         report_cfg = self.subject.getReportConfiguration()
@@ -441,6 +463,17 @@ class GpCheckCatTestCase(GpTestCase):
                 self.num_batches += 1
                 self.num_joins = 0
                 self.num_starts = 0
+
+# Define a mock class to represent CatalogTable objects
+class MockCatalogTable:
+    def __init__(self, table_name):
+        self.table_name = table_name
+
+    def getTableName(self):
+        return self.table_name
+
+    def getCatalogTables(self):
+        return self
 class Global():
     def __init__(self):
         self.opt = {}

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckcat.feature
@@ -744,12 +744,9 @@ Feature: gpcheckcat tests
         Then psql should return a return code of 0
         When the user runs "psql miss_attr_db5 -c "SET allow_system_table_mods=true; DELETE FROM pg_shdescription where objoid=(SELECT oid from pg_tablespace where spcname='outerspace');""
         Then psql should return a return code of 0
-        When the user runs "gpcheckcat miss_attr_db5"
-        Then gpcheckcat should print "Missing description metadata of {.*} on content -1" to stdout
-        And gpcheckcat should not print "Execution error:" to stdout
-        And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_description" to stdout
-        Then gpcheckcat should print "Missing shdescription metadata of {.*} on content -1" to stdout
-        And gpcheckcat should print "Name of test which found this issue: missing_extraneous_pg_shdescription" to stdout
+        When the user runs "gpcheckcat -R missing_extraneous miss_attr_db5"
+        Then gpcheckcat should print "PASSED" to stdout
+        And the user runs "dropdb miss_attr_db5"
 
     Scenario: set multiple GUC at session level in gpcheckcat
         Given database "all_good" is dropped and recreated


### PR DESCRIPTION

Issue:
gpcheckcat missing_extraneous test reported errors when gpdb was upgraded from older version to a newer version after performing gpexpand.

RCA:
This is a false alarm and the catalog tables can be skipped during gpcheckcat missing_extraneous test

Solution:
gpcheckcat is modified to skip the tables during missing/extra tests.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
