### PR TITLE
Backport upstream upgrade check improvements for roles starting with "pg_"

### DIFF
--- a/src/bin/pg_upgrade/check.c
+++ b/src/bin/pg_upgrade/check.c
@@ -1306,27 +1306,52 @@ check_for_pg_role_prefix(ClusterInfo *cluster)
 {
 	PGresult   *res;
 	PGconn	   *conn = connectToServer(cluster, "template1");
+	int			ntups;
+	int			i_roloid;
+	int			i_rolname;
+	FILE	   *script = NULL;
+	char		output_path[MAXPGPATH];
 
 	prep_status("Checking for roles starting with \"pg_\"");
 
+	snprintf(output_path, sizeof(output_path), "%s/%s",
+			 log_opts.basedir,
+			 "pg_role_prefix.txt");
+
 	res = executeQueryOrDie(conn,
-							"SELECT * "
+							"SELECT oid AS roloid, rolname "
 							"FROM pg_catalog.pg_roles "
 							"WHERE rolname ~ '^pg_'");
 
-	if (PQntuples(res) != 0)
+	ntups = PQntuples(res);
+	i_roloid = PQfnumber(res, "roloid");
+	i_rolname = PQfnumber(res, "rolname");
+	for (int rowno = 0; rowno < ntups; rowno++)
 	{
-		if (cluster == &old_cluster)
-			gp_fatal_log("The source cluster contains roles starting with \"pg_\"\n");
-		else
-			gp_fatal_log("The target cluster contains roles starting with \"pg_\"\n");
+		if (script == NULL && (script = fopen_priv(output_path, "w")) == NULL)
+			gp_fatal_log("could not open file \"%s\": %s",
+					 output_path, strerror(errno));
+		fprintf(script, "%s (oid=%s)\n",
+				PQgetvalue(res, rowno, i_rolname),
+				PQgetvalue(res, rowno, i_roloid));
 	}
 
 	PQclear(res);
 
 	PQfinish(conn);
 
-	check_ok();
+	if (script)
+	{
+		fclose(script);
+		pg_log(PG_REPORT, "fatal\n");
+		gp_fatal_log("| Your installation contains roles starting with \"pg_\".\n"
+				 "| \"pg_\" is a reserved prefix for system roles, the cluster\n"
+				 "| cannot be upgraded until these roles are renamed.\n"
+				 "| A list of roles starting with \"pg_\" is in the file:\n"
+				 "|     %s", output_path);
+	}
+	else
+		check_ok();
 }
 
 


### PR DESCRIPTION
Running pg_upgrade -c and checking for roles starting with "pg_" prefix doesn't say "fatal" when there is an error, instead it says "ok"
These changes corrects the output to show "fatal" on failure and also gets the user a list of all roles that failed the check

Sample output:
```
Checking for tables WITH OIDS                               ok
Checking for invalid "sql_identifier" user columns          ok
Checking for invalid "unknown" user columns                 ok
Checking for hash indexes                                   ok
Checking for roles starting with "pg_"                      fatal
| Your installation contains roles starting with "pg_".
| "pg_" is a reserved prefix for system roles, the cluster
| cannot be upgraded until these roles are renamed.
| A list of roles starting with "pg_" is in the file:
|  /Users/vanjared/gpAdminLogs/pg_upgrade_output.d/20240321T113617.440/pg_role_prefix.txt
Checking for appendonly materialized view with relfrozenxid ok
  ```

Cherry-pick diff in gp: use gp_fatal_log function for continuing on errors
