### PR TITLE
Check parameter across Motion and support InitPlan with Replicated Flow

### DIFF
--- a/src/backend/optimizer/plan/createplan.c
+++ b/src/backend/optimizer/plan/createplan.c
@@ -2823,11 +2823,6 @@ create_recursiveunion_plan(PlannerInfo *root, RecursiveUnionPath *best_path)
 								best_path->distinctList,
 								numGroups);
 
-	/*
-	 * Check whether there is a motion above WorkTableScan
-	 */
-	checkMotionAboveWorkTableScan((Node *)rightplan, root);
-
 	copy_generic_path_info(&plan->plan, (Path *) best_path);
 
 	return plan;

--- a/src/backend/optimizer/util/paramassign.c
+++ b/src/backend/optimizer/util/paramassign.c
@@ -69,9 +69,6 @@ assign_param_for_var(PlannerInfo *root, Var *var)
 	PlannerParamItem *pitem;
 	Index		levelsup;
 
-	/* check multi-level correlated subquery in GPDB planner */
-	check_multi_subquery_correlated(root, var);
-
 	/* Find the query level the Var belongs to */
 	for (levelsup = var->varlevelsup; levelsup > 0; levelsup--)
 		root = root->parent_root;

--- a/src/include/cdb/cdbmutate.h
+++ b/src/include/cdb/cdbmutate.h
@@ -55,6 +55,6 @@ extern void remove_subquery_in_RTEs(Node *node);
 extern Plan *cdbpathtoplan_create_sri_plan(RangeTblEntry *rte, PlannerInfo *subroot, Path *subpath, int createplan_flags);
 
 extern bool contains_outer_params(Node *node, void *context);
-extern void checkMotionAboveWorkTableScan(Node* node, PlannerInfo *root);
-extern void checkMotionWithParam(Node *node, Bitmapset *bmsNestParams, PlannerInfo *root);
+extern void check_motion_parameter(Plan *plan, PlannerInfo *root);
+
 #endif   /* CDBMUTATE_H */

--- a/src/include/optimizer/subselect.h
+++ b/src/include/optimizer/subselect.h
@@ -49,7 +49,6 @@ extern void SS_make_initplan_from_plan(PlannerInfo *root,
 									   Param *prm, bool is_initplan_func_sublink);
 
 extern bool IsSubqueryCorrelated(Query *sq);
-extern void check_multi_subquery_correlated(PlannerInfo *root, Var *var);
 
 extern List *generate_subquery_vars(PlannerInfo *root, List *tlist,
 					   Index varno);

--- a/src/test/regress/expected/bfv_catalog.out
+++ b/src/test/regress/expected/bfv_catalog.out
@@ -125,10 +125,7 @@ CREATE TABLE t1 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE t2 (a int, b int) DISTRIBUTED BY (a);
 CREATE TABLE x (a int) DISTRIBUTED BY (a);
 select * from x where a=  (select sum(t1.a)  from t1 inner join (select x.a as outer_ref, * from t2) as foo on (foo.a=t1.a+ outer_ref)  group by foo.a);
- a 
----
-(0 rows)
-
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = off;

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -8071,7 +8071,31 @@ select a, c from orca.r, orca.s where a  <> all (select c) order by a, c limit 1
 (10 rows)
 
 select a, (select (select (select c from orca.s where a=c group by c))) as subq from orca.r order by a;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ a  | subq 
+----+------
+  1 |    1
+  2 |    2
+  3 |    3
+  4 |    4
+  5 |    5
+  6 |    6
+  7 |     
+  8 |     
+  9 |     
+ 10 |     
+ 11 |     
+ 12 |     
+ 13 |     
+ 14 |     
+ 15 |     
+ 16 |     
+ 17 |     
+ 18 |     
+ 19 |     
+ 20 |     
+    |     
+(21 rows)
+
 with v as (select a,b from orca.r, orca.s where a=c)  select c from orca.s group by c having count(*) not in (select b from v where a=c) order by c;
  c 
 ---

--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -6076,7 +6076,7 @@ lateral (select * from int8_tbl t1,
                                      where q2 = (select greatest(t1.q1,t2.q2))
                                        and (select v.id=0)) offset 0) ss2) ss
          where t1.q1 = ss.q2) ss0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in nestloop. (cdbmutate.c:2038)
 select * from (values (0), (1)) v(id),
 lateral (select * from int8_tbl t1,
          lateral (select * from
@@ -6085,7 +6085,7 @@ lateral (select * from int8_tbl t1,
                                      where q2 = (select greatest(t1.q1,t2.q2))
                                        and (select v.id=0)) offset 0) ss2) ss
          where t1.q1 = ss.q2) ss0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in nestloop. (cdbmutate.c:2038)
 -- test some error cases where LATERAL should have been used but wasn't
 select f1,g from int4_tbl a, (select f1 as g) ss;
 ERROR:  column "f1" does not exist

--- a/src/test/regress/expected/join_optimizer.out
+++ b/src/test/regress/expected/join_optimizer.out
@@ -6212,7 +6212,7 @@ lateral (select * from int8_tbl t1,
                                      where q2 = (select greatest(t1.q1,t2.q2))
                                        and (select v.id=0)) offset 0) ss2) ss
          where t1.q1 = ss.q2) ss0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in nestloop. (cdbmutate.c:2038)
 select * from (values (0), (1)) v(id),
 lateral (select * from int8_tbl t1,
          lateral (select * from
@@ -6221,7 +6221,7 @@ lateral (select * from int8_tbl t1,
                                      where q2 = (select greatest(t1.q1,t2.q2))
                                        and (select v.id=0)) offset 0) ss2) ss
          where t1.q1 = ss.q2) ss0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in nestloop. (cdbmutate.c:2038)
 -- test some error cases where LATERAL should have been used but wasn't
 select f1,g from int4_tbl a, (select f1 as g) ss;
 ERROR:  column "f1" does not exist

--- a/src/test/regress/expected/qp_correlated_query.out
+++ b/src/test/regress/expected/qp_correlated_query.out
@@ -596,11 +596,14 @@ select * from A where A.j = any (select C.j from C,B where C.j = A.j and B.i = a
 
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 select * from A,B where A.j = any (select C.j from C where C.j = A.j and B.i = any (select C.i from C where C.i != 10 and C.i = A.i)) order by 1,2,3,4;
-ERROR:  correlated subquery with skip-level correlations is not supported
--- start_ignore
--- GPDB_96_MERGE_FIXME: we used to propagate the (i <> 10) qual to the Seq Scans on
--- 'c'. Investigate why we lost that
--- end_ignore
+ i | j | i | j  
+---+---+---+----
+ 1 | 1 | 1 |  1
+ 1 | 1 | 1 |  1
+ 1 | 1 | 1 | 43
+ 1 | 1 | 1 | 43
+(4 rows)
+
 explain select A.i, B.i, C.j from A, B, C where A.j = (select C.j from C where C.j = A.j and C.i = any (select B.i from B where C.i = B.i and B.i !=10)) order by A.i, B.i, C.j limit 10;
                                                                     QUERY PLAN                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -1690,7 +1693,14 @@ SELECT a, (SELECT d FROM qp_csq_t3 WHERE a=c) FROM qp_csq_t1 GROUP BY a order by
 
 -- Planner should fail due to skip-level correlation not supported. ORCA should pass
 SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a order by a;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ a |   d   
+---+-------
+ 1 | one
+ 3 | three
+ 5 | five
+ 7 | seven
+(4 rows)
+
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ in select list (Heap) 
 -- ----------------------------------------------------------------------
@@ -1723,10 +1733,10 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
 
 -- Planner should fail due to skip-level correlation not supported. Query should not cause segfault like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 -- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
 -- ----------------------------------------------------------------------
@@ -3885,7 +3895,7 @@ WHERE EXISTS (
         FROM skip_correlated_t2
     )
 );
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 EXPLAIN (COSTS OFF)
 SELECT *
 FROM skip_correlated_t1
@@ -3900,7 +3910,7 @@ WHERE EXISTS (
         )
         )
 );
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 EXPLAIN (COSTS OFF)
 SELECT *
 FROM skip_correlated_t1
@@ -3915,7 +3925,7 @@ WHERE EXISTS (
         )
         )
 );
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 --------------------------------------------------------------------------------
 -- Query should not cause segfault on ORCA. Will fallback to planner as no plan
 -- is computed by ORCA. Github Issue #15693

--- a/src/test/regress/expected/qp_correlated_query_optimizer.out
+++ b/src/test/regress/expected/qp_correlated_query_optimizer.out
@@ -1834,12 +1834,12 @@ select (select avg(x) from qp_csq_t1, qp_csq_t2 where qp_csq_t1.a = any (select 
 select A.j, (select array_agg(a_B) from (select B.j, (select array_agg(a_C) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 -- Planner should fail due to skip-level correlation not supported. Query should not return wrong results like in issue #12054.
 select A.j, (select array_agg(a_B) from (select B.j, (select sum(a_C.j) from (select C.j from C where C.i = A.i) a_C) from B where B.i = A.i order by A.j) a_B) from A;
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: Whole-row variable
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 -- ----------------------------------------------------------------------
 -- Test: Correlated Subquery: CSQ with multiple columns (Heap)
 -- ----------------------------------------------------------------------
@@ -4017,7 +4017,7 @@ WHERE EXISTS (
 );
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 EXPLAIN (COSTS OFF)
 SELECT *
 FROM skip_correlated_t1
@@ -4034,7 +4034,7 @@ WHERE EXISTS (
 );
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 EXPLAIN (COSTS OFF)
 SELECT *
 FROM skip_correlated_t1
@@ -4051,7 +4051,7 @@ WHERE EXISTS (
 );
 INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
 DETAIL:  Falling back to Postgres-based planner because no plan has been computed for required properties in GPORCA
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 --------------------------------------------------------------------------------
 -- Query should not cause segfault on ORCA. Will fallback to planner as no plan
 -- is computed by ORCA. Github Issue #15693

--- a/src/test/regress/expected/shared_scan.out
+++ b/src/test/regress/expected/shared_scan.out
@@ -190,10 +190,10 @@ select * from cte1 where ( EXISTS ( select cte2.a from cte2 left join cte3 on (E
          SubPlan 2
            ->  Nested Loop Left Join
                  Join Filter: $1
-                 InitPlan 1 (returns $1)  (slice4)
+                 InitPlan 1 (returns $1)  (slice1; segments: 3)
                    ->  Subquery Scan on cte2
                          ->  Materialize
-                               ->  Gather Motion 3:1  (slice5; segments: 3)
+                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                      ->  Seq Scan on sisc2
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice2; segments: 3)

--- a/src/test/regress/expected/shared_scan_optimizer.out
+++ b/src/test/regress/expected/shared_scan_optimizer.out
@@ -191,8 +191,8 @@ with cte1 as (select * from sisc1),
 cte2 as (select * from sisc2),
 cte3 as (select * from sisc3)
 select * from cte1 where ( EXISTS ( select cte2.a from cte2 left join cte3 on (EXISTS ( select cte1.b from cte2))));
-                                 QUERY PLAN                                  
------------------------------------------------------------------------------
+                                  QUERY PLAN                                   
+-------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Subquery Scan on cte1
          Filter: (SubPlan 2)
@@ -200,10 +200,10 @@ select * from cte1 where ( EXISTS ( select cte2.a from cte2 left join cte3 on (E
          SubPlan 2
            ->  Nested Loop Left Join
                  Join Filter: $1
-                 InitPlan 1 (returns $1)  (slice4)
+                 InitPlan 1 (returns $1)  (slice1; segments: 3)
                    ->  Subquery Scan on cte2
                          ->  Materialize
-                               ->  Gather Motion 3:1  (slice5; segments: 3)
+                               ->  Broadcast Motion 3:3  (slice4; segments: 3)
                                      ->  Seq Scan on sisc2
                  ->  Materialize
                        ->  Broadcast Motion 3:3  (slice2; segments: 3)

--- a/src/test/regress/expected/subselect.out
+++ b/src/test/regress/expected/subselect.out
@@ -606,7 +606,7 @@ select
   ( select min(tb.id) from tb
     where tb.aval = (select ta.val from ta where ta.id = tc.aid) ) as min_tb_id
 from tc;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ERROR:  Passing parameters across motion is not supported in subplan. (cdbmutate.c:2035)
 --
 -- Test case for 8.3 "failed to locate grouping columns" bug
 --
@@ -705,7 +705,10 @@ from
    from int8_tbl) sq0
   join
   int4_tbl i4 on dummy = i4.f1;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ qq1 
+-----
+(0 rows)
+
 --
 -- Test case for subselect within UPDATE of INSERT...ON CONFLICT DO UPDATE
 --
@@ -1078,14 +1081,53 @@ select sum(ss.tst::int) from
          random() as r
   from onek i where i.unique1 = o.unique1 ) ss
 where o.ten = 0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Aggregate
+   Output: sum((((hashed SubPlan 1)))::integer)
+   ->  Nested Loop
+         Output: ((hashed SubPlan 1))
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Output: o.hundred, o.unique1
+               ->  Seq Scan on public.onek o
+                     Output: o.hundred, o.unique1
+                     Filter: (o.ten = 0)
+         ->  Materialize
+               Output: ((hashed SubPlan 1)), (random())
+               ->  Result
+                     Output: (hashed SubPlan 1), random()
+                     Filter: (i.unique1 = o.unique1)
+                     ->  Materialize
+                           Output: i.ten, i.unique1
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Output: i.ten, i.unique1
+                                 ->  Seq Scan on public.onek i
+                                       Output: i.ten, i.unique1
+                     SubPlan 1
+                       ->  Result
+                             Output: int4_tbl.f1
+                             Filter: (int4_tbl.f1 <= $0)
+                             ->  Materialize
+                                   Output: int4_tbl.f1
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         Output: int4_tbl.f1
+                                         ->  Seq Scan on public.int4_tbl
+                                               Output: int4_tbl.f1
+ Optimizer: Postgres-based planner
+ Settings: optimizer = 'off'
+(32 rows)
+
 select sum(ss.tst::int) from
   onek o cross join lateral (
   select i.ten in (select f1 from int4_tbl where f1 <= o.hundred) as tst,
          random() as r
   from onek i where i.unique1 = o.unique1 ) ss
 where o.ten = 0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ sum 
+-----
+ 100
+(1 row)
+
 --
 -- Test rescan of a SetOp node
 --

--- a/src/test/regress/expected/subselect_gp.out
+++ b/src/test/regress/expected/subselect_gp.out
@@ -3764,6 +3764,41 @@ select (SELECT EXISTS
 (0 rows)
 
 drop table tmp;
+-- case for param cross motion after pullup sublink scenario
+create table tpm1(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tpm2(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tpm3(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)
+select (select count(*) from (select * from tpm2) d where d.b not in(select distinct generate_series(1, b) from tpm3 where tpm3.c = tpm1.c)) from tpm1;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Seq Scan on tpm1
+         SubPlan 1
+           ->  Aggregate
+                 ->  Hash Left Anti Semi (Not-In) Join
+                       Hash Cond: (tpm2.b = "NotIn_SUBQUERY".generate_series)
+                       ->  Materialize
+                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                   ->  Seq Scan on tpm2
+                       ->  Hash
+                             ->  Subquery Scan on "NotIn_SUBQUERY"
+                                   ->  ProjectSet
+                                         ->  Result
+                                               Filter: (tpm3.c = tpm1.c)
+                                               ->  Materialize
+                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
+                                                           ->  Seq Scan on tpm3
+ Optimizer: Postgres-based planner
+(18 rows)
+
+drop table tpm1,tpm2,tpm3;
 -- Test LEAST() and GREATEST() with an embedded subquery
 drop table if exists foo;
 create table foo (a int, b int) distributed by(a);

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3798,6 +3798,45 @@ select (SELECT EXISTS
 (0 rows)
 
 drop table tmp;
+-- case for param cross motion after pullup sublink scenario
+create table tpm1(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tpm2(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create table tpm3(a int, b int, c int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+explain (costs off)
+select (select count(*) from (select * from tpm2) d where d.b not in(select distinct generate_series(1, b) from tpm3 where tpm3.c = tpm1.c)) from tpm1;
+                                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Result
+   ->  Gather Motion 3:1  (slice1; segments: 3)
+         ->  Seq Scan on tpm1
+   SubPlan 2
+     ->  Aggregate
+           ->  Result
+                 Filter: (SubPlan 1)
+                 ->  Materialize
+                       ->  Gather Motion 3:1  (slice2; segments: 3)
+                             ->  Seq Scan on tpm2
+                 SubPlan 1
+                   ->  Result
+                         Filter: ((CASE WHEN (sum((CASE WHEN (tpm2.b = (generate_series(1, tpm3.b))) THEN 1 ELSE 0 END)) IS NULL) THEN true WHEN (sum((CASE WHEN ((generate_series(1, tpm3.b)) IS NULL) THEN 1 ELSE 0 END)) > '0'::bigint) THEN NULL::boolean WHEN (tpm2.b IS NULL) THEN NULL::boolean WHEN (sum((CASE WHEN (tpm2.b = (generate_series(1, tpm3.b))) THEN 1 ELSE 0 END)) = '0'::bigint) THEN true ELSE false END) = true)
+                         ->  Aggregate
+                               ->  Result
+                                     ->  ProjectSet
+                                           ->  Result
+                                                 Filter: (tpm3.c = tpm1.c)
+                                                 ->  Materialize
+                                                       ->  Gather Motion 3:1  (slice3; segments: 3)
+                                                             ->  Seq Scan on tpm3
+ Optimizer: GPORCA
+(22 rows)
+
+drop table tpm1,tpm2,tpm3;
 -- Test LEAST() and GREATEST() with an embedded subquery
 drop table if exists foo;
 create table foo (a int, b int) distributed by(a);

--- a/src/test/regress/expected/subselect_optimizer.out
+++ b/src/test/regress/expected/subselect_optimizer.out
@@ -1128,14 +1128,52 @@ select sum(ss.tst::int) from
          random() as r
   from onek i where i.unique1 = o.unique1 ) ss
 where o.ten = 0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+                                   QUERY PLAN                                   
+--------------------------------------------------------------------------------
+ Aggregate
+   Output: sum((((hashed SubPlan 1)))::integer)
+   ->  Nested Loop
+         Output: ((hashed SubPlan 1))
+         ->  Gather Motion 3:1  (slice1; segments: 3)
+               Output: o.hundred, o.unique1
+               ->  Seq Scan on public.onek o
+                     Output: o.hundred, o.unique1
+                     Filter: (o.ten = 0)
+         ->  Materialize
+               Output: ((hashed SubPlan 1)), (random())
+               ->  Result
+                     Output: (hashed SubPlan 1), random()
+                     Filter: (i.unique1 = o.unique1)
+                     ->  Materialize
+                           Output: i.ten, i.unique1
+                           ->  Gather Motion 3:1  (slice3; segments: 3)
+                                 Output: i.ten, i.unique1
+                                 ->  Seq Scan on public.onek i
+                                       Output: i.ten, i.unique1
+                     SubPlan 1
+                       ->  Result
+                             Output: int4_tbl.f1
+                             Filter: (int4_tbl.f1 <= $0)
+                             ->  Materialize
+                                   Output: int4_tbl.f1
+                                   ->  Gather Motion 3:1  (slice2; segments: 3)
+                                         Output: int4_tbl.f1
+                                         ->  Seq Scan on public.int4_tbl
+                                               Output: int4_tbl.f1
+ Optimizer: Postgres-based planner
+(31 rows)
+
 select sum(ss.tst::int) from
   onek o cross join lateral (
   select i.ten in (select f1 from int4_tbl where f1 <= o.hundred) as tst,
          random() as r
   from onek i where i.unique1 = o.unique1 ) ss
 where o.ten = 0;
-ERROR:  correlated subquery with skip-level correlations is not supported
+ sum 
+-----
+ 100
+(1 row)
+
 --
 -- Test rescan of a SetOp node
 --

--- a/src/test/regress/expected/tablesample.out
+++ b/src/test/regress/expected/tablesample.out
@@ -350,11 +350,11 @@ RESET enable_nestloop;
 select * from
   (values (0),(100)) v(pct),
   lateral (select count(*) from tenk1 tablesample bernoulli (pct)) ss;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:2033)
+ERROR:  Passing parameters across motion is not supported in nestloop. (cdbmutate.c:2038)
 select * from
   (values (0),(100)) v(pct),
   lateral (select count(*) from tenk1 tablesample system (pct)) ss;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:2033)
+ERROR:  Passing parameters across motion is not supported in nestloop. (cdbmutate.c:2038)
 explain (costs off)
 select pct, count(unique1) from
   (values (0),(100)) v(pct),

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -1074,7 +1074,7 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+ERROR:  Passing parameters across motion is not supported in RecursiveUnion. (cdbmutate.c:2041)
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN

--- a/src/test/regress/expected/with_clause.out
+++ b/src/test/regress/expected/with_clause.out
@@ -2216,7 +2216,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+ERROR:  Passing parameters across motion is not supported in RecursiveUnion. (cdbmutate.c:2041)
 -- should error out during parse-analyze
 with recursive rcte(x,y) as
 (
@@ -2228,7 +2228,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+ERROR:  Passing parameters across motion is not supported in RecursiveUnion. (cdbmutate.c:2041)
 -- This used to deadlock, before the IPC between ShareInputScans across
 -- slices was rewritten.
 set gp_cte_sharing=on;

--- a/src/test/regress/expected/with_clause_optimizer.out
+++ b/src/test/regress/expected/with_clause_optimizer.out
@@ -2219,7 +2219,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+ERROR:  Passing parameters across motion is not supported in RecursiveUnion. (cdbmutate.c:2041)
 -- should error out during parse-analyze
 with recursive rcte(x,y) as
 (
@@ -2231,7 +2231,7 @@ with recursive rcte(x,y) as
   where t.b = x
 )
 select * from rcte limit 10;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+ERROR:  Passing parameters across motion is not supported in RecursiveUnion. (cdbmutate.c:2041)
 -- This used to deadlock, before the IPC between ShareInputScans across
 -- slices was rewritten.
 set gp_cte_sharing=on;

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -1081,7 +1081,7 @@ WITH RECURSIVE cte(level, id) as (
 	UNION ALL
 	SELECT level+1, c FROM (SELECT * FROM cte OFFSET 0) foo, bar)
 SELECT * FROM cte LIMIT 10;
-ERROR:  Passing parameters across motion is not supported. (cdbmutate.c:1989)
+ERROR:  Passing parameters across motion is not supported in RecursiveUnion. (cdbmutate.c:2041)
 CREATE TEMPORARY TABLE y (a INTEGER) DISTRIBUTED RANDOMLY;
 INSERT INTO y SELECT generate_series(1, 10);
 -- LEFT JOIN

--- a/src/test/regress/sql/subselect_gp.sql
+++ b/src/test/regress/sql/subselect_gp.sql
@@ -1422,6 +1422,16 @@ select (SELECT EXISTS
                   WHERE schemaname = a)) from tmp;
 drop table tmp;
 
+-- case for param cross motion after pullup sublink scenario
+create table tpm1(a int, b int, c int);
+create table tpm2(a int, b int, c int);
+create table tpm3(a int, b int, c int);
+
+explain (costs off)
+select (select count(*) from (select * from tpm2) d where d.b not in(select distinct generate_series(1, b) from tpm3 where tpm3.c = tpm1.c)) from tpm1;
+
+drop table tpm1,tpm2,tpm3;
+
 -- Test LEAST() and GREATEST() with an embedded subquery
 drop table if exists foo;
 


### PR DESCRIPTION
## BackGround:
Currently, we do not support skipping reference level Vars in Subplan, and we handle this in the function check_multi_subquery_correlated(). The primary objective is to prevent parameters from crossing motions,
which is not supported in GPDB. However, there are cases where we cannot accurately verify this using the current approach.
```
select 
  (
    select count(*) from tpm2
    where 
      tpm2.b not in
      (
        select distinct generate_series(1, b) 
        from tpm3 
        where 
          tpm3.c = tpm1.c
      )
  ) 
from tpm1;
```
The SQL above shouldn't be supported because `tpm1.c` refers to two levels above as `tmp1`. However, in practice, after the NOT-IN sublink is pulled up and becomes a subquery, the SQL can execute successfully.
```
                                             QUERY PLAN                                              
-----------------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Seq Scan on tpm1
         SubPlan 1
           ->  Aggregate
                 ->  Hash Left Anti Semi (Not-In) Join
                       Hash Cond: (tpm2.b = "NotIn_SUBQUERY".generate_series)
                       ->  Materialize
                             ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                   ->  Seq Scan on tpm2
                       ->  Hash
                             ->  Subquery Scan on "NotIn_SUBQUERY"
                                   ->  ProjectSet
                                         ->  Result
                                               Filter: (tpm3.c = tpm1.c)
                                               ->  Materialize
                                                     ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                                           ->  Seq Scan on tpm3
 Optimizer: Postgres-based planner
(18 rows)
```


As a result, relying on checking skip reference levels to avoid parameters crossing motions is not a good option, and we should discard it. However, In this PR, we will introduce a new approach to check for parameters crossing motions.

## Implementation

### Check parameter across Motion 

Initially, we introduce a function called check_motion_parameter() at the end of the planner to examine parameters across motions by recursively traversing plans and subplans. We now not only assess subplan scenarios but also include Recursive and Nestloop scenarios, which could also involve parameters crossing motions. This work has been completed in https://github.com/greenplum-db/gpdb/pull/16958 and https://github.com/greenplum-db/gpdb/pull/16695, where we have reverted some code changes made in these two pull requests.

We traverse the plan tree recursively from top to bottom, and whenever we encounter a parameter producer (such as Subplan, Nestloop, or RecursiveUnion), we record the parameters. Upon encountering a Motion Node, we check if there are parameters in motion->extparam compared to the previously recorded parameters. If parameters are found to be passing through the motion, we raise an error.

### Support InitPlan with Replicated flow
After performing the parameter check across motions, we may be able to support some previously unsupported cases. However, a new problem arises when we encounter a Subplan with another InitPlan below it.
```
postgres=# explain(costs off) SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a order by a;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Merge Key: qp_csq_t1.a
   ->  GroupAggregate
         Group Key: qp_csq_t1.a
         ->  Sort
               Sort Key: qp_csq_t1.a
               ->  Seq Scan on qp_csq_t1
         SubPlan 2
           ->  Result
                 InitPlan 1 (returns $1)  (slice1; segments: 3)
                   ->  Result
                         Filter: (qp_csq_t1.a = qp_csq_t3.c)
                         ->  Materialize
                               ->  Gather Motion 3:1  (slice2; segments: 3)
                                     ->  Seq Scan on qp_csq_t3
 Optimizer: Postgres-based planner
(16 rows)
```
The lowest `Gather Motion 3:1` is incorrect, and the plan will crash because the InitPlan should execute before the main plan. However, in this scenario, we cannot handle the parameter `qp_csq_t1.a`. Consequently, we need to support InitPlan with a broadcast flow to ensure the plan is executable.
```
postgres=# explain(costs off) SELECT a, (SELECT (SELECT d FROM qp_csq_t3 WHERE a=c)) FROM qp_csq_t1 GROUP BY a order by a;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   Merge Key: qp_csq_t1.a
   ->  GroupAggregate
         Group Key: qp_csq_t1.a
         ->  Sort
               Sort Key: qp_csq_t1.a
               ->  Seq Scan on qp_csq_t1
         SubPlan 2
           ->  Result
                 InitPlan 1 (returns $1)  (slice1; segments: 3)
                   ->  Result
                         Filter: (qp_csq_t1.a = qp_csq_t3.c)
                         ->  Materialize
                               ->  Broadcast Motion 3:3  (slice2; segments: 3)
                                     ->  Seq Scan on qp_csq_t3
 Optimizer: Postgres-based planner
(16 rows)
```
If the Initplan includes parameters from outside (excluding outer initplan set parameters), then the flow should be replicated (broadcast). Otherwise, we should keep it as single (Gather).

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
