### PR TITLE
[6X_STABLE] skip pg_description and pg_shdescription tables with gpcheckcat missing/extra tests

### DIFF
--- a/gpMgmt/bin/gpcheckcat
+++ b/gpMgmt/bin/gpcheckcat
@@ -2357,10 +2357,12 @@ def _checkAllTablesForMissingEntries():
     catalog_issues = {}
     tables = GV.catalog.getCatalogTables()
     for catalog_table_obj in sorted(tables):
+        catalog_name = catalog_table_obj.getTableName()
+        if catalog_name == "pg_description" or catalog_name == "pg_shdescription":
+            continue
         issues = checkTableMissingEntry(catalog_table_obj)
         if not issues:
             continue
-        catalog_name = catalog_table_obj.getTableName()
         _, pk_name = getPrimaryKeyColumn(catalog_name, catalog_table_obj.getPrimaryKey())
         # We do this check in this function rather than getPrimaryKeyColumn as
         # it is used in checkACL and we do not want to modify that functionality


### PR DESCRIPTION
Issue:
    gpcheckcat missing_extraneous test reported errors when gpdb was upgraded from older version to a newer version after performing gpexpand.

RCA:
    This is a false alarm and the catalog tables can be skipped during gpcheckcat missing_extraneous test

Solution:
    gpcheckcat is modified to skip the tables during missing/extra tests.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
