### PR TITLE
Optimize MPP FDW LIMIT/OFFSET push down when there is NULL/0.

### DIFF
--- a/contrib/postgres_fdw/Makefile
+++ b/contrib/postgres_fdw/Makefile
@@ -27,7 +27,7 @@ endif
 
 # For postgres_fdw test
 export PG_PORT=5432
-installcheck: prep_postgres
+installcheck: install prep_postgres
 clean: clean_postgres
 prep_postgres:
 	./postgres_setup.bash

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -981,7 +981,8 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
  1000 |  0
 (2 rows)
 
--- test LIMIT 0, OFFSET null
+-- test LIMIT 0, OFFSET null/0
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'true');
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset null;
                                     QUERY PLAN                                     
@@ -1026,21 +1027,19 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 0;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 998;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Limit
    Output: c1, c2
    ->  Gather Motion 2:1  (slice1; segments: 2)
          Output: c1, c2
          Merge Key: c1
-         ->  Limit
+         ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               ->  Foreign Scan on public.mpp_ft2
-                     Output: c1, c2
-                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT NULL::bigint
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
-(12 rows)
+(10 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 0;
@@ -1058,21 +1057,19 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 0;
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 998;
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
+                                                 QUERY PLAN                                                 
+------------------------------------------------------------------------------------------------------------
  Limit
    Output: c1, c2
    ->  Gather Motion 2:1  (slice1; segments: 2)
          Output: c1, c2
          Merge Key: c1
-         ->  Limit
+         ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               ->  Foreign Scan on public.mpp_ft2
-                     Output: c1, c2
-                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT NULL::bigint
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
-(12 rows)
+(10 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset null;
@@ -1099,7 +1096,7 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;
          Merge Key: c1
          ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (998::bigint + 0::bigint)
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 0::bigint
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (10 rows)
@@ -1115,7 +1112,7 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset null;
          Merge Key: c1
          ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (NULL::bigint + 0::bigint)
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 0::bigint
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (10 rows)
@@ -1131,7 +1128,7 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset null;
          Merge Key: c1
          ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (NULL::bigint + 3::bigint)
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 3::bigint
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (10 rows)
@@ -1147,11 +1144,12 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset 0;
          Merge Key: c1
          ->  Foreign Scan on public.mpp_ft2
                Output: c1, c2
-               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (0::bigint + 3::bigint)
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 3::bigint
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (10 rows)
 
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
 -- Query with aggregates and limit clause together is NOT pushed down.
 -- Because it's unsafe to do partial aggregate and limit in multiple remote servers.
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -984,48 +984,6 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 -- test LIMIT 0, OFFSET null/0
 ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'true');
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 offset null;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)
-   Output: c1, c2
-   Merge Key: c1
-   ->  Foreign Scan on public.mpp_ft2
-         Output: c1, c2
-         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres-based planner
- Settings: gp_enable_minmax_optimization = 'off'
-(8 rows)
-
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset null;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)
-   Output: c1, c2
-   Merge Key: c1
-   ->  Foreign Scan on public.mpp_ft2
-         Output: c1, c2
-         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres-based planner
- Settings: gp_enable_minmax_optimization = 'off'
-(8 rows)
-
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)
-   Output: c1, c2
-   Merge Key: c1
-   ->  Foreign Scan on public.mpp_ft2
-         Output: c1, c2
-         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres-based planner
- Settings: gp_enable_minmax_optimization = 'off'
-(8 rows)
-
-EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 998;
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
@@ -1042,20 +1000,6 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 998;
 (10 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 0;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)
-   Output: c1, c2
-   Merge Key: c1
-   ->  Foreign Scan on public.mpp_ft2
-         Output: c1, c2
-         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres-based planner
- Settings: gp_enable_minmax_optimization = 'off'
-(8 rows)
-
-EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 998;
                                                  QUERY PLAN                                                 
 ------------------------------------------------------------------------------------------------------------
@@ -1070,20 +1014,6 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 998;
  Optimizer: Postgres-based planner
  Settings: gp_enable_minmax_optimization = 'off'
 (10 rows)
-
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset null;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
- Gather Motion 2:1  (slice1; segments: 2)
-   Output: c1, c2
-   Merge Key: c1
-   ->  Foreign Scan on public.mpp_ft2
-         Output: c1, c2
-         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
- Optimizer: Postgres-based planner
- Settings: gp_enable_minmax_optimization = 'off'
-(8 rows)
 
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;

--- a/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
+++ b/contrib/postgres_fdw/expected/mpp_gp2pg_postgres_fdw.out
@@ -981,6 +981,177 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
  1000 |  0
 (2 rows)
 
+-- test LIMIT 0, OFFSET null
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset null;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft2
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(8 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset null;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft2
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(8 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft2
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(8 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 998;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Limit
+               Output: c1, c2
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c1, c2
+                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(12 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 0;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft2
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(8 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 998;
+                                          QUERY PLAN                                           
+-----------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Limit
+               Output: c1, c2
+               ->  Foreign Scan on public.mpp_ft2
+                     Output: c1, c2
+                     Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(12 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset null;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Gather Motion 2:1  (slice1; segments: 2)
+   Output: c1, c2
+   Merge Key: c1
+   ->  Foreign Scan on public.mpp_ft2
+         Output: c1, c2
+         Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(8 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Foreign Scan on public.mpp_ft2
+               Output: c1, c2
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (998::bigint + 0::bigint)
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(10 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset null;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Foreign Scan on public.mpp_ft2
+               Output: c1, c2
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (NULL::bigint + 0::bigint)
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(10 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset null;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Foreign Scan on public.mpp_ft2
+               Output: c1, c2
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (NULL::bigint + 3::bigint)
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(10 rows)
+
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset 0;
+                                                      QUERY PLAN                                                       
+-----------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: c1, c2
+   ->  Gather Motion 2:1  (slice1; segments: 2)
+         Output: c1, c2
+         Merge Key: c1
+         ->  Foreign Scan on public.mpp_ft2
+               Output: c1, c2
+               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (0::bigint + 3::bigint)
+ Optimizer: Postgres-based planner
+ Settings: gp_enable_minmax_optimization = 'off'
+(10 rows)
+
 -- Query with aggregates and limit clause together is NOT pushed down.
 -- Because it's unsafe to do partial aggregate and limit in multiple remote servers.
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -237,19 +237,9 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 -- test LIMIT 0, OFFSET null/0
 ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'true');
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 offset null;
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset null;
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 0;
-EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 998;
 EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 0;
-EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 998;
-EXPLAIN (VERBOSE, COSTS OFF)
-SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset null;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -233,6 +233,31 @@ SELECT c1, c2 FROM mpp_ft2 order by c1 offset 2 limit 3;
 EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
+
+-- test LIMIT 0, OFFSET null
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 offset null;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset null;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit null offset 998;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 0;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset 998;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit all offset null;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset null;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset null;
+EXPLAIN (VERBOSE, COSTS OFF)
+SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset 0;
+
 -- Query with aggregates and limit clause together is NOT pushed down.
 -- Because it's unsafe to do partial aggregate and limit in multiple remote servers.
 EXPLAIN (VERBOSE, COSTS OFF)

--- a/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
+++ b/contrib/postgres_fdw/sql/mpp_gp2pg_postgres_fdw.sql
@@ -234,7 +234,8 @@ EXPLAIN VERBOSE
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset 998;
 
--- test LIMIT 0, OFFSET null
+-- test LIMIT 0, OFFSET null/0
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'true');
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 offset null;
 EXPLAIN (VERBOSE, COSTS OFF)
@@ -257,6 +258,7 @@ EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset null;
 EXPLAIN (VERBOSE, COSTS OFF)
 SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset 0;
+ALTER FOREIGN TABLE mpp_ft2 OPTIONS(set use_remote_estimate 'false');
 
 -- Query with aggregates and limit clause together is NOT pushed down.
 -- Because it's unsafe to do partial aggregate and limit in multiple remote servers.


### PR DESCRIPTION
While play MPP FDW with LIMIT, found several cases could be improved:
When there were NULL or zero values in OFFSET/LIMIT, we may don't need to fetch more rows, and expression
has NULL plus others is pointless.

example before this fix:
```sql
EXPLAIN (VERBOSE, COSTS OFF)
SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;
QUERY PLAN
--------------
 Limit
   Output: c1, c2
   ->  Gather Motion 2:1  (slice1; segments: 2)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.mpp_ft2
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY
c1 ASC NULLS LAST LIMIT (998::bigint + 0::bigint)
```
We will have to fetch 998 rows from remote, but as we have limit 0, that's pointless.
With this fix:

```sql
EXPLAIN (VERBOSE, COSTS OFF)
SELECT c1, c2 FROM mpp_ft2 order by c1 limit 0 offset 998;
QUERY PLAN
--------------
 Limit
   Output: c1, c2
   ->  Gather Motion 2:1  (slice1; segments: 2)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.mpp_ft2
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY
c1 ASC NULLS LAST LIMIT 0::bigint
```
And NULL plus int is wired, like: `LIMIT (NULL::bigint + 3::bigint)`
```sql
EXPLAIN (VERBOSE, COSTS OFF)
SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset null;
                                                        QUERY PLAN

--------------------------------------------------------------------------------------------------------------------------
 Limit
   Output: c1, c2
   ->  Gather Motion 2:1  (slice1; segments: 2)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.mpp_ft2
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT (NULL::bigint + 3::bigint)
 Optimizer: Postgres-based planner
 Settings: gp_enable_minmax_optimization = 'off'
(10 rows)
```
With this fix:
```sql
EXPLAIN (VERBOSE, COSTS OFF)
SELECT c1, c2 FROM mpp_ft2 order by c1 limit 3 offset null;
                                                        QUERY PLAN                                                        
--------------------------------------------------------------------------------------------------------------------------
 Limit
   Output: c1, c2
   ->  Gather Motion 2:1  (slice1; segments: 2)
         Output: c1, c2
         Merge Key: c1
         ->  Foreign Scan on public.mpp_ft2
               Output: c1, c2
               Remote SQL: SELECT c1, c2 FROM "MPP_S 1"."T 2" ORDER BY c1 ASC NULLS LAST LIMIT 3::bigint
 Optimizer: Postgres-based planner
 Settings: gp_enable_minmax_optimization = 'off'
(10 rows)
```


See more examples in 2c4642eb9bad96e5c0ff331db9b57d5b5e586d70 with some cases added.

This PR improve them by:
```shell
optimize (N > 0)
    LIMIT 0 OFFSET N to LIMIT 0
    LIMIT 0 OFFSET NULL to LIMIT 0
    LIMIT N OFFSET NULL to LIMIT N
    LIMIT N OFFSET 0 to LIMIT N
```



## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [x] Review a PR in return to support the community
