### PR TITLE
Fix warning of the comparison will always evaluate as 'true'

### DIFF
--- a/src/include/catalog/pg_appendonly.h
+++ b/src/include/catalog/pg_appendonly.h
@@ -140,11 +140,11 @@ GetAppendOnlyEntryAttributes(Oid relid,
 do { \
 	Form_pg_appendonly aoForm = (rel)->rd_appendonly; \
 	Assert(RelationStorageIsAO(rel)); \
-	if ((segrelid_ptr) != NULL) \
+	if ((uintptr_t) segrelid_ptr != (uintptr_t) NULL) \
 		*((Oid*)segrelid_ptr) = aoForm->segrelid; \
-	if ((blkdirrelid_ptr) != NULL) \
+	if ((uintptr_t) blkdirrelid_ptr != (uintptr_t) NULL) \
 		*((Oid*)blkdirrelid_ptr) = aoForm->blkdirrelid; \
-	if ((visimaprelid_ptr) != NULL) \
+	if ((uintptr_t) visimaprelid_ptr != (uintptr_t) NULL) \
 		*((Oid*)visimaprelid_ptr) = aoForm->visimaprelid; \
 } while (0)
 


### PR DESCRIPTION
I met plenty of warning msg about function `GetAppendOnlyEntryAuxOids()`, some examples are as follows:

``` 
./../../../src/include/catalog/pg_appendonly.h:147:25: warning: the comparison will always evaluate as ‘true’ for the address of ‘visimaprelid’ will never be NULL [-Waddress]
  if ((visimaprelid_ptr) != NULL) \
                         ^
appendonly_visimap_udf.c:91:3: note: in expansion of macro ‘GetAppendOnlyEntryAuxOids’
   GetAppendOnlyEntryAuxOids(context->aorel,
   ^
appendonly_visimap_udf.c: In function ‘gp_aovisimap_hidden_info’:
../../../../src/include/catalog/pg_appendonly.h:143:21: warning: the comparison will always evaluate as ‘true’ for the address of ‘segrelid’ will never be NULL [-Waddress]
  if ((segrelid_ptr) != NULL) \
                     ^
appendonly_visimap_udf.c:204:3: note: in expansion of macro ‘GetAppendOnlyEntryAuxOids’
   GetAppendOnlyEntryAuxOids(context->parentRelation,
   ^

appendonly_blkdir_udf.c: In function ‘gp_aoblkdir’:
../../../../src/include/catalog/pg_appendonly.h:145:24: warning: the comparison will always evaluate as ‘true’ for the address of ‘blkdirrelid’ will never be NULL [-Waddress]
  if ((blkdirrelid_ptr) != NULL) \
                        ^
appendonly_blkdir_udf.c:100:3: note: in expansion of macro ‘GetAppendOnlyEntryAuxOids’
   GetAppendOnlyEntryAuxOids(context->aorel,
   ^
```

The **solution** is easy, pls refer to https://stackoverflow.com/questions/27048171/disable-warning-the-address-of-x-will-always-evaluate-as-true

Signed-off-by: Yongtao Huang <yongtaoh2022@gmail.com>