### PR TITLE
[6X Backport] Added Support for -i flag with differential recovery

### DIFF
--- a/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/buildMirrorSegments.py
@@ -97,7 +97,7 @@ def get_recovery_type(file_basename):
 #   failoverSegment = segment to recover "to"
 # In other words, we are recovering the failedSegment to the failoverSegment using the liveSegment.
 class GpMirrorToBuild:
-    def __init__(self, failedSegment, liveSegment, failoverSegment, forceFullSynchronization, differentialSynchronization):
+    def __init__(self, failedSegment, liveSegment, failoverSegment, forceFullSynchronization, differentialSynchronization, recoveryType=None):
         checkNotNone("forceFullSynchronization", forceFullSynchronization)
 
         # We need to call this validate function here because addmirrors directly calls GpMirrorToBuild.
@@ -108,18 +108,23 @@ class GpMirrorToBuild:
         self.__failoverSegment = failoverSegment
 
         """
-        __forceFullSynchronization is true if full resynchronization should be FORCED -- that is, the
+            __forceFullSynchronization is true if full resynchronization should be FORCED -- that is, the
            existing segment will be cleared and all objects will be transferred by the file resynchronization
            process on the server
+           
+            __differentialSynchronization is true if differential resynchronization should be done -- that is only 
+            the delta between the source and target datadir will be copied over to the target server
         """
         self.__forceFullSynchronization = forceFullSynchronization
 
-        """
-                __differentialSynchronization is true if differential resynchronization should be done -- that is only 
-                the delta between the source and target datadir will be copied over to the target server
-                """
-
         self.__differentialSynchronization = differentialSynchronization
+
+        if not (forceFullSynchronization or differentialSynchronization) and recoveryType in ["Differential", "Full"] and self.__failoverSegment is None:
+            # If either forceFullSynchronization or differentialSynchronization is explicitly not set, and
+            # If recovery config file is provided without failover segment and recoveryType is either "Differential" or "Full",
+            # set __forceFullSynchronization and __differentialSynchronization to True accordingly.
+            self.__forceFullSynchronization = recoveryType == "Full"
+            self.__differentialSynchronization = recoveryType == "Differential"
 
     def getFailedSegment(self):
         """

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment.py
@@ -112,7 +112,7 @@ class GpRecoverSegmentProgram:
         if self.__options.rebalanceSegments:
             return GpSegmentRebalanceOperation(gpEnv, gpArray, self.__options.parallelDegree, self.__options.parallelPerHost, self.__options.replayLag)
         instance = RecoveryTripletsFactory.instance(gpArray, self.__options.recoveryConfigFile, self.__options.newRecoverHosts, self.__options.outputSampleConfigFile, self.__options.parallelDegree)
-        segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization)
+        segs = [GpMirrorToBuild(t.failed, t.live, t.failover, self.__options.forceFullResynchronization, self.__options.differentialResynchronization, t.recovery_type)
                 for t in instance.getTriplets()]
         return GpMirrorListToBuild(segs, self.__pool, self.__options.quiet,
                                    self.__options.parallelDegree,
@@ -247,14 +247,15 @@ class GpRecoverSegmentProgram:
         optionCnt = 0
         if self.__options.newRecoverHosts is not None:
             optionCnt += 1
-        if self.__options.recoveryConfigFile is not None:
-            optionCnt += 1
         if self.__options.rebalanceSegments:
             optionCnt += 1
-        if self.__options.differentialResynchronization:
-            optionCnt += 1
         if optionCnt > 1:
-            raise ProgramArgumentValidationException("Only one of -i, -p, -r and --differential may be specified")
+            raise ProgramArgumentValidationException("Only one of -p and -r may be specified")
+        if optionCnt > 0 and self.__options.recoveryConfigFile is not None:
+            raise ProgramArgumentValidationException("Only one of -i, -p and -r may be specified")
+
+        if optionCnt > 0 and self.__options.differentialResynchronization:
+            raise ProgramArgumentValidationException("Only one of -p, -r and --differential may be specified")
 
         # verify "mode to recover" options
         if self.__options.forceFullResynchronization and self.__options.differentialResynchronization:

--- a/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/clsRecoverSegment_triples.py
@@ -67,6 +67,44 @@ def is_pg_rewind_running(hostname, port):
             hostname, str(port), str(e)))
 
 
+def extract_recovery_config_info(parts):
+    """
+    Extracts relevant recovery configuration information from a list of parts.
+    """
+    address, port, datadir = parts[-3:]
+    recovery_type = "Incremental"
+    hostname_check_required = False
+    hostname = address
+
+    recovery_type_flag = False
+    # If 5 fields are there in part then first field represents recovery type and it should any of I,D,F.i,d,f
+    if len(parts) == 5:
+        if parts[0] not in {"I", "D", "F", "i", "d", "f"}:
+            raise Exception("Invalid recovery type provided, please provide any of I,D,F,i,d,f as recovery_type")
+        hostname = parts[1]
+        hostname_check_required = True
+        recovery_type_flag = True
+
+    # If 4 fields are there in recovery part then first field can be either recovery_type or hostname
+    # if first field part[0] is not in {I,D,F,i,d,f} then it is hostname
+    if len(parts) == 4:
+        if parts[0] in {"I", "D", "F", "i", "d", "f"}:
+            recovery_type_flag = True
+        else:
+            hostname = parts[0]
+            hostname_check_required = True
+
+    # If recovery_type field has been provided by user then sync_mode needs be decided based on input
+    if recovery_type_flag:
+        sync_mode = parts[0]
+        if sync_mode in {"D", "d"}:
+            recovery_type = "Differential"
+        elif sync_mode in {"F", "f"}:
+            recovery_type = "Full"
+
+    return hostname, address, port, datadir, recovery_type, hostname_check_required
+
+
 class RecoveryTriplet:
     """
     Represents the segments needed to perform a recovery on a given segment.
@@ -74,11 +112,12 @@ class RecoveryTriplet:
     live     = acting primary to use to recover that failed segment
     failover = failed segment will be recovered here
     """
-    def __init__(self, failed, live, failover):
+    def __init__(self, failed, live, failover, recovery_type=None):
         self.failed = failed
         self.live = live
         self.failover = failover
         self.validate(failed, live, failover)
+        self.recovery_type = recovery_type
 
     def __repr__(self):
         return "Failed: {0} Live: {1} Failover: {2}".format(self.failed, self.live, self.failover)
@@ -143,7 +182,7 @@ class RecoveryTriplet:
 
 
 class RecoveryTripletRequest:
-    def __init__(self, failed, failover_host_name=None, failover_host_address=None, failover_port=None, failover_datadir=None, is_new_host=False):
+    def __init__(self, failed, failover_host_name=None, failover_host_address=None, failover_port=None, failover_datadir=None, is_new_host=False, recovery_type=None):
         self.failed = failed
 
         self.failover_host_name = failover_host_name
@@ -151,6 +190,7 @@ class RecoveryTripletRequest:
         self.failover_port = failover_port
         self.failover_datadir = failover_datadir
         self.failover_to_new_host = is_new_host
+        self.recovery_type = recovery_type
 
 
 # TODO: gparray is mutated for all triplets, even if we skip recovery for them(if they are unreachable)
@@ -290,7 +330,7 @@ class RecoveryTriplets:
 
             peer = dbIdToPeerMap.get(req.failed.getSegmentDbId())
 
-            triplets.append(RecoveryTriplet(req.failed, peer, failover))
+            triplets.append(RecoveryTriplet(req.failed, peer, failover, req.recovery_type))
 
         if len(failed_segments_with_running_basebackup) > 0:
             logger.warning(
@@ -449,7 +489,10 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
 
         requests = []
         for row in self.rows:
-            req = RecoveryTripletRequest(_find_failed_from_row(), row.get('newHostname'), row.get('newAddress'), row.get('newPort'), row.get('newDataDirectory'))
+            req = RecoveryTripletRequest(_find_failed_from_row(), failover_host_name=row.get('newHostname'),
+                                         failover_host_address=row.get('newAddress'),
+                                         failover_port=row.get('newPort'), failover_datadir=row.get('newDataDirectory'),
+                                         recovery_type=row.get('recovery_type'))
             requests.append(req)
 
         return self._convert_requests_to_triplets(requests)
@@ -468,23 +511,17 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
         rows = []
         with open(config_file) as f:
             for lineno, line in line_reader(f):
-                hostname_check_required = False
                 groups = line.split()  # NOT line.split(' ') due to MPP-15675
                 if len(groups) not in [1, 2]:
                     msg = "line %d of file %s: expected 1 or 2 groups but found %d" % (lineno, config_file, len(groups))
                     raise ExceptionNoStackTraceNeeded(msg)
                 parts = groups[0].split('|')
 
-                if len(parts) not in [3, 4]:
-                    msg = "line {0} of file {1}: expected 3 or 4 parts on failed segment group, obtained {2}" .format(
+                if len(parts) not in {3, 4, 5}:
+                    msg = "line {0} of file {1}: expected 3, 4 or 5 parts on failed segment group, obtained {2}".format(
                         lineno, config_file, len(parts))
                     raise ExceptionNoStackTraceNeeded(msg)
-                if len(parts) == 4:
-                    hostname, address, port, datadir = parts
-                    hostname_check_required = True
-                else:
-                    address, port, datadir = parts
-                    hostname = address
+                hostname, address, port, datadir, recovery_type, hostname_check_required = extract_recovery_config_info(parts)
                 check_values(lineno, hostname=hostname, address=address, port=port, datadir=datadir)
                 datadir = normalizeAndValidateInputPath(datadir, f.name, lineno)
 
@@ -494,7 +531,8 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
                     'failedPort': port,
                     'failedDataDirectory': datadir,
                     'lineno': lineno,
-                    'hostname_check_required': hostname_check_required
+                    'hostname_check_required': hostname_check_required,
+                    'recovery_type': recovery_type
                 }
                 if len(groups) == 2:
                     parts2 = groups[1].split('|')
@@ -512,6 +550,7 @@ class RecoveryTripletsUserConfigFile(RecoveryTriplets):
                     check_values(lineno, hostname=hostname2, address=address2, port=port2, datadir=datadir2)
                     datadir2 = normalizeAndValidateInputPath(datadir2, f.name, lineno)
 
+                    row['recovery_type'] = "Full"
                     row.update({
                         'newHostname': hostname2,
                         'newAddress': address2,

--- a/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
+++ b/gpMgmt/bin/gppylib/programs/test/unit/test_cluster_clsrecoversegment_triples.py
@@ -9,9 +9,9 @@ import itertools
 import gppylib
 from gppylib.gparray import GpArray, Segment
 from gppylib.programs.clsRecoverSegment_triples import RecoveryTripletsUserConfigFile, RecoveryTripletsFactory, \
-    RecoveryTriplet, get_segments_with_running_basebackup, is_pg_rewind_running
+    RecoveryTriplet, get_segments_with_running_basebackup, is_pg_rewind_running, extract_recovery_config_info
 from gppylib.operations.get_segments_in_recovery import is_seg_in_backup_mode
-from test.unit.gp_unittest import GpTestCase, SubTest, FakeCursor
+from gppylib.test.unit.gp_unittest import GpTestCase, SubTest, FakeCursor
 
 
 class RecoveryTripletsFactoryTestCase(GpTestCase):
@@ -965,6 +965,13 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
             "name": "old_to_new_new_to_old",
             "config": """sdw1|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5
                          sdw3|20001|/primary/gpseg5 sdw1|20000|/primary/gpseg0"""
+        },
+        {
+            "name": "with_recovery_type",
+            "config": """I|sdw1|20000|/primary/gpseg0
+                            D|sdw1|20000|/primary/gpseg1
+                            F|sdw1|20000|/primary/gpseg2
+                            D|sdw1-1|sdw1|20000|/primary/gpseg3"""
         }
         ]
 
@@ -994,7 +1001,7 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
                 """sdw1|20000|/mirror/gpseg0 sdw3|20001|/mirror/gpseg5
                    sdw1|20000 sdw3|20001|/mirror/gpseg5""",
             "expected":
-                "line 2 of file .*: expected 3 or 4 parts on failed segment group, obtained 2"
+                "line 2 of file .*: expected 3, 4 or 5 parts on failed segment group, obtained 2"
         },
         {
             "name":
@@ -1128,6 +1135,14 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
             "expected":
                 "line 2 of file .*: expected equal parts, either 3 or 4 on both segment group, obtained 4 on group1 and 3 on group2"
         },
+        {
+            "name":
+                "failover_with_recovery_type_with",
+            "config":
+                """D|sdw1|20000|/primary/gpseg0 sdw3|20001|/primary/gpseg5""",
+            "expected":
+                "line 1 of file .*: expected equal parts, either 3 or 4 on both segment group, obtained 4 on group1 and 3 on group2"
+        },
     ]
 
     def test_parsing_should_fail(self):
@@ -1146,23 +1161,18 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
         lineno = 0
 
         for line in config_str.splitlines():
-            hostname_check_required = False
             lineno += 1
             groups = line.split()
             parts = groups[0].split('|')
-            if len(parts) == 4:
-                hostname, address, port, datadir = parts
-                hostname_check_required = True
-            else:
-                address, port, datadir = parts
-                hostname = address
+            hostname, address, port, datadir, recovery_type, hostname_check_required = extract_recovery_config_info(parts)
             row = {
                 'failedHostname': hostname,
                 'failedAddress': address,
                 'failedPort': port,
                 'failedDataDirectory': datadir,
                 'lineno': lineno,
-                'hostname_check_required': hostname_check_required
+                'hostname_check_required': hostname_check_required,
+                'recovery_type': recovery_type
 
             }
 
@@ -1173,6 +1183,7 @@ class RecoveryTripletsUserConfigFileParserTestCase(GpTestCase):
                 else:
                     address2, port2, datadir2 = parts2
                     hostname2 = address2
+                row["recovery_type"] = "Full"
                 row.update({
                     'newHostname': hostname2,
                     'newAddress': address2,

--- a/gpMgmt/doc/gprecoverseg_help
+++ b/gpMgmt/doc/gprecoverseg_help
@@ -166,7 +166,7 @@ Lines beginning with # are treated as comments and ignored.
 
 Segments to Recover
 Each line after the first specifies a segment to recover. This line can 
-have one of two formats. In the event of in-place recovery, enter one 
+have one of three formats. In the event of in-place recovery, enter one
 group of colon delimited fields in the line:
 
 failedAddress|failedPort|failedDataDirectory
@@ -177,6 +177,17 @@ add additional spaces.
 
 failedAddress|failedPort|failedDataDirectorySPACEnewAddress|newPort|
 newDataDirectory
+
+To do mix recovery, include a field with values I/D/F/i/d/f on each line. Default is
+incremental recovery if recovery_type field is not provided.
+
+recoveryType|failedAddress|failedPort|failedDataDirectory
+
+recoveryType field supports below values:
+    I/i for incremental recovery
+    D/d for differential recovery
+    F/f for full recovery
+
 
 Examples
 
@@ -192,6 +203,14 @@ Recovery of a single mirror to a new host with hostname specified:
 sdw1|sdw1-1|50001|/data1/mirror/gpseg16 SPACE
 sdw4|sdw4-1|50001|51001|/data1/recover1/gpseg16
 
+In-place recovery of down mirrors with recovery type:
+sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery (By default)
+I|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+i|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+D|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+d|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+F|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
+f|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
 
 Obtaining a Sample File
 

--- a/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gprecoverseg.feature
@@ -1,6 +1,51 @@
 @gprecoverseg
 Feature: gprecoverseg tests
 
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg recovery with a recovery configuration file and differential flag
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user immediately stops all mirror processes for content 0,1,2
+        And the user waits until mirror on content 0,1,2 is down
+        And user can start transactions
+        And the gprecoverseg input file "recover_config_file" is cleaned up
+       When a gprecoverseg input file "recover_config_file" is created with all the failed segments and valid recovery type
+        And the user runs "gprecoverseg -i /tmp/recover_config_file -a --differential"
+       Then gprecoverseg should return a return code of 0
+        And verify that mirror on content 0,1,2 is up
+        And gprecoverseg should print "Synchronization mode.* = Differential" to stdout 2 times
+        And gprecoverseg should print "Synchronization mode.* = Full" to stdout 1 times
+        And all the segments are running
+        And the segments are synchronized
+
+
+  @demo_cluster
+  @concourse_cluster
+  Scenario: gprecoverseg" with a recovery configuration file specifying the recovery type
+      Given the database is running
+        And all the segments are running
+        And the segments are synchronized
+        And user immediately stops all mirror processes for content 0,1,2
+        And the user waits until mirror on content 0,1,2 is down
+        And user can start transactions
+        And the gprecoverseg input file "recover_config_file" is cleaned up
+       When a gprecoverseg input file "recover_config_file" is created with all the failed segments and invalid recovery type
+        And the user runs "gprecoverseg -i /tmp/recover_config_file -a"
+       Then gprecoverseg should return a return code of 2
+        And gprecoverseg should print "Invalid recovery type provided, please provide any of I,D,F,i,d,f as recovery_type" to stdout
+        And verify that mirror on content 0,1,2 is down
+       When a gprecoverseg input file "recover_config_file" is created with all the failed segments and valid recovery type
+        And the user runs "gprecoverseg -i /tmp/recover_config_file -a"
+       Then gprecoverseg should return a return code of 0
+        And verify that mirror on content 0,1,2 is up
+        And gprecoverseg should print "Synchronization mode.*= Incremental" to stdout 1 times
+        And gprecoverseg should print "Synchronization mode.* = Differential" to stdout 1 times
+        And gprecoverseg should print "Synchronization mode.* = Full" to stdout 1 times
+        And all the segments are running
+        And the segments are synchronized
+
     Scenario Outline: <scenario> recovery works with tablespaces
         Given the database is running
           And user stops all primary processes
@@ -58,10 +103,7 @@ Feature: gprecoverseg tests
         And gprecoverseg should print "Only one of -F and --differential may be specified" to stdout
        When the user runs "gprecoverseg -a --differential -p localhost"
        Then gprecoverseg should return a return code of 2
-        And gprecoverseg should print "Only one of -i, -p, -r and --differential may be specified" to stdout
-       When the user runs gprecoverseg with input file and additional args "-a --differential"
-       Then gprecoverseg should return a return code of 2
-        And gprecoverseg should print "Only one of -i, -p, -r and --differential may be specified" to stdout
+        And gprecoverseg should print "Only one of -p, -r and --differential may be specified" to stdout
        When the user runs "gprecoverseg -a --differential -o outputConfigFile"
        Then gprecoverseg should return a return code of 2
         And gprecoverseg should print "Invalid -o provided with --differential argument" to stdout
@@ -668,6 +710,7 @@ Feature: gprecoverseg tests
     And the user waits until saved async process is completed
     And recovery_progress.file should not exist in gpAdminLogs
     And verify that mirror on content 0,1,2 is up
+    And user can start transactions
     When the user runs gprecoverseg with input file and additional args "-av"
     Then gprecoverseg should print "No basebackup running" to stdout
     And gprecoverseg should return a return code of 0

--- a/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
+++ b/gpMgmt/test/behave/mgmt_utils/steps/mgmt_utils.py
@@ -837,11 +837,8 @@ def impl(context, command, out_msg, num):
     msg_list = context.stdout_message.split('\n')
     msg_list = [x.strip() for x in msg_list]
 
-    count = 0
-    for line in msg_list:
-        if out_msg in line:
-            count += 1
-    if count != int(num):
+    match_count = len(re.findall(out_msg, context.stdout_message))
+    if match_count != int(num):
         raise Exception("Expected %s to occur %s times. Found %d. stdout: %s" % (out_msg, num, count, msg_list))
 
 @given('the user records the current timestamp in log_timestamp table')

--- a/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
+++ b/gpdb-doc/markdown/utility_guide/ref/gprecoverseg.html.md
@@ -101,7 +101,7 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 -i recover\_config\_file
 :   Specifies the name of a file with the details about failed segments to recover.
 
-    Each line in the config file specifies a segment to recover. This line can have one of two formats. In the event of in-place \(incremental\) recovery, enter one group of pipe-delimited fields in the line. For example:
+    Each line in the config file specifies a segment to recover. This line can have one of three formats. In the event of in-place \(incremental\) recovery, enter one group of pipe-delimited fields in the line. For example:
 
     ```
     failedAddress|failedPort|failedDataDirectory
@@ -125,6 +125,18 @@ The recovery process marks the segment as up again in the Greenplum Database sys
     failedHostname|failedAddress|failedPort|failedDataDirectory<SPACE>newHostname|newAddress|newPort|newDataDirectory
     ```
 
+    To do mix recovery, include a field with values I/D/F/i/d/f on each line. Default is incremental recovery if recovery_type field is not provided.
+
+    ```
+    recoveryType|failedAddress|failedPort|failedDataDirectory
+    ```
+
+    recoveryType field supports below values:
+        I/i for incremental recovery
+        D/d for differential recovery
+        F/f for full recovery
+
+
     > **Note** Lines beginning with `#` are treated as comments and ignored.
 
     **Examples**
@@ -139,6 +151,18 @@ The recovery process marks the segment as up again in the Greenplum Database sys
 
     ```
     sdw1-1|50001|/data1/mirror/gpseg16<SPACE>sdw4-1|50001|/data1/recover1/gpseg16
+    ```
+
+    In-place recovery of down mirrors with recovery type:
+
+    ```
+    sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery (By default)
+    I|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+    i|sdw1-1|50001|/data1/mirror/gpseg1   // Does incremental recovery
+    D|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+    d|sdw2-1|50002|/data1/mirror/gpseg2   // Does Differential recovery
+    F|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
+    f|sdw3-1|50003|/data1/mirror/gpseg3   // Does Full recovery
     ```
 
     **Obtaining a Sample File**


### PR DESCRIPTION
Backport of https://github.com/greenplum-db/gpdb/pull/16719

This PR added support for using the -i flag with differential recovery in the gprecoverseg command, enhancing its capabilities.

**Implementation:** 
Simultaneous Use of -i and --differential:
Added the functionality to allow the use of both the -i and --differential options simultaneously in the gprecoverseg command. This means that by providing a recovery configuration file with the -i flag and specifying the --differential flag, you will initiate a differential recovery process for all hosts listed in the recovery configuration file, similar to how the -i and -F options currently work together

**Recovery Type Specification in Recovery Configuration File:**
Added the functionality to specify I/D/F as a recovery type for each line in recovery_config_file and based on that recovery type respective recovery will be performed. The aim is to support existing formats of recovery config files, maintain backward compatibility, and add support for differential recovery.
E.g; A sample config file will look as follows:

```
I|sdw1|50001|/data1/primary/gpseg4  # Does incremental recovery
D|sdw1|50001|/data1/primary/gpseg4  # Does differential recovery
F|sdw1|50001|/data1/primary/gpseg4  # Does full recovery
sdw1|50001|/data1/primary/gpseg4     # Does incremental recovery 
sdw1-1|sdw1|50001|/data1/primary/gpseg4  # Does incremental recovery 
D|sdw1-1|sdw1|50001|/data1/primary/gpseg4  # Does differential recovery 
```
**Test:**
Added unit and behave test cases

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
