### PR TITLE
Pause on recovery target in continuous recovery

### DIFF
--- a/.abi-check/7.1.0/postgres.symbols.ignore
+++ b/.abi-check/7.1.0/postgres.symbols.ignore
@@ -1,4 +1,5 @@
 pgarch_start
 ConfigureNamesInt_gp
+ConfigureNamesBool_gp
 child_triggers
 has_update_triggers

--- a/gpcontrib/gp_pitr/Makefile
+++ b/gpcontrib/gp_pitr/Makefile
@@ -1,0 +1,23 @@
+EXTENSION = gp_pitr
+MODULES = gp_pitr
+
+EXTENSION_VERSION = 1.0
+
+
+DATA = gp_pitr--1.0.sql
+
+OBJS = gp_pitr.o
+
+MODULE_big = gp_pitr
+
+
+ifdef USE_PGXS
+PG_CONFIG = pg_config
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+include $(PGXS)
+else
+subdir = gpcontrib/gp_pitr
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif

--- a/gpcontrib/gp_pitr/gp_pitr--1.0.sql
+++ b/gpcontrib/gp_pitr/gp_pitr--1.0.sql
@@ -1,0 +1,15 @@
+/* gpcontrib/gp_pitr/gp_pitr--1.0.sql */
+
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION gp_pitr" to load this file. \quit
+
+CREATE FUNCTION gp_set_recovery_pause_target(
+    IN recovery_target_name text
+)
+    RETURNS void
+AS '$libdir/gp_pitr', 'gp_set_recovery_pause_target'
+LANGUAGE C VOLATILE;
+
+COMMENT ON FUNCTION gp_set_recovery_pause_target(text) IS 'Set recovery target name to pause on';
+
+REVOKE EXECUTE ON FUNCTION gp_set_recovery_pause_target(text) FROM public;

--- a/gpcontrib/gp_pitr/gp_pitr.c
+++ b/gpcontrib/gp_pitr/gp_pitr.c
@@ -1,0 +1,21 @@
+/*--------------------------------------------------------------------------
+ *
+ * gp_pitr.c
+ *	  Backports routines for creating named restore points
+ *
+ * Portions Copyright (c) 2020-Present Pivotal Software, Inc.
+ *--------------------------------------------------------------------------
+ */
+#include "postgres.h"
+
+#include "fmgr.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(gp_set_recovery_pause_target);
+
+Datum
+gp_set_recovery_pause_target(PG_FUNCTION_ARGS)
+{
+	return gp_set_recovery_pause_target_internal(fcinfo);
+}

--- a/gpcontrib/gp_pitr/gp_pitr.control
+++ b/gpcontrib/gp_pitr/gp_pitr.control
@@ -1,0 +1,3 @@
+comment = 'Distributed point-in-time-recovery functions'
+default_version = '1.0'
+relocatable = false

--- a/src/backend/access/transam/xlogfuncs_gp.c
+++ b/src/backend/access/transam/xlogfuncs_gp.c
@@ -292,3 +292,20 @@ gp_switch_wal(PG_FUNCTION_ARGS)
 
 	SRF_RETURN_DONE(funcctx);
 }
+
+/*
+ * GPDB:
+ * Sets recovery target to pause on
+ * in redo loop
+ */
+Datum
+gp_set_recovery_pause_target_internal(PG_FUNCTION_ARGS)
+{
+	text *recovery_target_name = PG_GETARG_TEXT_PP(0);
+	char *recovery_target_name_str;
+
+	recovery_target_name_str = text_to_cstring(recovery_target_name);
+	SetRecoveryPauseTarget(recovery_target_name_str);
+
+	PG_RETURN_VOID();
+}

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -2956,6 +2956,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		NULL, NULL, NULL
 	},
 	{
+		{"gp_pause_in_recovery", PGC_SIGHUP, DEVELOPER_OPTIONS,
+		 gettext_noop("Pause recovery right before start replaying WAL records."),
+		 NULL,
+		 GUC_NO_SHOW_ALL | GUC_NOT_IN_SAMPLE
+		},
+		&gp_pause_in_recovery,
+		false,
+		NULL, NULL, NULL
+	},
+	{
 		{"gp_autostats_allow_nonowner", PGC_SUSET, DEVELOPER_OPTIONS,
 			gettext_noop("Allow automatic stats collection on tables even for users who are not the owner of the relation."),
 			gettext_noop("If disabled, table statistics will be updated only when tables are modified by the owners of the relations.")

--- a/src/include/access/transam.h
+++ b/src/include/access/transam.h
@@ -190,6 +190,7 @@ extern int xid_warn_limit;
 
 /* GPDB-specific */
 extern bool gp_pause_on_restore_point_replay;
+extern bool gp_pause_in_recovery;
 
 /*
  * prototypes for functions in transam/transam.c

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -321,6 +321,7 @@ extern XLogRecPtr GetXLogInsertRecPtr(void);
 extern XLogRecPtr GetXLogWriteRecPtr(void);
 extern bool RecoveryIsPaused(void);
 extern void SetRecoveryPause(bool recoveryPause);
+extern void SetRecoveryPauseTarget(char *name);
 extern TimestampTz GetLatestXTime(void);
 extern TimestampTz GetCurrentChunkReplayStartTime(void);
 extern char *XLogFileNameP(TimeLineID tli, XLogSegNo segno);

--- a/src/include/fmgr.h
+++ b/src/include/fmgr.h
@@ -792,3 +792,5 @@ extern PGDLLIMPORT fmgr_hook_type fmgr_hook;
 	(!needs_fmgr_hook ? false : (*needs_fmgr_hook)(fn_oid))
 
 #endif							/* FMGR_H */
+
+extern Datum gp_set_recovery_pause_target_internal(PG_FUNCTION_ARGS);

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -206,6 +206,7 @@
 		"gp_max_system_slices",
 		"gp_motion_cost_per_row",
 		"gp_pause_on_restore_point_replay",
+		"gp_pause_in_recovery",
 		"gp_postmaster_address_family",
 		"gp_print_create_gang_time",
 		"gp_qd_hostname",

--- a/src/test/recovery/Makefile
+++ b/src/test/recovery/Makefile
@@ -10,6 +10,7 @@
 #-------------------------------------------------------------------------
 
 EXTRA_INSTALL=contrib/test_decoding
+EXTRA_INSTALL += gpcontrib/gp_pitr
 
 subdir = src/test/recovery
 top_builddir = ../../..

--- a/src/test/recovery/t/104_read_replica_pause_resume.pl
+++ b/src/test/recovery/t/104_read_replica_pause_resume.pl
@@ -1,0 +1,103 @@
+# Test pause in recovery and resume
+use strict;
+use warnings;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More tests => 17;
+
+# Initialize primary node
+my $node_primary = PostgreSQL::Test::Cluster->new('primary');
+$node_primary->init(has_archiving => 1, allows_streaming => 1);
+# Start it
+$node_primary->start;
+
+# Enable gp_pitr extension
+$node_primary->safe_psql('postgres', "CREATE EXTENSION gp_pitr;");
+
+# Create data before taking the backupj
+$node_primary->safe_psql('postgres', "CREATE TABLE table_foo AS SELECT generate_series(1,1000);");
+# Take backup from which all operations will be run
+$node_primary->backup('my_backup');
+$node_primary->safe_psql('postgres', "SELECT pg_create_restore_point('rp0');");
+my $lsn0 = $node_primary->safe_psql('postgres', "SELECT pg_current_wal_lsn();");
+$node_primary->safe_psql('postgres', "SELECT pg_switch_wal();");
+
+# Add more data, create restore points and switch wal
+# rp1
+$node_primary->safe_psql('postgres', "INSERT INTO table_foo VALUES (generate_series(1001,2000))");
+$node_primary->safe_psql('postgres', "SELECT pg_create_restore_point('rp1');");
+my $lsn1 = $node_primary->safe_psql('postgres', "SELECT pg_current_wal_lsn();");
+$node_primary->safe_psql('postgres', "SELECT pg_switch_wal();");
+
+# rp2
+$node_primary->safe_psql('postgres', "INSERT INTO table_foo VALUES (generate_series(2001, 3000))");
+$node_primary->safe_psql('postgres', "SELECT pg_create_restore_point('rp2');");
+my $lsn2 = $node_primary->safe_psql('postgres', "SELECT pg_current_wal_lsn();");
+$node_primary->safe_psql('postgres', "SELECT pg_switch_wal();");
+
+# rp3
+$node_primary->safe_psql('postgres', "INSERT INTO table_foo VALUES (generate_series(3001, 4000))");
+$node_primary->safe_psql('postgres', "SELECT pg_create_restore_point('rp3');");
+my $lsn3 = $node_primary->safe_psql('postgres', "SELECT pg_current_wal_lsn();");
+$node_primary->safe_psql('postgres', "SELECT pg_switch_wal();");
+
+# Restore the backup
+my $node_standby = PostgreSQL::Test::Cluster->new("standby");
+	$node_standby->init_from_backup($node_primary, 'my_backup',
+		has_restoring => 1);
+
+# Set `hot_standby` and `gp_pause_in_recovery` GUCs
+$node_standby->append_conf('postgresql.conf', qq(hot_standby = 'on'));
+$node_standby->append_conf('postgresql.conf', qq(gp_pause_in_recovery = 'on'));
+# Start the standby, it should pause before lsn0
+$node_standby->start;
+
+# Make sure recovery is paused ASAP
+ok($node_standby->safe_psql('postgres', 'SELECT pg_is_in_recovery();') eq 't',
+	'standby is in recovery after restore');
+ok($node_standby->safe_psql('postgres', 'SELECT pg_is_wal_replay_paused();') eq 't',
+	'standby is paused in recovery after restore');
+ok($node_standby->safe_psql('postgres', "SELECT pg_last_wal_replay_lsn() < '$lsn0'::pg_lsn;")  eq 't',
+	'standby has not replayed rp0 yet');
+
+sub test_pause_in_recovery
+{
+	my ($restore_point, $test_lsn, $num_rows) = @_;
+	# Set recovery target to pause and resume
+	$node_standby->safe_psql('postgres', "SELECT gp_set_recovery_pause_target('$restore_point');");
+	$node_standby->safe_psql('postgres', "SELECT pg_wal_replay_resume();");
+	# Wait until standby has replayed enough data
+	my $caughtup_query = "SELECT '$test_lsn'::pg_lsn <= pg_last_wal_replay_lsn()";
+	$node_standby->poll_query_until('postgres', $caughtup_query)
+		or die "Timed out while waiting for standby to catch up";
+	# Check data has been replayed
+	my $result = $node_standby->safe_psql('postgres', "SELECT count(*) FROM table_foo;");
+	is($result, $num_rows, "check standby content for $restore_point");
+	ok($node_standby->safe_psql('postgres', 'SELECT pg_is_in_recovery();') eq 't',
+		"standby is in recovery on $restore_point");
+	ok($node_standby->safe_psql('postgres', 'SELECT pg_is_wal_replay_paused();') eq 't',
+		"standby is paused in recovery on $restore_point");
+}
+
+test_pause_in_recovery('rp0', $lsn0, 1000);
+test_pause_in_recovery('rp1', $lsn1, 2000);
+test_pause_in_recovery('rp2', $lsn2, 3000);
+test_pause_in_recovery('rp3', $lsn3, 4000);
+
+# Run promote then resume recovery
+$node_standby->safe_psql('postgres', "SELECT pg_promote(false);");
+$node_standby->safe_psql('postgres', "SELECT pg_wal_replay_resume();");
+# Wait for standby to promote
+$node_standby->poll_query_until('postgres', "SELECT NOT pg_is_in_recovery();")
+	or die "Timed out while waiting for standby to exit recovery";
+my $result = $node_standby->safe_psql('postgres', "SELECT count(*) FROM table_foo;");
+is($result, 4000, "check standby content after promotion");
+# Make sure former standby is now writable
+$node_standby->safe_psql('postgres', "CREATE TABLE table_boo AS SELECT generate_series(1,1000);");
+$result = $node_standby->safe_psql('postgres', "SELECT count(*) FROM table_boo;");
+is($result, 1000, "check standby is writable after promotion");
+
+$node_primary->teardown_node;
+$node_standby->teardown_node;
+
+done_testing();


### PR DESCRIPTION
 Previously when in archive recovery we were not able to pause
 on specific wal record. The recovery continued until it
 reached recovery_target, specified in postgresql.conf,
 which is not reloadable, so to continue recovery to the
 next recovery_target we had to stop the cluster, change recovery_target
 and start the cluster again.
 If we want to enable the cluster for read-only queries while
 continuing archive recovery, we can not restart the cluster
 to reload the recovery target. In this commit, we introduce the ability
 to pause in recovery without restarting the cluster.

 The following changes were made:

 - The recoveryPauseTargetName field was added to the shared memory structure (XLogCtl). When in the recovery loop, this field will tell gpdb to pause on a specific restore point wal record and wait for unpause (resume).
 - The gp_pitr extension was added. When enabled it creates the UDF gp_set_recovery_pause_target(name), where 'name' is a restore point name to pause on. This function will allow the user to set the recoveryPauseTargetName in shared memory.
 - gp_pause_in_recovery GUC was added When this GUC is set, it does the following:
    - before even going to the redo loop it will zero out the recoveryPauseTargetName variable.
    - in the redo loop if recoveryPauseTargetName is not set, it will pause recovery and wait. This GUC is needed if we want to pause/resume recovery granularly on the wal record specified later.

  The user workflow would be the following:
  - create gp_pitr extension on the Primary cluster (it will be restored/replayed on the Recovery cluster)
  - on the Recovery cluster enable 2 GUCs: gp_pause_in_recovery and hot_standby so that we can connect
  - start the Recovery cluster and connect. The replay will be paused right after we reach the consistency point in the redo loop and the recoveryPauseTargetName will be unset.
  - call SELECT gp_set_recovery_pause_target(desired restore point name); then call SELECT pg_wal_replay_resume(); The recovery will proceed to the specified restore point and pause there.

  Note that in this workflow to stay in recovery we do not need to set
  either recovery_target_name or recovery_target_action in the postgresql.conf.
  These GUCs will define when to exit from the redo loop and what do to in this case.
  If we want to promote - we will need to call pg_promote() on
  coordinator and resume recovery.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
