### PR TITLE
fix subplan relids problem wrapped by PlaceHolderVar

### DIFF
--- a/src/test/regress/expected/join.out
+++ b/src/test/regress/expected/join.out
@@ -3068,28 +3068,28 @@ select * from
 where
   1 = (select 1 from int8_tbl t3 where ss.y is not null limit 1)
 order by 1,2;
-                                    QUERY PLAN                                     
------------------------------------------------------------------------------------
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Merge Key: t1.q1, t1.q2
    ->  Sort
          Sort Key: t1.q1, t1.q2
-         ->  Hash Left Join
-               Hash Cond: (t1.q2 = t2.q1)
-               Filter: ((SubPlan 1) = 1)
-               ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Hash Key: t1.q2
-                     ->  Seq Scan on int8_tbl t1
+         ->  Hash Right Join
+               Hash Cond: (t2.q1 = t1.q2)
+               Filter: (1 = ((SubPlan 1)))
+               ->  Seq Scan on int8_tbl t2
+                     SubPlan 1
+                       ->  Limit
+                             ->  Result
+                                   One-Time Filter: ((42) IS NOT NULL)
+                                   ->  Materialize
+                                         ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                                               ->  Seq Scan on int8_tbl t3
                ->  Hash
-                     ->  Seq Scan on int8_tbl t2
-               SubPlan 1
-                 ->  Limit
-                       ->  Result
-                             One-Time Filter: ((42) IS NOT NULL)
-                             ->  Materialize
-                                   ->  Broadcast Motion 3:3  (slice2; segments: 3)
-                                         ->  Seq Scan on int8_tbl t3
- Optimizer: Postgres query optimizer
+                     ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                           Hash Key: t1.q2
+                           ->  Seq Scan on int8_tbl t1
+ Optimizer: Postgres-based planner
 (20 rows)
 
 --


### PR DESCRIPTION
This PR is trying to fix the issue  #16680.

---

### 1. Context

At #8624, Heikki used `PlaceholderVar` to wrap the SubPlan nodes that could be referred to 
many times in many places, such as the below example:

```
create table foo(a int, b int);
create table bar(c int, d varchar);
create table buz(i int);

explain (costs off) SELECT bar.c FROM bar, foo WHERE 
foo.b = (SELECT max(i) FROM buz WHERE bar.c = 9) AND foo.b = bar.d::int4;
                                       QUERY PLAN                                        
-----------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice1; segments: 3)
   ->  Hash Join
         Hash Cond: (((SubPlan 1)) = foo.b)
         ->  Broadcast Motion 3:3  (slice2; segments: 3)
               ->  Seq Scan on bar
                     Filter: ((SubPlan 1) = (d)::integer)
                     SubPlan 1
                       ->  Aggregate
                             ->  Result
                                   One-Time Filter: (bar.c = 9)
                                   ->  Materialize
                                         ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                               ->  Seq Scan on buz
         ->  Hash
               ->  Seq Scan on foo
```

This query would generate an equivalence class containing 3 nodes:

```
(SubPlan 1) = foo.b = (d)::integer
```

So when we distribute eq_class member, we could refer to the simple SubPlan many times. And
as we know, Greenplum is a distributed database, we can not share data cross different processes,
so in Greenplum 6, this SubPlan will be executed twice in different slices:

```bash
explain (costs off) SELECT bar.c FROM bar, foo WHERE 
    foo.b = (SELECT max(i) FROM buz WHERE bar.c = 9) AND foo.b = bar.d::int4;
                                          QUERY PLAN                                           
-----------------------------------------------------------------------------------------------
 Gather Motion 3:1  (slice4; segments: 3)
   ->  Hash Join
         Hash Cond: ((SubPlan 1) = foo.b)
         ->  Broadcast Motion 3:3  (slice2; segments: 3)
               ->  Seq Scan on bar
                     Filter: ((SubPlan 1) = (d)::integer)
                     -- The first execution in slice2
                     SubPlan 1  (slice2; segments: 3)
                       ->  Aggregate
                             ->  Result
                                   One-Time Filter: (bar.c = 9)
                                   ->  Result
                                         ->  Materialize
                                               ->  Broadcast Motion 3:3  (slice1; segments: 3)
                                                     ->  Seq Scan on buz
         ->  Hash
               ->  Seq Scan on foo
        -- The second execution in slice4
         SubPlan 1  (slice4; segments: 3)
           ->  Aggregate
                 ->  Result
                       One-Time Filter: (bar.c = 9)
                       ->  Result
                             ->  Materialize
                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)
                                         ->  Seq Scan on buz
```

So in order to resolve this problem, #8624 has been created.

### 2. Issue #16680

In #16680, we actually have a strange query:

```sql
create table foo(a int, b int);
create table bar(c int, d varchar);
create table buz(i int, j int);

select * from foo
where EXISTS (
    select * from bar where 
        case when EXISTS (select foo.a from buz where bar.d is NULL) 
        then 0 else 1 end
        = bar.c
);
```

There is a CASE-WHEN clause and it's a correlated SubLink, since `bar.d` is the outer param. So we can
not pull up it simply, we have to treat it as a sub query. We'll wrap it with `PlaceHolderVar` and replace it
at the final stage of Planner. But during eq_class members distribution, the `PlaceHolderVar->phrels` is not
equal to `PlaceHolderInfo->ph_eval_at`, so the assertion failed.

### 3. The resolution

Honestly, I don't think this is a good way to resolve that problem, it's just an ugly patch and nobody will understand
why do we do that so, but I have no other choice.


