### PR TITLE
Add retries to gpssh and allow to failfast when hosts not reachable

### DIFF
--- a/gpMgmt/bin/gppylib/util/ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/ssh_utils.py
@@ -8,6 +8,7 @@ import cmd
 import os
 import sys
 import socket
+import time
 import threading
 from gppylib.commands.base import WorkerPool, REMOTE
 from gppylib.commands.unix import Hostname, Echo
@@ -16,6 +17,7 @@ from gpssh_modules import gppxssh_wrapper
 sys.path.insert(1, sys.path[0] + '/lib')
 from pexpect import pxssh
 
+RETRY_EXPONENT = 3
 
 class HostNameError(Exception):
     def __init__(self, msg, lineno=0):
@@ -167,7 +169,7 @@ class Session(cmd.Cmd):
         self.peerStringFormatRaw = "[%%%ds]" % cnt
         return self.peerStringFormatRaw
 
-    def login(self, hostList=None, userName=None, delaybeforesend=0.05, sync_multiplier=1.0, sync_retries=3):
+    def login(self, hostList=None, userName=None, delaybeforesend=0.05, sync_multiplier=1.0, sync_retries=3, all_hosts=None):
         """This is the normal entry point used to add host names to the object and log in to each of them"""
         if self.verbose: print('\n[Reset ...]')
         if not (self.hostList or hostList):
@@ -192,40 +194,51 @@ class Session(cmd.Cmd):
         good_list = []
         print_lock = threading.Lock()
 
-        def connect_host(hostname, p):
+        def connect_host(hostname):
             self.hostList.append(hostname)
-            try:
-                # The sync_multiplier value is passed onto pexpect.pxssh which is used to determine timeout
-                # values for prompt verification after an ssh connection is established.
-                p.login(hostname, self.userName, sync_multiplier=sync_multiplier)
-                p.x_peer = hostname
-                p.x_pid = p.pid
-                good_list.append(p)
-                if self.verbose:
+            num_retries = sync_retries
+            retry_attempt = 0
+            success = False
+            while (not success) and retry_attempt <= num_retries:
+                try:
+                    p = gppxssh_wrapper.PxsshWrapper(delaybeforesend=delaybeforesend,
+                                                     sync_retries=sync_retries,
+                                                     options={"StrictHostKeyChecking": "no",
+                                                              "BatchMode": "yes"})
+                    # The sync_multiplier value is passed onto pexpect.pxssh which is used to determine timeout
+                    # values for prompt verification after an ssh connection is established.
+                    p.login(hostname, self.userName, sync_multiplier=sync_multiplier)
+                    p.x_peer = hostname
+                    p.x_pid = p.pid
+                    good_list.append(p)
+                    success = True
+                    if self.verbose:
+                        with print_lock:
+                            print('[INFO] login %s' % hostname)
+                except Exception as e:
                     with print_lock:
-                        print('[INFO] login %s' % hostname)
-            except Exception as e:
-                with print_lock:
-                    print('[ERROR] unable to login to %s' % hostname)
-                    if type(e) is pxssh.ExceptionPxssh:
-                        print(e)
-                    elif type(e) is pxssh.EOF:
-                        print('Could not acquire connection.')
-                    else:
-                        print('hint: use gpssh-exkeys to setup public-key authentication between hosts')
+                        print('[ERROR] unable to login to %s' % hostname)
+                        if type(e) is pxssh.ExceptionPxssh:
+                            print(e)
+                        elif type(e) is pxssh.EOF:
+                            print('Could not acquire connection.')
+                        else:
+                            print(e)
+                            print('hint: use gpssh-exkeys to setup public-key authentication between hosts')
+                    time.sleep(min(120, RETRY_EXPONENT ** retry_attempt))
+                    retry_attempt += 1
 
         thread_list = []
         for host in hostList:
-            p = gppxssh_wrapper.PxsshWrapper(delaybeforesend=delaybeforesend,
-                                             sync_retries=sync_retries,
-                                             options={"StrictHostKeyChecking": "no",
-                                                      "BatchMode": "yes"})
-            t = threading.Thread(target=connect_host, args=(host, p))
+            t = threading.Thread(target=connect_host, args=(host,))
             t.start()
             thread_list.append(t)
 
         for t in thread_list:
             t.join()
+
+        if all_hosts and len(good_list) != len(hostList):
+            raise RuntimeError("Not all hosts reached.")
 
         # Restore terminal type
         if origTERM:

--- a/gpMgmt/bin/gppylib/util/test/unit/test_cluster_ssh_utils.py
+++ b/gpMgmt/bin/gppylib/util/test/unit/test_cluster_ssh_utils.py
@@ -30,7 +30,7 @@ class SshUtilsTestCase(unittest.TestCase):
         hostlist.add('localhost')
         hostlist.add('localhost')
         hostlist.filterMultiHomedHosts()
-        self.assertEqual(len(hostlist.get()), 1, 
+        self.assertEqual(len(hostlist.get()), 1,
                          "There should be only 1 host in the hostlist after calling filterMultiHomedHosts")
 
     def test01_test_SessionLogin(self):
@@ -40,10 +40,18 @@ class SshUtilsTestCase(unittest.TestCase):
 
         uname = pwd.getpwuid(os.getuid()).pw_name
 
-        s = Session()
-        s.login(['localhost', 'fakehost'], uname)
-        pxssh_hosts = [pxssh_session.x_peer for pxssh_session in s.pxssh_list]
+        s1 = Session()
+        s1.login(['localhost', 'fakehost'], uname)
+        pxssh_hosts = [pxssh_session.x_peer for pxssh_session in s1.pxssh_list]
         self.assertEqual(pxssh_hosts, ['localhost'])
+
+        s2 = Session()
+        try:
+            s2.login(['localhost', 'example.com'], uname, all_hosts=True)
+            self.assert_("Unrechable")
+        except RuntimeError:
+            pxssh_hosts = [pxssh_session.x_peer for pxssh_session in s2.pxssh_list]
+            self.assertEqual(pxssh_hosts, ['localhost'])
 
     def test02_pxssh_delaybeforesend(self):
         '''

--- a/gpMgmt/bin/gpssh
+++ b/gpMgmt/bin/gpssh
@@ -5,16 +5,17 @@ gpssh -- ssh access to multiple hosts at once
 
 Usage: gpssh [--version] [-?v] [-h host] [-f hostfile] [cmd]
 
-          --version : print version information
-          -?        : print this help screen
-          -v        : verbose mode
-          -e        : echo commands as they are executed
-          -h host   : the host to connect to (multiple -h is okay)
-          -f file   : a file listing all hosts to connect to
-          -D        : do not filter multi-homed hosts 
-          -s        : source gpdb environment while login
-          cmd       : the command to execute. If not present, 
-                      go into interactive mode
+          --version   : print version information
+          -?          : print this help screen
+          -v          : verbose mode
+          -e          : echo commands as they are executed
+          -h host     : the host to connect to (multiple -h is okay)
+          -f file     : a file listing all hosts to connect to
+          -D          : do not filter multi-homed hosts
+          -s          : source gpdb environment while login
+          --all-hosts : fail execution when not all hosts reached
+          cmd         : the command to execute. If not present,
+                        go into interactive mode
 '''
 import os
 import sys
@@ -52,6 +53,7 @@ class __globals__:
     DELAY_BEFORE_SEND = None
     PROMPT_VALIDATION_TIMEOUT = None
     SYNC_RETRIES = None
+    ALL_HOSTS = None
 
 GV = __globals__()
 
@@ -73,7 +75,7 @@ def print_version():
 
 def parseCommandLine():
     try:
-        (options, args) = getopt.getopt(sys.argv[1:], '?evsh:f:D:u:d:t:', ['version'])
+        (options, args) = getopt.getopt(sys.argv[1:], '?evsh:f:D:u:d:t:', ['version', 'all-hosts'])
     except Exception as e:
         usage('Error: ' + str(e))
     for (switch, val) in options:
@@ -93,6 +95,8 @@ def parseCommandLine():
             GV.DELAY_BEFORE_SEND = float(val)
         elif (switch == '-t'):
             GV.PROMPT_VALIDATION_TIMEOUT = float(val)
+        elif (switch == '--all-hosts'):
+            GV.ALL_HOSTS = True
     hf = (len(GV.opt['-h']) and 1 or 0) + (GV.opt['-f'] and 1 or 0)
     if hf != 1:
         usage('Error: please specify at least one of -h or -f args, but not both')
@@ -207,7 +211,7 @@ def interactive():
             if not GV.session:
                 GV.session = ssh_utils.Session()
                 GV.session.verbose = GV.opt['-v']
-                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT, GV.SYNC_RETRIES)
+                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT, GV.SYNC_RETRIES, GV.ALL_HOSTS)
                 GV.session.echoCommand = GV.opt['-e']
             if GV.opt['-s']:
                 GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))
@@ -261,7 +265,7 @@ def main():
             try:
                 GV.session = ssh_utils.Session()
                 GV.session.verbose = GV.opt['-v']
-                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT, GV.SYNC_RETRIES)
+                GV.session.login(GV.opt['-h'], GV.USER, GV.DELAY_BEFORE_SEND, GV.PROMPT_VALIDATION_TIMEOUT, GV.SYNC_RETRIES, GV.ALL_HOSTS)
                 GV.session.echoCommand = GV.opt['-e']
                 if GV.opt['-s']:
                     GV.session.executeCommand("source {0}/greenplum_path.sh".format(os.environ["GPHOME"]))


### PR DESCRIPTION
Hi, greenplum team!

Here a patch that:
* adds retries to connection phase of gpssh
* allows to fail fast when some of hosts are not reachable

I am using this to make some scripting around greenplum a bit more reliable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
