### PR TITLE
Fix typo

### DIFF
--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -1447,7 +1447,7 @@ AppendOnlyStorageWrite_Content(AppendOnlyStorageWrite *storageWrite,
 			 * Since ~_GetBuffer now takes in a specification of the header
 			 * kind, we need to set the header kind so general routines like
 			 * ~_CompressAppend will work correctly when writing the small
-			 * "fragments
+			 * fragments
 			 */
 			storageWrite->getBufferAoHeaderKind = AoHeaderKind_SmallContent;
 			AppendOnlyStorageWrite_CompressAppend(storageWrite,

--- a/src/backend/cdb/cdbappendonlystoragewrite.c
+++ b/src/backend/cdb/cdbappendonlystoragewrite.c
@@ -130,14 +130,14 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 	 * Now that we have determined the compression overrun, we can initialize
 	 * BufferedAppend with the correct maxBufferLen + compressionOverrunLen.
 	 */
-	storageWrite->maxBufferWithCompressionOverrrunLen =
+	storageWrite->maxBufferWithCompressionOverrunLen =
 		storageWrite->maxBufferLen + storageWrite->compressionOverrunLen;
 	storageWrite->maxLargeWriteLen = 2 * storageWrite->maxBufferLen;
-	Assert(storageWrite->maxBufferWithCompressionOverrrunLen <= storageWrite->maxLargeWriteLen);
+	Assert(storageWrite->maxBufferWithCompressionOverrunLen <= storageWrite->maxLargeWriteLen);
 
 	memoryLen = BufferedAppendMemoryLen
 		(
-		 storageWrite->maxBufferWithCompressionOverrrunLen, /* maxBufferLen */
+		 storageWrite->maxBufferWithCompressionOverrunLen, /* maxBufferLen */
 		 storageWrite->maxLargeWriteLen);
 
 	memory = (uint8 *) palloc(memoryLen);
@@ -145,7 +145,7 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 	BufferedAppendInit(&storageWrite->bufferedAppend,
 					   memory,
 					   memoryLen,
-					   storageWrite->maxBufferWithCompressionOverrrunLen,
+					   storageWrite->maxBufferWithCompressionOverrunLen,
 					   storageWrite->maxLargeWriteLen,
 					   relationName);
 
@@ -154,7 +154,7 @@ AppendOnlyStorageWrite_Init(AppendOnlyStorageWrite *storageWrite,
 		   storageWrite->relationName,
 		   (storageWrite->storageAttributes.compress ? "true" : "false"),
 		   storageWrite->storageAttributes.compressLevel,
-		   storageWrite->maxBufferWithCompressionOverrrunLen,
+		   storageWrite->maxBufferWithCompressionOverrunLen,
 		   storageWrite->maxLargeWriteLen);
 
 	/*
@@ -1038,7 +1038,7 @@ AppendOnlyStorageWrite_CompressAppend(AppendOnlyStorageWrite *storageWrite,
 
 	dataBuffer = &header[storageWrite->currentCompleteHeaderLen];
 	dataBufferWithOverrrunLen =
-		storageWrite->maxBufferWithCompressionOverrrunLen
+		storageWrite->maxBufferWithCompressionOverrunLen
 		- storageWrite->currentCompleteHeaderLen;
 
 	/*

--- a/src/backend/cdb/cdbbufferedappend.c
+++ b/src/backend/cdb/cdbbufferedappend.c
@@ -36,14 +36,14 @@ static void BufferedAppendWrite(
  * large write lengths.
  */
 int32
-BufferedAppendMemoryLen(int32 maxBufferWithCompressionOverrrunLen,
+BufferedAppendMemoryLen(int32 maxBufferWithCompressionOverrunLen,
 						int32 maxLargeWriteLen)
 {
-	Assert(maxBufferWithCompressionOverrrunLen > 0);
-	Assert(maxLargeWriteLen >= maxBufferWithCompressionOverrrunLen);
+	Assert(maxBufferWithCompressionOverrunLen > 0);
+	Assert(maxLargeWriteLen >= maxBufferWithCompressionOverrunLen);
 
 	/* Large write memory areas plus adjacent extra memory for 1 buffer. */
-	return (maxLargeWriteLen + maxBufferWithCompressionOverrrunLen);
+	return (maxLargeWriteLen + maxBufferWithCompressionOverrunLen);
 }
 
 /*
@@ -56,15 +56,15 @@ void
 BufferedAppendInit(BufferedAppend *bufferedAppend,
 				   uint8 *memory,
 				   int32 memoryLen,
-				   int32 maxBufferWithCompressionOverrrunLen,
+				   int32 maxBufferWithCompressionOverrunLen,
 				   int32 maxLargeWriteLen,
 				   char *relationName)
 {
 	Assert(bufferedAppend != NULL);
 	Assert(memory != NULL);
-	Assert(maxBufferWithCompressionOverrrunLen> 0);
-	Assert(maxLargeWriteLen >= maxBufferWithCompressionOverrrunLen);
-	Assert(memoryLen >= BufferedAppendMemoryLen(maxBufferWithCompressionOverrrunLen, maxLargeWriteLen));
+	Assert(maxBufferWithCompressionOverrunLen> 0);
+	Assert(maxLargeWriteLen >= maxBufferWithCompressionOverrunLen);
+	Assert(memoryLen >= BufferedAppendMemoryLen(maxBufferWithCompressionOverrunLen, maxLargeWriteLen));
 
 	memset(bufferedAppend, 0, sizeof(BufferedAppend));
 
@@ -76,7 +76,7 @@ BufferedAppendInit(BufferedAppend *bufferedAppend,
 	/*
 	 * Large-read memory level members.
 	 */
-	bufferedAppend->maxBufferWithCompressionOverrrunLen = maxBufferWithCompressionOverrrunLen;
+	bufferedAppend->maxBufferWithCompressionOverrunLen = maxBufferWithCompressionOverrunLen;
 	bufferedAppend->maxLargeWriteLen = maxLargeWriteLen;
 
 	bufferedAppend->memory = memory;
@@ -257,10 +257,10 @@ BufferedAppendGetBuffer(BufferedAppend *bufferedAppend,
 
 	Assert(bufferedAppend != NULL);
 	Assert(bufferedAppend->file >= 0);
-	if (bufferLen > bufferedAppend->maxBufferWithCompressionOverrrunLen)
+	if (bufferLen > bufferedAppend->maxBufferWithCompressionOverrunLen)
 		elog(ERROR,
 			 "bufferLen %d greater than maxBufferLen %d at position " INT64_FORMAT " in table \"%s\" in file \"%s\"",
-			 bufferLen, bufferedAppend->maxBufferWithCompressionOverrrunLen, bufferedAppend->largeWritePosition,
+			 bufferLen, bufferedAppend->maxBufferWithCompressionOverrunLen, bufferedAppend->largeWritePosition,
 			 bufferedAppend->relationName,
 			 bufferedAppend->filePathName);
 
@@ -271,7 +271,7 @@ BufferedAppendGetBuffer(BufferedAppend *bufferedAppend,
 	currentLargeWriteLen = bufferedAppend->largeWriteLen;
 	Assert(currentLargeWriteLen + bufferLen <=
 		   bufferedAppend->maxLargeWriteLen +
-		   bufferedAppend->maxBufferWithCompressionOverrrunLen);
+		   bufferedAppend->maxBufferWithCompressionOverrunLen);
 
 	bufferedAppend->bufferLen = bufferLen;
 
@@ -304,7 +304,7 @@ BufferedAppendGetMaxBuffer(BufferedAppend *bufferedAppend)
 
 	return BufferedAppendGetBuffer(
 								   bufferedAppend,
-								   bufferedAppend->maxBufferWithCompressionOverrrunLen);
+								   bufferedAppend->maxBufferWithCompressionOverrunLen);
 }
 
 void
@@ -339,7 +339,7 @@ BufferedAppendFinishBuffer(BufferedAppend *bufferedAppend,
 
 	newLen = bufferedAppend->largeWriteLen + usedLen;
 	Assert(newLen <= bufferedAppend->maxLargeWriteLen +
-		   bufferedAppend->maxBufferWithCompressionOverrrunLen);
+		   bufferedAppend->maxBufferWithCompressionOverrunLen);
 	if (newLen >= bufferedAppend->maxLargeWriteLen)
 	{
 		/*

--- a/src/include/cdb/cdbappendonlystoragewrite.h
+++ b/src/include/cdb/cdbappendonlystoragewrite.h
@@ -149,7 +149,7 @@ typedef struct AppendOnlyStorageWrite
 	int32		compressionOverrunLen;
 
 	/* The maximum buffer plus compression overrun byte length */
-	int32		maxBufferWithCompressionOverrrunLen;
+	int32		maxBufferWithCompressionOverrunLen;
 
 	/*
 	 * When non-null, we are doing VerifyBlock and this is the buffer to

--- a/src/include/cdb/cdbbufferedappend.h
+++ b/src/include/cdb/cdbbufferedappend.h
@@ -33,7 +33,7 @@ typedef struct BufferedAppend
 	 */
 
     /* AO block size plus additional space cost of compression algorithm */
-    int32      			 maxBufferWithCompressionOverrrunLen;
+    int32      			 maxBufferWithCompressionOverrunLen;
     /* buffer will be flushed to disk when maxLargeWriteLen is reached  */
     int32      			 maxLargeWriteLen;
 
@@ -87,7 +87,7 @@ typedef struct BufferedAppend
  * large write lengths.
  */
 extern int32 BufferedAppendMemoryLen(
-    int32                maxBufferWithCompressionOverrrunLen,
+    int32                maxBufferWithCompressionOverrunLen,
     int32                maxLargeWriteLen);
 
 /*
@@ -100,7 +100,7 @@ extern void BufferedAppendInit(
 	BufferedAppend *bufferedAppend,
 	uint8          *memory,
 	int32          memoryLen,
-	int32          maxBufferWithCompressionOverrrunLen,
+	int32          maxBufferWithCompressionOverrunLen,
 	int32          maxLargeWriteLen,
 	char           *relationName);
 


### PR DESCRIPTION
There are 2 vars, `compressionOverrunLen` and  `maxBufferWithCompressionOverrrunLen` in the definition of struct `AppendOnlyStorageWrite`. The two variables are related, but spelled differently. I think there is a redundant letter **_R_** in maxBufferWithCompressionOver **_R_**  runLen.
```
typedef struct AppendOnlyStorageWrite
{
        /*......*/
	/*
	 * Number of bytes of extra buffer must have beyond the output compression
	 * buffer needed for spillover for some compression libraries.
	 */
	int32		compressionOverrunLen;

	/* The maximum buffer plus compression overrun byte length */
	int32		maxBufferWithCompressionOverrrunLen;
        /*......*/
}
```
