### PR TITLE
Fix Inject_fault suspend cannot be canceled

### DIFF
--- a/src/backend/utils/misc/faultinjector.c
+++ b/src/backend/utils/misc/faultinjector.c
@@ -469,6 +469,7 @@ FaultInjector_InjectFaultIfSet_out_of_line(
 			while ((entry = FaultInjector_LookupHashEntry(entryLocal->faultName)) != NULL &&
 				   entry->faultInjectorType != FaultInjectorTypeResume)
 			{
+				CHECK_FOR_INTERRUPTS();
 				pg_usleep(1000000L);  // 1 sec
 			}
 

--- a/src/test/isolation2/expected/cancel_query.out
+++ b/src/test/isolation2/expected/cancel_query.out
@@ -49,3 +49,35 @@ SELECT gp_inject_fault('zlib_decompress_after_decompress_fn', 'reset', dbid) FRO
  Success:        
  Success:        
 (8 rows)
+
+CREATE TABLE  a_suspend_blocking(a int, b int, c int);
+CREATE TABLE
+INSERT INTO a_suspend_blocking select i,i,i from generate_series(1, 100) i;
+INSERT 0 100
+
+0: SELECT gp_inject_fault_infinite('exec_mpp_query_start', 'suspend', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content >= 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+0&: SELECT * FROM a_suspend_blocking;  <waiting ...>
+
+1: SELECT pg_cancel_backend(pid) FROM pg_stat_activity WHERE query LIKE 'SELECT * FROM a_suspend_blocking%';
+ pg_cancel_backend 
+-------------------
+ t                 
+(1 row)
+0<:  <... completed>
+ERROR:  canceling statement due to user request
+
+SELECT gp_inject_fault_infinite('exec_mpp_query_start', 'reset', dbid) FROM gp_segment_configuration WHERE role = 'p' AND content >= 0;
+ gp_inject_fault_infinite 
+--------------------------
+ Success:                 
+ Success:                 
+ Success:                 
+(3 rows)
+DROP TABLE a_suspend_blocking;
+DROP TABLE


### PR DESCRIPTION
we should CHECK_FOR_INTERRUPTS() as FaultInjectorTypeSuspend is sleep in while().

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community