### PR TITLE
Do RelationStorageIsAO() check before call AORelationVersion_Validate()

### DIFF
--- a/src/backend/optimizer/util/plancat.c
+++ b/src/backend/optimizer/util/plancat.c
@@ -196,9 +196,12 @@ get_relation_info(PlannerInfo *root, Oid relationObjectId, bool inhparent,
 		 * GPDB supports index-only scan on AO starting from AORelationVersion_GP7.
 		 */
 		bool enable_ios_ao = false;
-		if (RelationIsAppendOptimized(relation) &&
-			AORelationVersion_Validate(relation, AORelationVersion_GP7))
-			enable_ios_ao = true;
+		if (RelationStorageIsAO(relation))
+		{
+			Assert(relation->rd_appendonly != NULL);
+			if (AORelationVersion_Validate(relation, AORelationVersion_GP7))
+				enable_ios_ao = true;
+		}
 
 		indexoidlist = RelationGetIndexList(relation);
 

--- a/src/test/regress/expected/hash_part.out
+++ b/src/test/regress/expected/hash_part.out
@@ -113,3 +113,37 @@ select satisfies_hash_partition('text_hashp'::regclass, 2, 0, 'xxx'::text) OR
 DROP TABLE mchash;
 DROP TABLE mcinthash;
 DROP TABLE text_hashp;
+-- Test case for AO Hash partitioning table
+-- https://github.com/greenplum-db/gpdb/pull/17280
+CREATE TABLE tbl_17280(c0 int) PARTITION BY HASH(c0) WITH (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'c0' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+CREATE INDEX idx_17280 ON tbl_17280 USING HASH(c0) WHERE (c0!=0);
+-- should not panic
+SELECT count(*) FROM tbl_17280;
+ count 
+-------
+     0
+(1 row)
+
+create table tbl_17280_p1 partition of tbl_17280 for values with (modulus 2, remainder 0) WITH (appendonly=true);
+NOTICE:  table has parent, setting distribution columns to match parent table
+create table tbl_17280_p2 partition of tbl_17280 for values with (modulus 2, remainder 1) WITH (appendonly=true);
+NOTICE:  table has parent, setting distribution columns to match parent table
+insert into tbl_17280 select generate_series(1,1000);
+set optimizer to off;
+set enable_seqscan to off;
+analyze tbl_17280_p1;
+-- should use bitmap index scan
+explain select c0 from tbl_17280_p1 where c0=12;
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)  (cost=4.01..8.04 rows=1 width=4)
+   ->  Bitmap Heap Scan on tbl_17280_p1  (cost=4.01..8.02 rows=1 width=4)
+         Recheck Cond: (c0 = 12)
+         ->  Bitmap Index Scan on tbl_17280_p1_c0_idx  (cost=0.00..4.01 rows=1 width=0)
+               Index Cond: (c0 = 12)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+DROP TABLE tbl_17280;


### PR DESCRIPTION
In a rare scenario: 
A (Postgres-style) partition AO table with index on it, but haven't created any child table for it yet. QD will panic when accessing it.

Root cause is in the `get_relation_info()`:
```
* no child table mean no corresponding entry in pg_inherits => `inhparent` is false
* then go into the `hasindex` condition and will check the AO version soon
* but `relation->rd_appendonly` is NULL (since it's a parent table)
* then panic happened in `AORelationVersion_Validate()`
```

Fix:
Using `RelationStorageIsAO()` (rather than `RelationIsAppendOptimized()`) as the prerequisites check: it checks the "true" storage, so skip the parent partition table. (We did a similar check in `DefineIndex()`)

No need to port to 6x (since no related logic in it).

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
