### PR TITLE
[6X]Add hint message for MTU settings when IC reports ERROR Failed to send packet

### DIFF
--- a/src/include/cdb/cdbicudpfaultinjection.h
+++ b/src/include/cdb/cdbicudpfaultinjection.h
@@ -83,6 +83,7 @@ typedef enum {
 	FINC_OS_NET_INTERFACE = 19,
 	FINC_OS_MEM_INTERFACE = 20,
 	FINC_OS_CREATE_THREAD = 21,
+	FINC_PKT_TOO_LONG = 22,
 
 	/* These are used to inject network faults. */
 	FINC_NET_PKT_DUP = 24,
@@ -244,6 +245,13 @@ testmode_sendto(const char *caller_name, int socket, const void *buffer,
 				break;
 			write_log("inject fault to sendto: FINC_OS_NET_INTERFACE");
 			errno = EFAULT;
+			return -1;
+		
+		case FINC_PKT_TOO_LONG:
+			if (!FINC_HAS_FAULT(fault_type) || !is_pkt)
+				break;
+			write_log("inject fault to sendto: FINC_PKT_TOO_LONG");
+			errno = EMSGSIZE;
 			return -1;
 
 		default:

--- a/src/test/regress/expected/icudp/icudp_full.out
+++ b/src/test/regress/expected/icudp/icudp_full.out
@@ -544,6 +544,14 @@ SELECT system_call_fault_injection_test();
  
 (1 row)
 
+-- inject faults for errMsgSize when packet is too long.
+SET gp_udpic_fault_inject_bitmap = 4194304;
+SELECT system_call_fault_injection_test();
+ system_call_fault_injection_test 
+----------------------------------
+ 
+(1 row)
+
 -- disable ipv6 may increase the code coverage.
 SET gp_udpic_network_disable_ipv6 = 1;
 SELECT system_call_fault_injection_test();

--- a/src/test/regress/sql/icudp/icudp_full.sql
+++ b/src/test/regress/sql/icudp/icudp_full.sql
@@ -276,6 +276,10 @@ $$;
 SET gp_udpic_fault_inject_bitmap = 524288;
 SELECT system_call_fault_injection_test();
 
+-- inject faults for errMsgSize when packet is too long.
+SET gp_udpic_fault_inject_bitmap = 4194304;
+SELECT system_call_fault_injection_test();
+
 -- disable ipv6 may increase the code coverage.
 SET gp_udpic_network_disable_ipv6 = 1;
 SELECT system_call_fault_injection_test();


### PR DESCRIPTION
Backport from 7X commit https://github.com/greenplum-db/gpdb/commit/b8411c0ba394d5df44056c07993038e59820a1de

When the user encounters the IC error `interconnect may encountered a network error, please check your network`, one possible reason is MTU settings.

As the error message is very generic, this PR gives a hint message about MTU settings when the error no is `EMSGSIZE` for `sendto()`

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
