### PR TITLE
Add a new option for gpexpand to bypass checking the icproxy address

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -152,6 +152,8 @@ def parseargs():
                       help='Do not prompt for confirmation to proceed on warnings')
     parser.add_option('', '--hba-hostnames', action='store_true', default=False,
                       help='use hostnames instead of CIDR in pg_hba.conf')
+    parser.add_option('', '--without-icproxy-check', action='store_true', default=False,
+                      help='no check the icproxy address')
     parser.add_option('--usage', action="briefhelp")
 
     parser.set_defaults(verbose=False, filters=[], slice=(None, None))
@@ -2596,7 +2598,8 @@ def main(options, args, parser):
             _gp_expand.validate_heap_checksums()
             newSegList = _gp_expand.read_input_files()
             _gp_expand.addNewSegments(newSegList)
-            _gp_expand.validate_icproxy_addr(newSegList)
+            if not options.without_icproxy_check:
+                _gp_expand.validate_icproxy_addr(newSegList)
             newTableSpaceInfo = _gp_expand.read_tablespace_file()
             _gp_expand.sync_packages()
             _gp_expand.start_prepare()

--- a/gpMgmt/doc/gpexpand_help
+++ b/gpMgmt/doc/gpexpand_help
@@ -14,6 +14,7 @@ gpexpand
       | --hba-hostnames
       | --rollback
       | --clean
+      | --without-icproxy-check
 [--verbose] [--silent]
 
 gpexpand -? | -h | --help 
@@ -175,6 +176,9 @@ OPTIONS
 -V | --novacuum
  Do not vacuum catalog tables before creating schema copy.
 
+
+--without-icproxy-check
+ Skip the step of checking the icproxy address.
 
 -? | -h | --help
  Displays the online help.


### PR DESCRIPTION
Because the 'icproxy' is a configurable function. So, if we have not config it, give us a chance to bypass it.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [x] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
