### PR TITLE
Removed the permission check for `cpu.pressure` item when resource manager sets to 'group-v2'.

### DIFF
--- a/gpMgmt/bin/gpcheckresgroupv2impl
+++ b/gpMgmt/bin/gpcheckresgroupv2impl
@@ -47,7 +47,6 @@ class CgroupValidationVersionTwo(CgroupValidation):
         self.validate_permission("gpdb/cgroup.procs", "rw")
 
         self.validate_permission("gpdb/cpu.max", "rw")
-        self.validate_permission("gpdb/cpu.pressure", "rw")
         self.validate_permission("gpdb/cpu.weight", "rw")
         self.validate_permission("gpdb/cpu.weight.nice", "rw")
         self.validate_permission("gpdb/cpu.stat", "r")

--- a/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
+++ b/src/backend/utils/resgroup/cgroup-ops-linux-v2.c
@@ -91,7 +91,6 @@ static int64 system_cfs_quota_us = -1LL;
 static const PermItem perm_items_cpu[] =
 {
 	{ CGROUP_COMPONENT_PLAIN, "cpu.max", R_OK | W_OK },
-	{ CGROUP_COMPONENT_PLAIN, "cpu.pressure", R_OK | W_OK },
 	{ CGROUP_COMPONENT_PLAIN, "cpu.weight", R_OK | W_OK },
 	{ CGROUP_COMPONENT_PLAIN, "cpu.weight.nice", R_OK | W_OK },
 	{ CGROUP_COMPONENT_PLAIN, "cpu.stat", R_OK },


### PR DESCRIPTION
`cpu.pressure` is one of API for PSI.
PSI(Pressure Stall Information) is an optional feature of the Linux kernel.
PSI is not enabled by default on some Linux distributions. For example, on UOS 20 SP1:

```bash
gpdb@yz-PC:/sys/fs/cgroup/gpdb$ pwd
/sys/fs/cgroup/gpdb

gpdb@yz-PC:/sys/fs/cgroup/gpdb$ ll cpu.*
-rw-r--r-- 1 gpdb gpdb 0 Apr   8 19:19 cpu.max
-r--r--r-- 1 gpdb gpdb 0 Apr   8 19:19 cpu.stat
-rw-r--r-- 1 gpdb gpdb 0 Apr   8 19:19 cpu.weight
-rw-r--r-- 1 gpdb gpdb 0 Apr   8 19:19 cpu.weight.nice
```

This causes GPDB to FAIL to start if `gp_resource_manager='group-v2'`.
On the other hand, `cpu.pressure` is not used in GPDB resource management, so it can be removed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
