### PR TITLE
Fix the memory leak in _bitmap_xlog_insert_bitmapwords()

### DIFF
--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -323,6 +323,8 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogReaderState *record)
 		if (BufferIsValid(bitmapBuffers[bmpageno]))
 			UnlockReleaseBuffer(bitmapBuffers[bmpageno]);
 	}
+
+	pfree(bitmapBuffers);
 }
 
 static void

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1160,6 +1160,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	}
 
 	SetDatabasePath(fullpath);
+	pfree(fullpath);
 
 	/*
 	 * It's now possible to do real access to the system catalogs.


### PR DESCRIPTION
An obvious memory leak in `_bitmap_xlog_insert_bitmapwords()`, it caused the memory usage of startup process to continue to grow. We already have a user to report it and it can be reproduced locally.

* Fix it in the first commit.
* In the process of checking this issue, we found another memory leak related commit of upstream (https://github.com/postgres/postgres/commit/0bd56172b2871e94c0d7115ffbf430308317ac49), also ported it in the second commit.

(need to backport to 6x)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
