### PR TITLE
Avoid replay dtx info in checkpoint for newly expanded segments

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -685,3 +685,25 @@ Feature: expand the cluster by adding more segments
         And table "test_good_2" should be marked as expanded
         And table "test_already_expanded" should be marked as expanded
         And table "test_broken" should not be marked as expanded
+
+    @gpexpand_no_mirrors
+    @gpexpand_verify_dtx
+    Scenario: Gpexpand should succeed when xlog has DTX info
+        Given the database is not running
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "3" primaries only
+        And database "gptest" exists
+        And the user runs psql with "-c 'create extension IF NOT EXISTS gp_inject_fault;create table ttt(tc1 int);'" against database "gptest"
+        And the user runs psql with "-c "SELECT gp_inject_fault('before_notify_commited_dtx_transaction', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"" against database "gptest"
+        And the user runs the command "psql gptest -c 'insert into ttt select generate_series(1,100);'" in the background without sleep
+        And waiting "1" seconds
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        And the user runs psql with "-c "SELECT gp_inject_fault('before_notify_commited_dtx_transaction', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"" against database "gptest"
+        And waiting "1" seconds
+        And the user runs psql with "-c 'drop table ttt;'" against database "gptest"
+        Then verify that the cluster has 1 new segments

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2890,7 +2890,10 @@ CommitTransaction(void)
 	 * happen after using the dispatcher.
 	 */
 	if (notifyCommittedDtxTransactionIsNeeded())
+	{
+		SIMPLE_FAULT_INJECTOR("before_notify_commited_dtx_transaction");
 		notifyCommittedDtxTransaction();
+	}
 
 	/*
 	 * Let others know about no transaction in progress by me. Note that this

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8851,8 +8851,13 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 	 * We should be wary of conflating "report" parameter.  It is currently
 	 * always true when we want to process the extended checkpoint record.
 	 * For now this seems fine as it avoids a diff with postgres.
+	 *
+	 * The coordinator may execute write DTX during gpexpand, so the newly
+	 * added segment may contain DTX info in checkpoint XLOG. However, this step
+	 * is useless and should be avoided for segments, or fatal may be thrown since
+	 * max_tm_gxacts is 0 in segments.
 	 */
-	if (report)
+	if (report && IS_QUERY_DISPATCHER())
 	{
 		CheckpointExtendedRecord ckptExtended;
 		UnpackCheckPointRecord(xlogreader, &ckptExtended);


### PR DESCRIPTION
`gpexpand` will create new segment by doing pg_basebackup from coordinator, and DTX can be started in coordinator during that phase. So the newly added segment's checkpoint XLOG may contain DTX info, which will result in the start of the segment failed.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
