### PR TITLE
Fix the memory leak in _bitmap_xlog_insert_bitmapwords()

### DIFF
--- a/src/backend/access/bitmap/bitmapxlog.c
+++ b/src/backend/access/bitmap/bitmapxlog.c
@@ -393,6 +393,8 @@ _bitmap_xlog_insert_bitmapwords(XLogRecPtr lsn, XLogRecord *record)
 		if (BufferIsValid(bitmapBuffers[bmpageno]))
 			UnlockReleaseBuffer(bitmapBuffers[bmpageno]);
 	}
+
+	pfree(bitmapBuffers);
 }
 
 static void

--- a/src/backend/utils/init/postinit.c
+++ b/src/backend/utils/init/postinit.c
@@ -1106,6 +1106,7 @@ InitPostgres(const char *in_dbname, Oid dboid, const char *username,
 	}
 
 	SetDatabasePath(fullpath);
+	pfree(fullpath);
 
 	/*
 	 * It's now possible to do real access to the system catalogs.


### PR DESCRIPTION
This PR backports https://github.com/greenplum-db/gpdb/pull/17332 to 6x.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
