### PR TITLE
fix wildcard interconnect address type

### DIFF
--- a/src/backend/cdb/motion/ic_udpifc.c
+++ b/src/backend/cdb/motion/ic_udpifc.c
@@ -1175,6 +1175,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	struct addrinfo 		*addrs = NULL;
 	struct addrinfo 		*addr;
 	struct addrinfo 		hints;
+	char					service[32];
 	int						ret;
 	int 					ic_socket = PGINVALID_SOCKET;
 	struct sockaddr_storage ic_socket_addr;
@@ -1184,6 +1185,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	uint32					socketSendBufferSize;
 	uint32					socketRecvBufferSize;
 
+	snprintf(service, 32, "%d", 0);
 	memset(&hints, 0, sizeof(struct addrinfo));
 	hints.ai_family = AF_UNSPEC;	/* Allow IPv4 or IPv6 */
 	hints.ai_socktype = SOCK_DGRAM; /* Datagram socket */
@@ -1219,8 +1221,7 @@ setupUDPListeningSocket(int *listenerSocketFd, uint16 *listenerPort, int *txFami
 	 * Restrict what IP address we will listen on to just the one that was
 	 * used to create this QE session.
 	 */
-	Assert(interconnect_address && strlen(interconnect_address) > 0);
-	ret = pg_getaddrinfo_all(interconnect_address, NULL, &hints, &addrs);
+	ret = pg_getaddrinfo_all(interconnect_address, service, &hints, &addrs);
 	if (ret || !addrs)
 	{
 		ereport(LOG,

--- a/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
+++ b/src/backend/cdb/motion/test/cdbsenddummypacket_test.c
@@ -163,6 +163,7 @@ test_send_dummy_packet_ipv4_to_ipv4(void **state)
 	int txFamily;
 
 	interconnect_address = "0.0.0.0";
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_UNICAST;
 	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
 
 	Gp_listener_port = (listenerPort << 16);
@@ -195,6 +196,7 @@ test_send_dummy_packet_ipv4_to_ipv6_should_fail(void **state)
 	int txFamily;
 
 	interconnect_address = "::";
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_UNICAST;
 	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
 
 	Gp_listener_port = (listenerPort << 16);
@@ -222,6 +224,7 @@ test_send_dummy_packet_ipv6_to_ipv6(void **state)
 	int txFamily;
 
 	interconnect_address = "::1";
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_UNICAST;
 	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
 
 	Gp_listener_port = (listenerPort << 16);
@@ -249,6 +252,7 @@ test_send_dummy_packet_ipv6_to_ipv4(void **state)
 	int txFamily;
 
 	interconnect_address = "0.0.0.0";
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_UNICAST;
 	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
 
 	Gp_listener_port = (listenerPort << 16);
@@ -256,6 +260,36 @@ test_send_dummy_packet_ipv6_to_ipv4(void **state)
 
 	ICSenderSocket = create_sender_socket(AF_INET6);
 	ICSenderFamily = AF_INET6;
+
+	SendDummyPacket();
+
+	const struct sockaddr_in *in = (const struct sockaddr_in *) &udp_dummy_packet_sockaddr;
+	assert_true(txFamily == AF_INET);
+	assert_true(in->sin_family == AF_INET);
+	assert_true(listenerPort == ntohs(in->sin_port));
+	assert_true(strcmp("0.0.0.0", inet_ntoa(in->sin_addr)) == 0);
+
+	wait_for_receiver(false);
+}
+
+
+static void
+test_send_dummy_packet_ipv4_to_ipv4_wildcard(void **state)
+{
+	break_loop = false;
+	int listenerSocketFd;
+	uint16 listenerPort;
+	int txFamily;
+
+	interconnect_address = NULL;
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_WILDCARD;
+	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
+
+	Gp_listener_port = (listenerPort << 16);
+	UDP_listenerFd = listenerSocketFd;
+
+	ICSenderSocket = create_sender_socket(AF_INET);
+	ICSenderFamily = AF_INET;
 
 	SendDummyPacket();
 
@@ -278,6 +312,7 @@ test_send_dummy_packet_ipv6_to_ipv6_wildcard(void **state)
 	int txFamily;
 
 	interconnect_address = "::";
+	Gp_interconnect_address_type = INTERCONNECT_ADDRESS_TYPE_UNICAST;
 	setupUDPListeningSocket(&listenerSocketFd, &listenerPort, &txFamily, &udp_dummy_packet_sockaddr);
 
 	Gp_listener_port = (listenerPort << 16);
@@ -317,6 +352,7 @@ main(int argc, char* argv[])
 			unit_test(test_send_dummy_packet_ipv4_to_ipv6_should_fail),
 			unit_test(test_send_dummy_packet_ipv6_to_ipv6),
 			unit_test(test_send_dummy_packet_ipv6_to_ipv4),
+			unit_test(test_send_dummy_packet_ipv4_to_ipv4_wildcard),
 			unit_test(test_send_dummy_packet_ipv6_to_ipv6_wildcard),
 		};
 		return run_tests(tests);


### PR DESCRIPTION
Partially revert 50748b7 changes that broke down wildcard interconnect address type handling for gpdb 7. Removed duplicated assertion, already checked for unicast interconnect few lines above. interconnect_address is null for wildcard address type. In this case service arg of getaddrinfo must not be null, because either node or service may be null according to man page.

A unit test for this case is provided too.

## Here are some reminders before you submit the pull request
- [x] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
