### PR TITLE
Stream WAL archiving status from primaries to mirrors

### DIFF
--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -456,6 +456,9 @@ double		optimizer_jit_optimize_above_cost;
 /* Switch to toggle block-directory based sampling for AO/CO tables */
 bool		gp_enable_blkdir_sampling;
 
+/* GUC to set interval for streaming archival status */
+int wal_sender_archiving_status_interval;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -4402,6 +4405,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_parallel_cursors,
 		-1, -1, 1024,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"wal_sender_archiving_status_interval", PGC_SIGHUP, REPLICATION_SENDING,
+			gettext_noop("Sets the maximum interval for streaming archival status to standby"),
+			NULL, GUC_UNIT_MS
+		},
+		&wal_sender_archiving_status_interval,
+		10000, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -307,6 +307,8 @@ max_prepared_transactions = 250		# can be 0 or more
 				# and comma-separated list of application_name
 				# from standby(s); '*' = all
 #vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+#wal_sender_archiving_status_interval = 0 # send archival status to standby this often
+                                          # in milliseconds; 0 disables
 
 # - Standby Servers -
 

--- a/src/bin/pg_basebackup/receivelog.c
+++ b/src/bin/pg_basebackup/receivelog.c
@@ -846,6 +846,10 @@ HandleCopyStream(PGconn *conn, StreamCtl *stream,
 				if (!CheckCopyStreamStop(conn, stream, blockpos, stoppos))
 					goto error;
 			}
+			else if (copybuf[0] == 'a')
+			{
+				/* GPDB: Skip archive report message. */
+			}
 			else
 			{
 				pg_log_error("unrecognized streaming header: \"%c\"",

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -192,6 +192,9 @@ extern PGDLLIMPORT int wal_level;
 #define XLogArchivingAlways() \
 	(AssertMacro(XLogArchiveMode == ARCHIVE_MODE_OFF || wal_level >= WAL_LEVEL_REPLICA), XLogArchiveMode == ARCHIVE_MODE_ALWAYS)
 #define XLogArchiveCommandSet() (XLogArchiveCommand[0] != '\0')
+/* Is WAL archiving status streaming enabled? */
+#define XLogArchivingStatusReportingActive() \
+	(XLogArchivingActive() && wal_sender_archiving_status_interval > 0)
 
 /*
  * Is WAL-logging necessary for archival or log-shipping, or can we skip

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -1452,6 +1452,8 @@ extern void pgstat_report_queuestat(void); /* GPDB */
 
 extern void pgstat_drop_database(Oid databaseid);
 
+extern void pgstat_request_update(TimestampTz cur_ts, TimestampTz min_ts);
+extern void pgstat_use_stale_snapshot(void);
 extern void pgstat_clear_snapshot(void);
 extern void pgstat_reset_counters(void);
 extern void pgstat_reset_shared_counters(const char *);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -377,6 +377,8 @@ extern bool execute_pruned_plan;
 extern int gp_max_partition_level;
 extern bool gp_enable_relsize_collection;
 
+extern int wal_sender_archiving_status_interval;
+
 /* Debug DTM Action */
 typedef enum
 {

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -562,6 +562,7 @@
 		"wal_recycle",
 		"wal_retrieve_retry_interval",
 		"wal_segment_size",
+		"wal_sender_archiving_status_interval",
 		"wal_sync_method",
 		"wal_writer_delay",
 		"wal_writer_flush_after",

--- a/src/test/perl/PostgreSQL/Test/Utils.pm
+++ b/src/test/perl/PostgreSQL/Test/Utils.pm
@@ -84,6 +84,7 @@ our @EXPORT = qw(
   command_like_safe
   command_fails_like
   command_checks_all
+  wait_until_file_exists
 
   $windows_os
 );
@@ -745,6 +746,14 @@ sub command_checks_all
 	}
 
 	return;
+}
+
+sub wait_until_file_exists
+{
+	my ($node, $filepath, $filedesc) = @_;
+	my $query = "SELECT size IS NOT NULL FROM pg_stat_file('$filepath')";
+	$node->poll_query_until('postgres', $query)
+		or die "Timed out while waiting for $filedesc $filepath";
 }
 
 1;

--- a/src/test/recovery/t/121_streaming_and_archiving.pl
+++ b/src/test/recovery/t/121_streaming_and_archiving.pl
@@ -1,0 +1,217 @@
+use strict;
+use warnings;
+use PostgreSQL::Test::Cluster;
+use PostgreSQL::Test::Utils;
+use Test::More;
+
+my $node_primary;
+my $node_standby;
+
+##################### Test with wal_sender_archiving_status_interval disabled #####################
+
+# Initialize primary node with WAL archiving setup and wal_sender_archiving_status_interval as disabled
+$node_primary = PostgreSQL::Test::Cluster->new('primary');
+$node_primary->init(
+	has_archiving    => 1,
+	allows_streaming => 1);
+$node_primary->append_conf('postgresql.conf', 'wal_sender_archiving_status_interval = 0');
+$node_primary->start;
+my $primary_data = $node_primary->data_dir;
+
+# Set an incorrect archive_command so that archiving fails
+my $incorrect_command = "exit 1";
+$node_primary->safe_psql(
+'postgres', qq{
+ALTER SYSTEM SET archive_command TO '$incorrect_command';
+SELECT pg_reload_conf();
+});
+
+# Take backup
+$node_primary->backup('my_backup');
+
+# Initialize the standby node. It will inherit wal_sender_archiving_status_interval from the primary
+$node_standby = PostgreSQL::Test::Cluster->new('standby');
+$node_standby->init_from_backup($node_primary, 'my_backup', has_streaming => 1);
+my $standby_data = $node_standby->data_dir;
+$node_standby->start;
+
+$node_primary->safe_psql(
+	'postgres', q{
+	CREATE TABLE test1 AS SELECT generate_series(1,10) AS x;
+});
+
+my $current_walfile = $node_primary->safe_psql('postgres', "SELECT pg_walfile_name(pg_current_wal_lsn())");
+$node_primary->safe_psql(
+	'postgres', q{
+	SELECT pg_switch_wal();
+	CHECKPOINT;
+});
+
+# After switching wal, the current wal file will be marked as ready to be archived on the primary. But this wal file
+# won't get archived because of the incorrect archive_command
+my $walfile_ready = "pg_wal/archive_status/$current_walfile.ready";
+my $walfile_done = "pg_wal/archive_status/$current_walfile.done";
+
+# Wait for the standby to catch up
+$node_primary->wait_for_catchup($node_standby, 'replay',
+	$node_primary->lsn('insert'));
+
+# Wait for archive failure
+$node_primary->poll_query_until('postgres',
+q{SELECT failed_count > 0 FROM pg_stat_archiver}, 't')
+or die "Timed out while waiting for archiving to fail";
+
+# Due to archival failure, check if primary has only .ready wal file and not .done
+# Check if standby has .done created as wal_sender_archiving_status_interval is disabled.
+ok( -f "$primary_data/$walfile_ready",
+	".ready file exists on primary for WAL segment $current_walfile"
+);
+ok( !-f "$primary_data/$walfile_done",
+	".done file does not exist on primary for WAL segment $current_walfile"
+);
+
+ok( !-f "$standby_data/$walfile_ready",
+	".ready file does not exist on standby for WAL segment $current_walfile when wal_sender_archiving_status_interval=0"
+);
+ok( -f "$standby_data/$walfile_done",
+	".done file exists on standby for WAL segment $current_walfile when wal_sender_archiving_status_interval=0"
+);
+
+##################### Test with wal_sender_archiving_status_interval enabled #####################
+$node_primary->adjust_conf('postgresql.conf', 'wal_sender_archiving_status_interval', "50ms");
+$node_primary->reload;
+# We need to enable wal_sender_archiving_status_interval on the standby as well. Technically the value doesn't matter
+# since the wal_receiver process only cares about this guc being set and not the actual value.
+$node_standby->adjust_conf('postgresql.conf', 'wal_sender_archiving_status_interval', "50ms");
+$node_standby->reload;
+
+$node_primary->safe_psql(
+	'postgres', q{
+	CREATE TABLE test2 AS SELECT generate_series(1,10) AS x;
+});
+
+my $current_walfile2 = $node_primary->safe_psql('postgres', "SELECT pg_walfile_name(pg_current_wal_lsn())");
+my $walfile_ready2 = "pg_wal/archive_status/$current_walfile2.ready";
+my $walfile_done2 = "pg_wal/archive_status/$current_walfile2.done";
+
+$node_primary->safe_psql(
+	'postgres', q{
+	SELECT pg_switch_wal();
+	CHECKPOINT;
+});
+
+# Wait for standby to catch up
+$node_primary->wait_for_catchup($node_standby, 'replay',
+	$node_primary->lsn('insert'));
+
+# Check if primary and standby have created .ready file for the wal that failed to archive
+ok( -f "$primary_data/$walfile_ready2",
+	".ready file exists on primary for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+ok( -f "$standby_data/$walfile_ready2",
+	".ready file exists on standby for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+
+ok( !-f "$primary_data/$walfile_done2",
+	".done file does not exist on primary for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f "$standby_data/$walfile_done2",
+	".done file does not exist on standby for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+
+# Make WAL archiving work again for primary by resetting the archive_command
+$node_primary->safe_psql(
+	'postgres', q{
+	ALTER SYSTEM RESET archive_command;
+	SELECT pg_reload_conf();
+});
+
+# Wait until all the failed files get archived by the primary
+$node_primary->poll_query_until('postgres',"SELECT archived_count=failed_count FROM pg_stat_archiver", 't')
+  or die "Timed out while waiting for archiving to finish";
+
+# Check if primary has .done file created for the archived segment and also that the file gets uploaded to the archive
+ok( -f "$primary_data/$walfile_done2",
+	".done file exists for WAL segment $current_walfile2");
+ok( !-f "$primary_data/$walfile_ready2",
+	".ready file does not exist for WAL segment $current_walfile2");
+ok( -f $node_primary->archive_dir . "/$current_walfile2",
+	"$current_walfile2 exists in primary's archive");
+
+# Check if standby has .done file created for the archived segment
+wait_until_file_exists($node_standby, "$standby_data/$walfile_done2",
+	".done file to exist on standby for WAL segment $current_walfile2"
+);
+ok( !-f "$standby_data/$walfile_ready2",
+	".ready file does not exist on standby for WAL segment $current_walfile2");
+
+ok( !-f $node_standby->archive_dir . "/$current_walfile2",
+	"$current_walfile2 does not exist in standby's archive");
+
+################### Now again make archiving fail but this time promote the standby and let the standby archive the wal
+$node_primary->safe_psql(
+	'postgres', qq{
+	ALTER SYSTEM SET archive_command TO '$incorrect_command';
+	SELECT pg_reload_conf();
+});
+# make archiving work for the standby node
+$node_standby->safe_psql(
+	'postgres', q{
+	ALTER SYSTEM RESET archive_command;
+	SELECT pg_reload_conf();
+});
+
+$node_primary->safe_psql(
+	'postgres', q{
+	CREATE TABLE test3 AS SELECT generate_series(1,10) AS x;
+});
+my $current_walfile3 = $node_primary->safe_psql('postgres', "SELECT pg_walfile_name(pg_current_wal_lsn())");
+$node_primary->safe_psql(
+	'postgres', q{
+	SELECT pg_switch_wal();
+	CHECKPOINT;
+});
+my $walfile_ready3 = "pg_wal/archive_status/$current_walfile3.ready";
+my $walfile_done3 = "pg_wal/archive_status/$current_walfile3.done";
+
+# Wait for the standby to catch up
+$node_primary->wait_for_catchup($node_standby, 'replay',
+	$node_primary->lsn('insert'));
+
+ok( -f "$standby_data/$walfile_ready3",
+	".ready file exists on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f "$standby_data/$walfile_done3",
+	".done file does not exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f $node_primary->archive_dir . "/$current_walfile3",
+	"$current_walfile3 does not exist in the archive");
+
+# Now promote the standby
+$node_standby->promote;
+
+# Wait for promotion to complete
+$node_standby->poll_query_until('postgres', "SELECT NOT pg_is_in_recovery();")
+or die "Timed out while waiting for promotion";
+
+# Wait until the wal file gets archived by the standby, Note that the archive dir is primary's archive dir and not standby's.
+# This is because archive_command (which has the cp command) gets copied over from the primary node when we initialize the standby
+wait_until_file_exists($node_primary, $node_primary->archive_dir . "/$current_walfile3",
+	"$current_walfile3 to be archived by the standby");
+
+ok( -f "$primary_data/$walfile_ready3",
+	".ready file exists on primary for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+# primary won't be able to archive and hence won't have the .done file
+ok( !-f "$primary_data/$walfile_done3",
+	".done file does not exist on primary for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+wait_until_file_exists($node_standby, "$standby_data/$walfile_done3",
+	".done file to exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f "$standby_data/$walfile_ready3",
+	".ready file does not exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+
+done_testing();
+


### PR DESCRIPTION
This commit introduces a GUC `wal_sender_archiving_status_interval`
that will specify the interval at which primaries will send an
archival status messages to their mirrors (including coordinator and
standby coordinator). Any value greater than zero will enable this
feature and set the interval.

Currently, if a primary loses connectivity to its archive repository
while the streaming replication between the primary and its mirror is
intact, it is likely that there will be WAL files that the mirror has
but the archive repository does not. If primary goes down at this
stage, those WAL files will be lost forever as they are marked as
.done on the mirror as part of regular streaming replication
logic. When the mirror is promoted, it will start archiving from the
last WAL file that was streamed over. As a result, there will be holes
in the sequence of WAL files in the archive repository that may
negatively affect future restores from the archive repository.

With the GUC value set, the mirror will now mark all WAL files that
are streamed over as .ready instead of .done. In parallel, the
primary's WAL sender process will fetch the last archived WAL from the
`pg_stat_archiver` view that gets updated by the primary's archiver
process. This informartion is sent at regular intervals (set by the
GUC) to the mirror's WAL receiver process via the existing WAL
replication stream. Based on this information, the mirror will mark
corresponding WAL files from .ready to .done status. When the mirror
gets promoted, it may now have WAL files in .ready state which will
then get archived accordingly.

There is a possibility that these WAL files may have already been
archived by the primary because the archiving status updates sent to
the mirror are not real-time. However, trying to re-archive them
should be safe as long as the archive_command GUC is configured
accordingly to check if the file is already in the archive repository,
compare the checksums if so, and skip the file if the checksums are
the same.

This patch was inspired by an unapplied patch from Heikki Linnakangas
in the upstream pgsql-hackers thread:
https://www.postgresql.org/message-id/5550D20D.6090703%40iki.fi
