### PR TITLE
gp init cluster: support for mirror  functional tests

### DIFF
--- a/gpMgmt/bin/go-tools/test/integration/init_cluster/init_cluster_config_validation_test.go
+++ b/gpMgmt/bin/go-tools/test/integration/init_cluster/init_cluster_config_validation_test.go
@@ -295,7 +295,7 @@ func TestInputFileValidation(t *testing.T) {
 
 	})
 
-	t.Run("when both hostaddress and hostnames are not provided", func(t *testing.T) {
+	t.Run("when both hostaddress and hostnames are not provided for primary segment", func(t *testing.T) {
 		var ok bool
 		configFile := testutils.GetTempFile(t, "config.json")
 		config := GetDefaultConfig(t)
@@ -322,7 +322,7 @@ func TestInputFileValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("when the hostname alone is empty", func(t *testing.T) {
+	t.Run("when the hostname alone is empty for primary segment", func(t *testing.T) {
 		var ok bool
 		configFile := testutils.GetTempFile(t, "config.json")
 		config := GetDefaultConfig(t)
@@ -398,6 +398,289 @@ func TestInputFileValidation(t *testing.T) {
 			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
 		}
 	})
+
+	t.Run("when number of primary and mirror segments are not equal", func(t *testing.T) {
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		}
+
+		valueSegPair[0].Mirror = nil
+		SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+
+		numPrimary := len(valueSegPair)
+		numMirror := 0
+		for _, pair := range valueSegPair {
+			if pair.Mirror != nil {
+				numMirror++
+			}
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-number of primary segments %d and number of mirror segments %d must be equal\n", numPrimary, numMirror)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when the hostname is empty for mirror segment", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[0].Mirror.Hostname = ""
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-hostName has not been provided for the segment with port %d and data_directory %s", valueSegPair[0].Mirror.Port, valueSegPair[0].Mirror.DataDirectory)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when port number is not provided for the mirror segment", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[0].Mirror.Port = 0
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-invalid port has been provided for segment with hostname %s and data_directory %s", valueSegPair[0].Mirror.Hostname, valueSegPair[0].Mirror.DataDirectory)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when both hostaddress and hostnames are not provided for mirror segment", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[0].Mirror.Hostname = ""
+			valueSegPair[0].Mirror.Address = ""
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-hostName has not been provided for the segment with port %d and data_directory %s", valueSegPair[0].Mirror.Port, valueSegPair[0].Mirror.DataDirectory)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when empty data directory is given for a mirror segment", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[0].Mirror.DataDirectory = ""
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-data_directory has not been provided for segment with hostname %s and port %d", valueSegPair[0].Mirror.Hostname, valueSegPair[0].Mirror.Port)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when same port is given for a mirror segments", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[1].Mirror.Hostname = valueSegPair[0].Mirror.Hostname
+			valueSegPair[1].Mirror.Address = valueSegPair[0].Mirror.Address
+			valueSegPair[0].Mirror.Port = 1234
+			valueSegPair[1].Mirror.Port = 1234
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-duplicate port entry 1234 found for host %s", valueSegPair[1].Mirror.Hostname)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when same data directory is given for a mirror segment", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[1].Mirror.Hostname = valueSegPair[0].Mirror.Hostname
+			valueSegPair[1].Mirror.Address = valueSegPair[0].Mirror.Address
+			valueSegPair[0].Mirror.DataDirectory = "gpseg1"
+			valueSegPair[1].Mirror.DataDirectory = "gpseg1"
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+			t.Fatalf("got %v, want exit status 1", err)
+		}
+
+		expectedOut := fmt.Sprintf("[ERROR]:-duplicate data directory entry gpseg1 found for host %s", valueSegPair[0].Mirror.Hostname)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+	})
+
+	t.Run("when hostaddress is empty for the primary and mirror segments", func(t *testing.T) {
+		var ok bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		originalPrimaryAddress := valueSegPair[0].Primary.Address
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		} else {
+			valueSegPair[0].Primary.Address = ""
+			SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+		}
+
+		result, err := testutils.RunInitCluster(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %s, %v", result.OutputMsg, err)
+		}
+
+		expectedOut := fmt.Sprintf("[WARNING]:-hostAddress has not been provided, populating it with same as hostName %s for the segment with port %d and data_directory %s", valueSegPair[0].Primary.Hostname, valueSegPair[0].Primary.Port, valueSegPair[0].Primary.DataDirectory)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+		}
+
+		_, err = testutils.DeleteCluster()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		valueSegPair[0].Primary.Address = originalPrimaryAddress
+		SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+
+		// validation for mirror segments
+		valueSegPair[0].Mirror.Address = ""
+		SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+
+		resultMirror, errMirror := testutils.RunInitCluster(configFile)
+		if errMirror != nil {
+			t.Fatalf("unexpected error: %s, %v", resultMirror.OutputMsg, errMirror)
+		}
+
+		expectedOutMirror := fmt.Sprintf("[WARNING]:-hostAddress has not been provided, populating it with same as hostName %s for the segment with port %d and data_directory %s", valueSegPair[0].Mirror.Hostname, valueSegPair[0].Mirror.Port, valueSegPair[0].Mirror.DataDirectory)
+		if !strings.Contains(result.OutputMsg, expectedOut) {
+			t.Errorf("got %q, want %q", resultMirror.OutputMsg, expectedOutMirror)
+		}
+
+		_, err = testutils.DeleteCluster()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	//TODO: FIX this once duplicate key issue is resolved in golang
+	// t.Run("when duplicate mirror keys are present", func(t *testing.T) {
+	// 	configFile := testutils.GetTempFile(t, "config.json")
+	// 	config := GetDefaultConfig(t)
+
+	// 	primarySegs := config.Get("segment-array")
+	// 	valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+	// 	if !ok {
+	// 		t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+	// 	}
+
+	// 	// Add duplicate mirror key to the segment pair
+	// 	valueSegPair[0].Mirror = &cli.Segment{
+	// 		Hostname:      "testhost",
+	// 		Address:       "testhost",
+	// 		Port:          70010,
+	// 		DataDirectory: "/tmp/demo/mirror/gpseg10",
+	// 	}
+
+	// 	SetConfigKey(t, configFile, "segment-array", valueSegPair, true)
+
+	// 	result, err := testutils.RunInitCluster(configFile)
+	// 	if e, ok := err.(*exec.ExitError); !ok || e.ExitCode() != 1 {
+	// 		t.Fatalf("got %v, want exit status 1", err)
+	// 	}
+
+	// 	expectedOut := "[ERROR]:-duplicate mirror keys are present\n"
+	// 	if !strings.Contains(result.OutputMsg, expectedOut) {
+	// 		t.Errorf("got %q, want %q", result.OutputMsg, expectedOut)
+	// 	}
+	// })
 }
 
 func GetDefaultConfig(t *testing.T) *viper.Viper {
@@ -414,6 +697,7 @@ func GetDefaultConfig(t *testing.T) *viper.Viper {
 		t.Fatalf("unexpected error: %#v", err)
 	}
 
+	coordinatorHost := hostList[0]
 	instance.Set("coordinator", cli.Segment{
 		Port:          testutils.DEFAULT_COORDINATOR_PORT,
 		Hostname:      hostList[0],
@@ -428,14 +712,28 @@ func GetDefaultConfig(t *testing.T) *viper.Viper {
 
 	for i := 1; i < len(hostList); i++ {
 		hostPrimary := hostList[i]
+		hostMirror := hostList[(i+1)%len(hostList)]
+		if hostPrimary == coordinatorHost {
+			hostPrimary = hostList[(i+2)%len(hostList)]
+		}
+		if hostMirror == coordinatorHost {
+			hostMirror = hostList[(i+2)%len(hostList)]
+		}
 		primary := &cli.Segment{
 			Port:          testutils.DEFAULT_COORDINATOR_PORT + i + 1,
 			Hostname:      hostPrimary,
 			Address:       hostPrimary,
-			DataDirectory: filepath.Join("/tmp", "demo", fmt.Sprintf("%d", i-1)),
+			DataDirectory: filepath.Join("/tmp", "primary", fmt.Sprintf("gpseg%d", i-1)),
+		}
+		mirror := &cli.Segment{
+			Port:          testutils.DEFAULT_COORDINATOR_PORT + i + 4,
+			Hostname:      hostMirror,
+			Address:       hostMirror,
+			DataDirectory: filepath.Join("/tmp", "mirror", fmt.Sprintf("gpmirror%d", i)),
 		}
 		segments = append(segments, cli.SegmentPair{
 			Primary: primary,
+			Mirror:  mirror,
 		})
 	}
 	instance.Set("segment-array", segments)

--- a/gpMgmt/bin/go-tools/test/integration/init_cluster/init_cluster_test.go
+++ b/gpMgmt/bin/go-tools/test/integration/init_cluster/init_cluster_test.go
@@ -2,9 +2,12 @@ package init_cluster
 
 import (
 	"fmt"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/greenplum-db/gpdb/gp/cli"
 	"github.com/greenplum-db/gpdb/gp/test/integration/testutils"
 )
 
@@ -156,4 +159,225 @@ func TestInitCluster(t *testing.T) {
 	t.Run("check if the cluster is created successfully by passing config file with toml extension", func(t *testing.T) {
 		testConfigFileCreation(t, "toml")
 	})
+
+}
+
+func TestPgHbaConfValidation(t *testing.T) {
+	/* FIXME:concurse is failing to resolve ip to hostname*/
+	/*t.Run("pghba config file validation when hbahostname is true", func(t *testing.T) {
+		var value cli.Segment
+		var ok bool
+		var valueSeg []cli.Segment
+		var okSeg bool
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		err := config.WriteConfigAs(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+
+		SetConfigKey(t, configFile, "hba-hostnames", true, true)
+
+		result, err := testutils.RunInitCluster(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %s, %v", result.OutputMsg, err)
+		}
+
+		coordinator := config.Get("coordinator")
+		if value, ok = coordinator.(cli.Segment); !ok {
+			t.Fatalf("unexpected data type for coordinator %T", value)
+		}
+
+		filePathCord := filepath.Join(coordinator.(cli.Segment).DataDirectory, "pg_hba.conf")
+		hostCord := coordinator.(cli.Segment).Hostname
+		cmdStr := "whoami"
+		cmd := exec.Command("ssh", hostCord, cmdStr)
+		output, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		resultCord := strings.TrimSpace(string(output))
+		pgHbaLine := fmt.Sprintf("host\tall\t%s\t%s\ttrust", resultCord, coordinator.(cli.Segment).Hostname)
+		cmdStrCord := fmt.Sprintf("/bin/bash -c 'cat %s | grep \"%s\"'", filePathCord, pgHbaLine)
+		cmdCord := exec.Command("ssh", hostCord, cmdStrCord)
+		_, err = cmdCord.CombinedOutput()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		}
+
+		pgHbaLineSeg := fmt.Sprintf("host\tall\tall\t%s\ttrust", primarySegs.([]cli.Segment)[0].Hostname)
+		filePathSeg := filepath.Join(primarySegs.([]cli.Segment)[0].DataDirectory, "pg_hba.conf")
+		cmdStr_seg := fmt.Sprintf("/bin/bash -c 'cat %s | grep \"%s\"'", filePathSeg, pgHbaLineSeg)
+		hostSeg := primarySegs.([]cli.Segment)[0].Hostname
+		cmdSeg := exec.Command("ssh", hostSeg, cmdStr_seg)
+		_, err = cmdSeg.CombinedOutput()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		_, err = testutils.DeleteCluster()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})*/
+
+	t.Run("pghba config file validation when hbahostname is false", func(t *testing.T) {
+		var value cli.Segment
+		var ok bool
+
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		err := config.WriteConfigAs(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+
+		SetConfigKey(t, configFile, "hba-hostnames", false, true)
+
+		result, err := testutils.RunInitCluster(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %s, %v", result.OutputMsg, err)
+		}
+
+		coordinator := config.Get("coordinator")
+		if value, ok = coordinator.(cli.Segment); !ok {
+			t.Fatalf("unexpected data type for coordinator %T", value)
+		}
+
+		filePathCord := filepath.Join(coordinator.(cli.Segment).DataDirectory, "pg_hba.conf")
+		hostCord := coordinator.(cli.Segment).Hostname
+		cmdStr := "whoami"
+		cmd := exec.Command("ssh", hostCord, cmdStr)
+		output, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		resultCord := strings.TrimSpace(string(output))
+		cmdStrCord := "ip -4 addr show | grep inet | grep -v 127.0.0.1/8 | awk '{print $2}'"
+		cmdCord := exec.Command("ssh", hostCord, cmdStrCord)
+		outputCord, err := cmdCord.Output()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		resultCordValue := string(outputCord)
+		firstCordValue := strings.Split(resultCordValue, "\n")[0]
+		pgHbaLine := fmt.Sprintf("host\tall\t%s\t%s\ttrust", resultCord, firstCordValue)
+		cmdStrCordValue := fmt.Sprintf("/bin/bash -c 'cat %s | grep \"%s\"'", filePathCord, pgHbaLine)
+		cmdCordValue := exec.Command("ssh", hostCord, cmdStrCordValue)
+		_, err = cmdCordValue.CombinedOutput()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		}
+
+		filePathSeg := filepath.Join(valueSegPair[0].Primary.DataDirectory, "pg_hba.conf")
+		hostSegValue := valueSegPair[0].Primary.Hostname
+		cmdStrSegValue := "whoami"
+		cmdSegvalue := exec.Command("ssh", hostSegValue, cmdStrSegValue)
+		outputSeg, errSeg := cmdSegvalue.Output()
+		if errSeg != nil {
+			t.Fatalf("unexpected error : %v", errSeg)
+		}
+
+		resultSeg := strings.TrimSpace(string(outputSeg))
+		cmdStrSeg := "ip -4 addr show | grep inet | grep -v 127.0.0.1/8 | awk '{print $2}'"
+		cmdSegValueNew := exec.Command("ssh", hostSegValue, cmdStrSeg)
+		outputSegNew, err := cmdSegValueNew.Output()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		resultSegValue := string(outputSegNew)
+		firstValueNew := strings.Split(resultSegValue, "\n")[0]
+		pgHbaLineNew := fmt.Sprintf("host\tall\t%s\t%s\ttrust", resultSeg, firstValueNew)
+		cmdStrSegNew := fmt.Sprintf("/bin/bash -c 'cat %s | grep \"%s\"'", filePathSeg, pgHbaLineNew)
+		cmdSegNew := exec.Command("ssh", hostSegValue, cmdStrSegNew)
+		_, err = cmdSegNew.CombinedOutput()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		_, err = testutils.DeleteCluster()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("pg_hba.conf replication entry validation in mirror segment", func(t *testing.T) {
+		var ok bool
+
+		configFile := testutils.GetTempFile(t, "config.json")
+		config := GetDefaultConfig(t)
+
+		err := config.WriteConfigAs(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %#v", err)
+		}
+
+		SetConfigKey(t, configFile, "hba-hostnames", false, true)
+
+		result, err := testutils.RunInitCluster(configFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %s, %v", result.OutputMsg, err)
+		}
+
+		primarySegs := config.Get("segment-array")
+		valueSegPair, ok := primarySegs.([]cli.SegmentPair)
+
+		if !ok {
+			t.Fatalf("unexpected data type for segment-array %T", primarySegs)
+		}
+
+		filePathSeg := filepath.Join(valueSegPair[0].Mirror.DataDirectory, "pg_hba.conf")
+		hostSegValue := valueSegPair[0].Mirror.Hostname
+		cmdStrSegValue := "whoami"
+		cmdSegvalue := exec.Command("ssh", hostSegValue, cmdStrSegValue)
+		outputSeg, errSeg := cmdSegvalue.Output()
+		if errSeg != nil {
+			t.Fatalf("unexpected error : %v", errSeg)
+		}
+		resultSeg := strings.TrimSpace(string(outputSeg))
+
+		primaryHostName := valueSegPair[0].Primary.Hostname
+		cmdStrSeg := "ip -4 addr show | grep inet | grep -v 127.0.0.1/8 | awk '{print $2}'"
+		cmdSegValueNew := exec.Command("ssh", primaryHostName, cmdStrSeg)
+		outputSegNew, err := cmdSegValueNew.Output()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		resultSegValue := string(outputSegNew)
+		firstValueNew := strings.Split(resultSegValue, "\n")[0]
+		pgHbaLineNew := fmt.Sprintf("host\treplication\t%s\t%s\ttrust", resultSeg, firstValueNew)
+		cmdStrSegNew := fmt.Sprintf("/bin/bash -c 'cat %s | grep \"%s\"'", filePathSeg, pgHbaLineNew)
+		cmdSegNew := exec.Command("ssh", hostSegValue, cmdStrSegNew)
+		_, err = cmdSegNew.CombinedOutput()
+		if err != nil {
+			t.Fatalf("unexpected error : %v", err)
+		}
+
+		_, err = testutils.DeleteCluster()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
 }

--- a/gpMgmt/bin/go-tools/test/integration/testutils/locale_utils.go
+++ b/gpMgmt/bin/go-tools/test/integration/testutils/locale_utils.go
@@ -37,7 +37,7 @@ func GetRandomLocale(t *testing.T) string {
 	var locales []string
 	lines := strings.Fields(string(out))
 	for _, line := range lines {
-		if strings.Contains(strings.ToLower(line), "utf") {
+		if strings.HasSuffix(strings.ToLower(line), "utf8") || strings.HasSuffix(strings.ToLower(line), "utf-8") {
 			locales = append(locales, line)
 		}
 	}

--- a/gpMgmt/bin/go-tools/test/integration/testutils/test_utils.go
+++ b/gpMgmt/bin/go-tools/test/integration/testutils/test_utils.go
@@ -116,7 +116,7 @@ func RunGpStatus(params ...string) (CmdResult, error) {
 	allParams := append([]string{"gpstate"}, params...)
 
 	genCmd := Command{
-		cmdStr: allParams[0],  
+		cmdStr: allParams[0],
 		args:   allParams[1:],
 	}
 
@@ -136,6 +136,16 @@ func RunGpCheckCat(params ...string) (CmdResult, error) {
 
 func RunGpStop(params ...string) (CmdResult, error) {
 	allParams := append([]string{"gpstop", "-a"}, params...)
+
+	genCmd := Command{
+		cmdStr: allParams[0],
+		args:   allParams[1:],
+	}
+
+	return runCmd(genCmd)
+}
+func RunGpRecoverSeg(params ...string) (CmdResult, error) {
+	allParams := append([]string{"gprecoverseg", "-a"}, params...)
 
 	genCmd := Command{
 		cmdStr: allParams[0],


### PR DESCRIPTION
This commit adds functional tests for the changes committed in the gpinitsystem support for mirror PR https://github.com/greenplum-db/gpdb/pull/17294. 

init_cluster_config_validation_test.go - This contains tests related to the input init config provided with support for mirrors and functions to form default config with primary and mirror support
init_cluster_db_validation_test.go - This contains tests related to the database configuration checks after the cluster is successfully initialized with mirror support

Note: This PR cant be merged until https://github.com/greenplum-db/gpdb/pull/17294 is merged 
