### PR TITLE
Fix CO sampling crashed on added column

### DIFF
--- a/src/backend/access/aocs/aocsam.c
+++ b/src/backend/access/aocs/aocsam.c
@@ -1268,7 +1268,16 @@ aocs_gettuple(AOCSScanDesc scan, int64 targrow, TupleTableSlot *slot)
 				/* continue next block */
 			}
 			else
-				pg_unreachable(); /* unreachable code */
+				/*
+				 * Fatal and raise message for unexpected code path here.
+				 * We didn't use PANIC as having a read-only backend crash
+				 * the whole instance is a little overkill.
+				 */
+				ereport(FATAL,
+						(errcode(ERRCODE_INTERNAL_ERROR),
+						 errmsg("Unexpected result was returned when getting AO block info for table '%s', "
+						 		"column %d, targrow %ld.",
+								AppendOnlyStorageRead_RelationName(&ds->ao_read), attno, targrow)));
 		}
 	}
 

--- a/src/backend/access/appendonly/appendonlyam.c
+++ b/src/backend/access/appendonly/appendonlyam.c
@@ -1320,7 +1320,15 @@ appendonly_getblock(AppendOnlyScanDesc scan, int64 targrow, int64 *startrow)
 			/* continue next block */
 		}
 		else
-			pg_unreachable(); /* unreachable code */
+			/*
+			 * Fatal and raise message for unexpected code path here.
+			 * We didn't use PANIC as having a read-only backend crash
+			 * the whole instance is a little overkill.
+			 */
+			ereport(FATAL,
+					(errcode(ERRCODE_INTERNAL_ERROR),
+					 errmsg("Unexpected result was returned when getting AO block info for table '%s', targrow %ld",
+							AppendOnlyStorageRead_RelationName(&scan->storageRead), targrow)));
 	}
 }
 

--- a/src/backend/utils/datumstream/datumstream.c
+++ b/src/backend/utils/datumstream/datumstream.c
@@ -874,6 +874,12 @@ datumstreamread_close_file(DatumStreamRead * ds)
 {
 	AppendOnlyStorageRead_CloseFile(&ds->ao_read);
 
+	/*
+	 * Reset blockRowCount as file being closed,
+	 * which also helps to direct to next segfile
+	 * reading in sampling scenario.
+	 */
+	ds->blockRowCount = 0;
 	ds->need_close_file = false;
 }
 

--- a/src/test/isolation2/input/uao/fast_analyze.source
+++ b/src/test/isolation2/input/uao/fast_analyze.source
@@ -423,3 +423,78 @@ select * from gp_acquire_sample_rows('test_dead_values_return_@amname@'::regclas
   (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, i int, j int, k int);
 
 drop table test_dead_values_return_@amname@;
+
+--
+-- Test sampling on ADD COLUMN rows.
+--
+-- Case 1, the added column row is a sample row, verify no reading exceeded EOF issue.
+drop table if exists sampling_add_column_@amname@_1;
+create table sampling_add_column_@amname@_1 (a int) using @amname@ distributed replicated;
+insert into sampling_add_column_@amname@_1 values (1);
+alter table sampling_add_column_@amname@_1 add column b int;
+insert into sampling_add_column_@amname@_1 values(100, 100);
+
+create or replace function test_sample_add_column() returns boolean as $$
+declare
+     cnt int; /* in func */
+begin
+     cnt := 0; /* in func */
+     while (cnt = 0)
+     loop
+          select count(*) into cnt from pg_catalog.gp_acquire_sample_rows('sampling_add_column_@amname@_1'::regclass, 1, 'f') as
+            (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, a int, b int)
+            where a = 100; /* in func */
+     end loop; /* in func */
+     return true; /* in func */
+end; /* in func */
+$$ language plpgsql;
+
+select test_sample_add_column();
+
+-- Case 2, verify sample rows are correct after ADD COLUMN operation.
+drop table if exists sampling_add_column_@amname@_2;
+create table sampling_add_column_@amname@_2 (a int) using @amname@;
+
+1: begin;
+2: begin;
+3: begin;
+
+1: insert into sampling_add_column_@amname@_2 select * from generate_series(1, 10);
+2: insert into sampling_add_column_@amname@_2 select * from generate_series(11, 20);
+3: insert into sampling_add_column_@amname@_2 select * from generate_series(21, 30);
+
+1: commit;
+2: commit;
+3: commit;
+
+alter table sampling_add_column_@amname@_2 add column b int;
+
+1: begin;
+2: begin;
+3: begin;
+
+1: insert into sampling_add_column_@amname@_2 values(100, 100);
+2: insert into sampling_add_column_@amname@_2 values(200, 200);
+3: insert into sampling_add_column_@amname@_2 values(300, 300);
+
+1: commit;
+2: commit;
+3: abort;
+
+alter table sampling_add_column_@amname@_2 add column c text;
+
+1: begin;
+2: begin;
+3: begin;
+
+1: insert into sampling_add_column_@amname@_2 values (100, 100, 'c100');
+2: insert into sampling_add_column_@amname@_2 values (200, 200, 'c200');
+3: insert into sampling_add_column_@amname@_2 values (300, 300, 'c300');
+
+1: commit;
+2: abort;
+3: commit;
+
+select * from sampling_add_column_@amname@_2;
+select * from gp_acquire_sample_rows('sampling_add_column_@amname@_2'::regclass, 32, 'f') as
+  (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, a int, b int, c text);

--- a/src/test/isolation2/output/uao/fast_analyze.source
+++ b/src/test/isolation2/output/uao/fast_analyze.source
@@ -795,3 +795,182 @@ select * from gp_acquire_sample_rows('test_dead_values_return_@amname@'::regclas
 
 drop table test_dead_values_return_@amname@;
 DROP TABLE
+
+--
+-- Test sampling on ADD COLUMN rows.
+--
+-- Case 1, the added column row is a sample row, verify no reading exceeded EOF issue.
+drop table if exists sampling_add_column_@amname@_1;
+DROP TABLE
+create table sampling_add_column_@amname@_1 (a int) using @amname@ distributed replicated;
+CREATE TABLE
+insert into sampling_add_column_@amname@_1 values (1);
+INSERT 0 1
+alter table sampling_add_column_@amname@_1 add column b int;
+ALTER TABLE
+insert into sampling_add_column_@amname@_1 values(100, 100);
+INSERT 0 1
+
+create or replace function test_sample_add_column() returns boolean as $$ declare cnt int; /* in func */ begin cnt := 0; /* in func */ while (cnt = 0) loop select count(*) into cnt from pg_catalog.gp_acquire_sample_rows('sampling_add_column_@amname@_1'::regclass, 1, 'f') as (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, a int, b int) where a = 100; /* in func */ end loop; /* in func */ return true; /* in func */ end; /* in func */ $$ language plpgsql;
+CREATE FUNCTION
+
+select test_sample_add_column();
+ test_sample_add_column 
+------------------------
+ t                      
+(1 row)
+
+-- Case 2, verify sample rows are correct after ADD COLUMN operation.
+drop table if exists sampling_add_column_@amname@_2;
+DROP TABLE
+create table sampling_add_column_@amname@_2 (a int) using @amname@;
+CREATE TABLE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+3: begin;
+BEGIN
+
+1: insert into sampling_add_column_@amname@_2 select * from generate_series(1, 10);
+INSERT 0 10
+2: insert into sampling_add_column_@amname@_2 select * from generate_series(11, 20);
+INSERT 0 10
+3: insert into sampling_add_column_@amname@_2 select * from generate_series(21, 30);
+INSERT 0 10
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+3: commit;
+COMMIT
+
+alter table sampling_add_column_@amname@_2 add column b int;
+ALTER TABLE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+3: begin;
+BEGIN
+
+1: insert into sampling_add_column_@amname@_2 values(100, 100);
+INSERT 0 1
+2: insert into sampling_add_column_@amname@_2 values(200, 200);
+INSERT 0 1
+3: insert into sampling_add_column_@amname@_2 values(300, 300);
+INSERT 0 1
+
+1: commit;
+COMMIT
+2: commit;
+COMMIT
+3: abort;
+ROLLBACK
+
+alter table sampling_add_column_@amname@_2 add column c text;
+ALTER TABLE
+
+1: begin;
+BEGIN
+2: begin;
+BEGIN
+3: begin;
+BEGIN
+
+1: insert into sampling_add_column_@amname@_2 values (100, 100, 'c100');
+INSERT 0 1
+2: insert into sampling_add_column_@amname@_2 values (200, 200, 'c200');
+INSERT 0 1
+3: insert into sampling_add_column_@amname@_2 values (300, 300, 'c300');
+INSERT 0 1
+
+1: commit;
+COMMIT
+2: abort;
+ROLLBACK
+3: commit;
+COMMIT
+
+select * from sampling_add_column_@amname@_2;
+ a   | b   | c    
+-----+-----+------
+ 2   |     |      
+ 3   |     |      
+ 4   |     |      
+ 7   |     |      
+ 8   |     |      
+ 16  |     |      
+ 18  |     |      
+ 19  |     |      
+ 22  |     |      
+ 24  |     |      
+ 27  |     |      
+ 29  |     |      
+ 1   |     |      
+ 300 | 300 | c300 
+ 12  |     |      
+ 15  |     |      
+ 20  |     |      
+ 23  |     |      
+ 26  |     |      
+ 30  |     |      
+ 5   |     |      
+ 6   |     |      
+ 9   |     |      
+ 10  |     |      
+ 200 | 200 |      
+ 11  |     |      
+ 13  |     |      
+ 14  |     |      
+ 17  |     |      
+ 100 | 100 | c100 
+ 21  |     |      
+ 25  |     |      
+ 28  |     |      
+ 100 | 100 |      
+(34 rows)
+select * from gp_acquire_sample_rows('sampling_add_column_@amname@_2'::regclass, 32, 'f') as (totalrows pg_catalog.float8, totaldeadrows pg_catalog.float8, oversized_cols_length pg_catalog._float8, a int, b int, c text);
+ totalrows | totaldeadrows | oversized_cols_length | a   | b   | c    
+-----------+---------------+-----------------------+-----+-----+------
+           |               |                       | 2   |     |      
+           |               |                       | 3   |     |      
+           |               |                       | 4   |     |      
+           |               |                       | 7   |     |      
+           |               |                       | 8   |     |      
+           |               |                       | 16  |     |      
+           |               |                       | 18  |     |      
+           |               |                       | 19  |     |      
+           |               |                       | 22  |     |      
+           |               |                       | 24  |     |      
+           |               |                       | 27  |     |      
+           |               |                       | 29  |     |      
+ 12        | 0             |                       |     |     |      
+           |               |                       | 1   |     |      
+           |               |                       | 300 | 300 | c300 
+           |               |                       | 12  |     |      
+           |               |                       | 15  |     |      
+           |               |                       | 20  |     |      
+           |               |                       | 23  |     |      
+           |               |                       | 26  |     |      
+           |               |                       | 30  |     |      
+ 8         | 0             |                       |     |     |      
+           |               |                       | 5   |     |      
+           |               |                       | 6   |     |      
+           |               |                       | 9   |     |      
+           |               |                       | 10  |     |      
+           |               |                       | 200 | 200 |      
+           |               |                       | 11  |     |      
+           |               |                       | 13  |     |      
+           |               |                       | 14  |     |      
+           |               |                       | 17  |     |      
+           |               |                       | 100 | 100 | c100 
+           |               |                       | 21  |     |      
+           |               |                       | 25  |     |      
+           |               |                       | 28  |     |      
+           |               |                       | 100 | 100 |      
+ 14        | 0             |                       |     |     |      
+(37 rows)


### PR DESCRIPTION
Sampling on CO tables requires all columns sub-segfiles
have the same total `tupcount` presented physically,
ADD COLUMN operation didn't populate physical rows which have
default values for better performance. This would break the
assumption as the new added column may have less phyical rows
than the anchor column, result in sampling scan may exceed
EOF on new added columns.

The solution of above issue is, after getting the target rowNum
of the anchor column (aka `phyrow`), fetch the same rowNum as
`phyrow` for the rest non-anchor columns instead of re-caculating
the target rowNum for each column.

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/hw-7X-debug-ao-sampling

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
