### PR TITLE
[6X] fix wrong result of MDQA in planner

### DIFF
--- a/src/backend/optimizer/plan/plangroupext.c
+++ b/src/backend/optimizer/plan/plangroupext.c
@@ -1263,7 +1263,6 @@ generate_dqa_plan(PlannerInfo *root,
 		root->group_pathkeys =
 			make_pathkeys_for_groupclause(root, root->parse->groupClause,
 										  context->sub_tlist);
-		root->group_pathkeys = root->group_pathkeys;
 	}
 
 	root->parse->havingQual = (Node *)new_qual;

--- a/src/test/regress/expected/bfv_dd.out
+++ b/src/test/regress/expected/bfv_dd.out
@@ -276,7 +276,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- group by and sort
 select a, count(*) from dd_part_singlecol where a=1 group by a;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------
@@ -284,7 +283,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 (1 row)
 
 select a, count(*) from dd_part_singlecol where a=1 group by a order by a;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------
@@ -572,7 +570,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- group by
 select a, count(*) from dd_singlecol_idx where a=1 and b=1  group by a;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------
@@ -803,7 +800,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- group by and sort
 select a, count(*) from dd_singlecol_1 where a=1 group by a;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------
@@ -811,7 +807,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 (1 row)
 
 select a, count(*) from dd_singlecol_1 where a=1 group by a order by a;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------

--- a/src/test/regress/expected/bfv_dd_multicolumn.out
+++ b/src/test/regress/expected/bfv_dd_multicolumn.out
@@ -218,7 +218,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 
 -- group by and sort
 select a, count(*) from dd_multicol_1 where a=1 and b=1 group by a,b;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------
@@ -226,7 +225,6 @@ INFO:  (slice 1) Dispatch command to SINGLE content
 (1 row)
 
 select a, count(*) from dd_multicol_1 where a=1 and b=1 group by a,b  order by a,b;
-INFO:  (slice 2) Dispatch command to ALL contents: 0 1 2
 INFO:  (slice 1) Dispatch command to SINGLE content
  a | count 
 ---+-------

--- a/src/test/regress/expected/gp_dqa.out
+++ b/src/test/regress/expected/gp_dqa.out
@@ -1398,3 +1398,152 @@ select count(distinct a), count(distinct b) from dqa_f4 group by c;
 
 reset optimizer_enable_multiple_distinct_aggs;
 drop table dqa_f4;
+-- Test corner case of mdqa as groupkey is constant
+create table dqa_f5(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set optimizer_enable_multiple_distinct_aggs=on;
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  GroupAggregate
+         Group Key: dqa_f5.a, dqa_f5.b
+         ->  Seq Scan on dqa_f5
+               Filter: ((a = 1) AND (b = 1))
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+explain (costs off)
+with tmp_result as (
+    select
+        a, d, count(distinct b), count(distinct c)
+    from dqa_f5
+    where a = 1
+    group by a,d
+    )
+select * from tmp_result where d=1;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  GroupAggregate
+         Group Key: dqa_f5.a, dqa_f5.d
+         ->  Seq Scan on dqa_f5
+               Filter: ((a = 1) AND (d = 1))
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+alter table dqa_f5 set distributed randomly;
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((NOT (share0_ref2.a IS DISTINCT FROM share0_ref1.a)) AND (NOT (share0_ref2.b IS DISTINCT FROM share0_ref1.b)))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: share0_ref2.a, share0_ref2.b
+               ->  HashAggregate
+                     Group Key: share0_ref2.a, share0_ref2.b
+                     ->  HashAggregate
+                           Group Key: share0_ref2.a, share0_ref2.b, share0_ref2.c
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: share0_ref2.a, share0_ref2.b
+                                 ->  HashAggregate
+                                       Group Key: share0_ref2.a, share0_ref2.b, share0_ref2.c
+                                       ->  Shared Scan (share slice:id 1:0)
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: share0_ref1.a, share0_ref1.b
+                     ->  HashAggregate
+                           Group Key: share0_ref1.a, share0_ref1.b, share0_ref1.d
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: share0_ref1.a, share0_ref1.b
+                                 ->  HashAggregate
+                                       Group Key: share0_ref1.a, share0_ref1.b, share0_ref1.d
+                                       ->  Shared Scan (share slice:id 3:0)
+                                             ->  Materialize
+                                                   ->  Seq Scan on dqa_f5
+                                                         Filter: ((a = 1) AND (b = 1))
+ Optimizer: Postgres query optimizer
+(28 rows)
+
+alter table dqa_f5 set distributed by (a,b,c);
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice4; segments: 3)
+   ->  Hash Join
+         Hash Cond: ((NOT (share0_ref2.a IS DISTINCT FROM share0_ref1.a)) AND (NOT (share0_ref2.b IS DISTINCT FROM share0_ref1.b)))
+         ->  Redistribute Motion 3:3  (slice2; segments: 3)
+               Hash Key: share0_ref2.a, share0_ref2.b
+               ->  HashAggregate
+                     Group Key: share0_ref2.a, share0_ref2.b
+                     ->  HashAggregate
+                           Group Key: share0_ref2.a, share0_ref2.b, share0_ref2.c
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: share0_ref2.a, share0_ref2.b
+                                 ->  HashAggregate
+                                       Group Key: share0_ref2.a, share0_ref2.b, share0_ref2.c
+                                       ->  Shared Scan (share slice:id 1:0)
+         ->  Hash
+               ->  HashAggregate
+                     Group Key: share0_ref1.a, share0_ref1.b
+                     ->  HashAggregate
+                           Group Key: share0_ref1.a, share0_ref1.b, share0_ref1.d
+                           ->  Redistribute Motion 3:3  (slice3; segments: 3)
+                                 Hash Key: share0_ref1.a, share0_ref1.b
+                                 ->  HashAggregate
+                                       Group Key: share0_ref1.a, share0_ref1.b, share0_ref1.d
+                                       ->  Shared Scan (share slice:id 3:0)
+                                             ->  Materialize
+                                                   ->  Seq Scan on dqa_f5
+                                                         Filter: ((a = 1) AND (b = 1))
+ Optimizer: Postgres query optimizer
+(28 rows)
+
+alter table dqa_f5 set distributed by (a,b);
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                 QUERY PLAN                  
+---------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  GroupAggregate
+         Group Key: dqa_f5.a, dqa_f5.b
+         ->  Seq Scan on dqa_f5
+               Filter: ((a = 1) AND (b = 1))
+ Optimizer: Postgres query optimizer
+(6 rows)
+
+reset optimizer_enable_multiple_distinct_aggs;
+drop table dqa_f5;

--- a/src/test/regress/expected/gp_dqa_optimizer.out
+++ b/src/test/regress/expected/gp_dqa_optimizer.out
@@ -1393,3 +1393,198 @@ select count(distinct a), count(distinct b) from dqa_f4 group by c;
 
 reset optimizer_enable_multiple_distinct_aggs;
 drop table dqa_f4;
+-- Test corner case of mdqa as groupkey is constant
+create table dqa_f5(a int, b int, c int, d int);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+set optimizer_enable_multiple_distinct_aggs=on;
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         Filter: (share1_ref3.b = 1)
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:1)
+                     ->  Materialize
+                           ->  Seq Scan on dqa_f5
+                                 Filter: (a = 1)
+               ->  Hash Join
+                     Hash Cond: ((NOT (share1_ref3.a IS DISTINCT FROM share1_ref2.a)) AND (NOT (share1_ref3.b IS DISTINCT FROM share1_ref2.b)))
+                     ->  GroupAggregate
+                           Group Key: share1_ref3.a, share1_ref3.b
+                           ->  Sort
+                                 Sort Key: share1_ref3.a, share1_ref3.b
+                                 ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share1_ref2.a, share1_ref2.b
+                                 ->  Sort
+                                       Sort Key: share1_ref2.a, share1_ref2.b
+                                       ->  Shared Scan (share slice:id 1:1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(22 rows)
+
+explain (costs off)
+with tmp_result as (
+    select
+        a, d, count(distinct b), count(distinct c)
+    from dqa_f5
+    where a = 1
+    group by a,d
+    )
+select * from tmp_result where d=1;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 1:1  (slice1; segments: 1)
+   ->  Result
+         Filter: (share1_ref3.d = 1)
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:1)
+                     ->  Materialize
+                           ->  Seq Scan on dqa_f5
+                                 Filter: (a = 1)
+               ->  Hash Join
+                     Hash Cond: ((NOT (share1_ref3.a IS DISTINCT FROM share1_ref2.a)) AND (NOT (share1_ref3.d IS DISTINCT FROM share1_ref2.d)))
+                     ->  GroupAggregate
+                           Group Key: share1_ref3.a, share1_ref3.d
+                           ->  Sort
+                                 Sort Key: share1_ref3.a, share1_ref3.d
+                                 ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share1_ref2.a, share1_ref2.d
+                                 ->  Sort
+                                       Sort Key: share1_ref2.a, share1_ref2.d
+                                       ->  Shared Scan (share slice:id 1:1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(22 rows)
+
+alter table dqa_f5 set distributed randomly;
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Sequence
+         ->  Shared Scan (share slice:id 3:2)
+               ->  Materialize
+                     ->  Seq Scan on dqa_f5
+                           Filter: ((a = 1) AND (b = 1))
+         ->  Hash Join
+               Hash Cond: ((NOT (share2_ref3.a IS DISTINCT FROM share2_ref2.a)) AND (NOT (share2_ref3.b IS DISTINCT FROM share2_ref2.b)))
+               ->  GroupAggregate
+                     Group Key: share2_ref3.a, share2_ref3.b
+                     ->  Sort
+                           Sort Key: share2_ref3.a, share2_ref3.b
+                           ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                 Hash Key: share2_ref3.a, share2_ref3.b
+                                 ->  Result
+                                       ->  Shared Scan (share slice:id 1:2)
+               ->  Hash
+                     ->  GroupAggregate
+                           Group Key: share2_ref2.a, share2_ref2.b
+                           ->  Sort
+                                 Sort Key: share2_ref2.a, share2_ref2.b
+                                 ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                       Hash Key: share2_ref2.a, share2_ref2.b
+                                       ->  Result
+                                             ->  Shared Scan (share slice:id 2:2)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(26 rows)
+
+alter table dqa_f5 set distributed by (a,b,c);
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice3; segments: 3)
+   ->  Result
+         Filter: (share1_ref3.b = 1)
+         ->  Sequence
+               ->  Shared Scan (share slice:id 3:1)
+                     ->  Materialize
+                           ->  Seq Scan on dqa_f5
+                                 Filter: (a = 1)
+               ->  Hash Join
+                     Hash Cond: ((NOT (share1_ref3.a IS DISTINCT FROM share1_ref2.a)) AND (NOT (share1_ref3.b IS DISTINCT FROM share1_ref2.b)))
+                     ->  GroupAggregate
+                           Group Key: share1_ref3.a, share1_ref3.b
+                           ->  Sort
+                                 Sort Key: share1_ref3.a, share1_ref3.b
+                                 ->  Redistribute Motion 3:3  (slice1; segments: 3)
+                                       Hash Key: share1_ref3.a, share1_ref3.b
+                                       ->  Result
+                                             ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share1_ref2.a, share1_ref2.b
+                                 ->  Sort
+                                       Sort Key: share1_ref2.a, share1_ref2.b
+                                       ->  Redistribute Motion 3:3  (slice2; segments: 3)
+                                             Hash Key: share1_ref2.a, share1_ref2.b
+                                             ->  Result
+                                                   ->  Shared Scan (share slice:id 2:1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(28 rows)
+
+alter table dqa_f5 set distributed by (a,b);
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+                                                                   QUERY PLAN                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)
+   ->  Result
+         Filter: (share1_ref3.b = 1)
+         ->  Sequence
+               ->  Shared Scan (share slice:id 1:1)
+                     ->  Materialize
+                           ->  Seq Scan on dqa_f5
+                                 Filter: (a = 1)
+               ->  Hash Join
+                     Hash Cond: ((NOT (share1_ref3.a IS DISTINCT FROM share1_ref2.a)) AND (NOT (share1_ref3.b IS DISTINCT FROM share1_ref2.b)))
+                     ->  GroupAggregate
+                           Group Key: share1_ref3.a, share1_ref3.b
+                           ->  Sort
+                                 Sort Key: share1_ref3.a, share1_ref3.b
+                                 ->  Shared Scan (share slice:id 1:1)
+                     ->  Hash
+                           ->  GroupAggregate
+                                 Group Key: share1_ref2.a, share1_ref2.b
+                                 ->  Sort
+                                       Sort Key: share1_ref2.a, share1_ref2.b
+                                       ->  Shared Scan (share slice:id 1:1)
+ Optimizer: Pivotal Optimizer (GPORCA)
+(22 rows)
+
+reset optimizer_enable_multiple_distinct_aggs;
+drop table dqa_f5;

--- a/src/test/regress/sql/gp_dqa.sql
+++ b/src/test/regress/sql/gp_dqa.sql
@@ -247,3 +247,63 @@ select count(distinct a), count(distinct b) from dqa_f4 group by c;
 reset optimizer_enable_multiple_distinct_aggs;
 
 drop table dqa_f4;
+
+-- Test corner case of mdqa as groupkey is constant
+create table dqa_f5(a int, b int, c int, d int);
+
+set optimizer_enable_multiple_distinct_aggs=on;
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+
+explain (costs off)
+with tmp_result as (
+    select
+        a, d, count(distinct b), count(distinct c)
+    from dqa_f5
+    where a = 1
+    group by a,d
+    )
+select * from tmp_result where d=1;
+
+alter table dqa_f5 set distributed randomly;
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+
+alter table dqa_f5 set distributed by (a,b,c);
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+
+alter table dqa_f5 set distributed by (a,b);
+explain (costs off)
+with tmp_result as (
+    select
+        a, b, count(distinct c), count(distinct d)
+    from dqa_f5
+    where a = 1
+    group by a,b
+    )
+select * from tmp_result where b=1;
+
+reset optimizer_enable_multiple_distinct_aggs;
+drop table dqa_f5;


### PR DESCRIPTION
In the 6x side, if the subpath's locus collocates tuples with group keys, the planner favors
local sortgroupagg over MDQ join rewrite. We also choose sortgroupagg when the group
key becomes constant, as constants should also be collocated.

In this PR, we need to differentiate between an empty groupClause and a constant
groupClause, as they are obviously distinct. In the function `cdb_grouping_planner`, 
`root->group_pathkeys == NULL` and `root->parse->groupClause` collocates with
subpath's locus indicate constant groupClause in the query. Otherwise, the groupClause
should be empty.

Fix Github Issue https://github.com/greenplum-db/gpdb/issues/17434