### PR TITLE
Add new fields to gp.conf for infra requirements

### DIFF
--- a/gpMgmt/bin/go-tools/.gitignore
+++ b/gpMgmt/bin/go-tools/.gitignore
@@ -1,0 +1,4 @@
+certificates/
+debug/
+
+*.conf

--- a/gpMgmt/bin/go-tools/internal/config/config.go
+++ b/gpMgmt/bin/go-tools/internal/config/config.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"github.com/spf13/viper"
+)
+
+type Config interface {
+	SetName(string)
+	Load(string) error
+
+	GetDatabaseConfig() DatabaseConfig
+	GetArtifactConfig() ArtifactConfig
+	GetInfraConfig() InfraConfig
+}
+
+func New() Config {
+	return &appConfig{
+		configName: "gp.conf",
+	}
+}
+
+type appConfig struct {
+	configName string
+	// TODO : embed hub Config
+
+	Database *Database `json:"database"`
+	Artifact *Artifact `json:"artifact"`
+	Infra    *Infra    `json:"infra"`
+}
+
+func (conf *appConfig) SetName(configName string) {
+	conf.configName = configName
+}
+
+func (conf *appConfig) Load(configPath string) error {
+	parser := viper.New()
+	parser.SetConfigName(conf.configName)
+	parser.SetConfigType("json")
+
+	parser.AddConfigPath(configPath)
+
+	conf.setDefaults(parser)
+	err := parser.ReadInConfig()
+	if err != nil {
+		return err
+	}
+
+	err = parser.Unmarshal(conf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (conf *appConfig) GetDatabaseConfig() DatabaseConfig {
+	return conf.Database
+}
+
+func (conf *appConfig) GetArtifactConfig() ArtifactConfig {
+	return conf.Artifact
+}
+
+func (conf *appConfig) GetInfraConfig() InfraConfig {
+	return conf.Infra
+}
+
+func (conf *appConfig) setDefaults(parser *viper.Viper) *viper.Viper {
+	parser.SetDefault("Infra.RequestPort", 4506)
+	parser.SetDefault("Infra.PublishPort", 4505)
+	parser.SetDefault("Infra.Coordinator.HostName", "cdw")
+	parser.SetDefault("Database.Admin.Name", "gpadmin")
+
+	return parser
+}

--- a/gpMgmt/bin/go-tools/internal/config/config_test.go
+++ b/gpMgmt/bin/go-tools/internal/config/config_test.go
@@ -1,0 +1,59 @@
+package config_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/greenplum-db/gpdb/gp/internal/config"
+	"github.com/greenplum-db/gpdb/gp/internal/enums"
+	"github.com/greenplum-db/gpdb/gp/testutils"
+	"github.com/greenplum-db/gpdb/gp/testutils/exectest"
+)
+
+func init() {
+	exectest.RegisterMains()
+}
+
+func TestConfig(t *testing.T) {
+
+	t.Run("config not present at location", func(t *testing.T) {
+
+		testConfig := config.New()
+		err := testConfig.Load(".")
+		if err == nil {
+			t.Fatalf("Expected %s, got %d", "error", err)
+		}
+
+	})
+
+	t.Run("config loaded succesfully with defaults", func(t *testing.T) {
+
+		testConfig := config.New()
+		testConfig.SetName("gpdeploy.testconf")
+		err := testConfig.Load("../../test/data")
+
+		testutils.Assert(t, nil, err, "Failed to load configs")
+		testutils.Assert(t, enums.DeploymentTypeMirrorless, testConfig.GetDatabaseConfig().GetDeploymentType(), "")
+
+		testutils.Assert(t, 4506, testConfig.GetInfraConfig().GetRequestPort(), "")
+		testutils.Assert(t, 4505, testConfig.GetInfraConfig().GetPublishPort(), "")
+		testutils.Assert(t, "custom-name", testConfig.GetInfraConfig().GetStandby().GetHostname(), "")
+		testutils.Assert(t, "10.202.89.77", testConfig.GetInfraConfig().GetCoordinator().GetIp(), "")
+		testutils.Assert(t, "192.168.100.1/24", testConfig.GetInfraConfig().GetSegmentHost().GetNetwork().GetInternalCidr(), "")
+	})
+
+	t.Run("config loaded succesfully overriding defaults", func(t *testing.T) {
+
+		testConfig := config.New()
+		testConfig.SetName("gpdeploy_override.testconf")
+		err := testConfig.Load("../../test/data")
+
+		testutils.Assert(t, nil, err, "Failed to load configs")
+		testutils.Assert(t, enums.DeploymentTypeMirrorless, testConfig.GetDatabaseConfig().GetDeploymentType(), "")
+		testutils.Assert(t, 5001, testConfig.GetInfraConfig().GetRequestPort(), "")
+		testutils.Assert(t, 5002, testConfig.GetInfraConfig().GetPublishPort(), "")
+		testutils.Assert(t, "cdw", testConfig.GetInfraConfig().GetCoordinator().GetHostname(), "")
+		testutils.Assert(t, "&{password dssdfwef}", fmt.Sprintf("%v", testConfig.GetInfraConfig().GetStandby().GetAuth()), "")
+
+	})
+}

--- a/gpMgmt/bin/go-tools/internal/config/database.go
+++ b/gpMgmt/bin/go-tools/internal/config/database.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"github.com/greenplum-db/gpdb/gp/internal/enums"
+)
+
+type DatabaseConfig interface {
+	GetDeploymentType() enums.DeploymentType
+	GetAdmin() UserConfig
+	GetSegmentsPerSegmentHost() int
+}
+type Database struct {
+	DeploymentType         enums.DeploymentType `json:"deploymentType"`
+	Admin                  *User                `json:"admin"`
+	SegmentsPerSegmentHost int                  `json:"segmentsPerSegmentHost"`
+}
+
+func (d Database) GetDeploymentType() enums.DeploymentType {
+	return d.DeploymentType
+}
+func (d Database) GetAdmin() UserConfig {
+	return d.Admin
+}
+func (d Database) GetSegmentsPerSegmentHost() int {
+	return d.SegmentsPerSegmentHost
+}
+
+type UserConfig interface {
+	GetName() string
+	GetPassword() string
+}
+type User struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+
+func (u User) GetName() string {
+	return u.Name
+}
+func (u User) GetPassword() string {
+	return u.Password
+}
+
+type ArtifactConfig interface {
+	GetGreenplum() string
+	GetDependencyList() []string
+}
+type Artifact struct {
+	Greenplum      string   `json:"greenplum"`
+	DependencyList []string `json:"dependencyList"`
+}
+
+func (a Artifact) GetGreenplum() string {
+	return a.Greenplum
+}
+func (a Artifact) GetDependencyList() []string {
+	return a.DependencyList
+}

--- a/gpMgmt/bin/go-tools/internal/config/infra.go
+++ b/gpMgmt/bin/go-tools/internal/config/infra.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"github.com/greenplum-db/gpdb/gp/internal/enums"
+)
+
+type InfraConfig interface {
+	GetRequestPort() int
+	GetPublishPort() int
+	GetCoordinator() HostConfig
+	GetStandby() HostConfig
+	GetSegmentHost() SegmentHostsConfig
+}
+type Infra struct {
+	RequestPort  int           `json:"requestPort"`
+	PublishPort  int           `json:"publishPort"`
+	Coordinator  *Host         `json:"coordinatorHost" mapstructure:"coordinatorHost"`
+	Standby      *Host         `json:"standbyHost" mapstructure:"standbyHost"`
+	SegmentHosts *SegmentHosts `json:"segmentHost" mapstructure:"segmentHost"`
+}
+
+func (i Infra) GetRequestPort() int {
+	return i.RequestPort
+}
+func (i Infra) GetPublishPort() int {
+	return i.PublishPort
+}
+func (i Infra) GetCoordinator() HostConfig {
+	return i.Coordinator
+}
+func (i Infra) GetStandby() HostConfig {
+	return i.Standby
+}
+func (i Infra) GetSegmentHost() SegmentHostsConfig {
+	return i.SegmentHosts
+}
+
+type AuthenticationConfig interface {
+	GetType() enums.AuthType
+	GetPassword() string
+}
+
+type Authentication struct {
+	Type     enums.AuthType `json:"type"`
+	Password string         `json:"password"`
+}
+
+func (a Authentication) GetType() enums.AuthType {
+	return a.Type
+}
+func (a Authentication) GetPassword() string {
+	return a.Password
+}
+
+type HostConfig interface {
+	GetIp() string
+	GetHostname() string
+	GetDomainName() string
+	GetAuth() AuthenticationConfig
+}
+
+type Host struct {
+	Hostname   string          `json:"hostname"`
+	DomainName string          `json:"domainName"`
+	Auth       *Authentication `json:"authentication"  mapstructure:"authentication"`
+	Ip         string          `json:"ip"`
+}
+
+func (h Host) GetIp() string {
+	return h.Ip
+}
+func (h Host) GetHostname() string {
+	return h.Hostname
+}
+func (h Host) GetDomainName() string {
+	return h.DomainName
+}
+func (h Host) GetAuth() AuthenticationConfig {
+	return h.Auth
+}
+
+type SegmentHostsConfig interface {
+	GetSegmentHostsCount() int
+	GetNetwork() SegmentHostsNetworkConfig
+	GetAuthentication() AuthenticationConfig
+	GetHostnamePrefix() string
+	GetDomainName() string
+}
+type SegmentHosts struct {
+	SegmentHostsCount int                  `json:"segmentHostsCount"`
+	Network           *SegmentHostsNetwork `json:"network"`
+	Authentication    *Authentication      `json:"authentication"`
+	HostnamePrefix    string               `json:"hostnamePrefix"`
+	DomainName        string               `json:"domainName"`
+}
+
+func (s SegmentHosts) GetSegmentHostsCount() int {
+	return s.SegmentHostsCount
+}
+func (s SegmentHosts) GetNetwork() SegmentHostsNetworkConfig {
+	return s.Network
+}
+func (s SegmentHosts) GetAuthentication() AuthenticationConfig {
+	return s.Authentication
+}
+func (s SegmentHosts) GetHostnamePrefix() string {
+	return s.HostnamePrefix
+}
+func (s SegmentHosts) GetDomainName() string {
+	return s.DomainName
+}
+
+type SegmentHostsNetworkConfig interface {
+	GetInternalCidr() string
+	GetIpRange() IpRangeConfig
+	GetIpList() []string
+}
+
+type SegmentHostsNetwork struct {
+	InternalCidr string   `json:"internalCidr"`
+	IpRange      *IpRange `json:"ipRange"`
+	IpList       []string `json:"ipList"`
+}
+
+func (sn SegmentHostsNetwork) GetInternalCidr() string {
+	return sn.InternalCidr
+}
+func (sn SegmentHostsNetwork) GetIpRange() IpRangeConfig {
+	return sn.IpRange
+}
+func (sn SegmentHostsNetwork) GetIpList() []string {
+	return sn.IpList
+}
+
+type IpRangeConfig interface {
+	GetFirstIp() string
+	GetLastIp() string
+}
+type IpRange struct {
+	FirstIp string `json:"first" mapstructure:"first"`
+	LastIp  string `json:"last" mapstructure:"last"`
+}
+
+func (ip IpRange) GetFirstIp() string {
+	return ip.FirstIp
+}
+func (ip IpRange) GetLastIp() string {
+	return ip.LastIp
+}

--- a/gpMgmt/bin/go-tools/internal/enums/auth_type.go
+++ b/gpMgmt/bin/go-tools/internal/enums/auth_type.go
@@ -1,0 +1,8 @@
+package enums
+
+type AuthType string
+
+const (
+	AuthTypeNone     AuthType = "none"
+	AuthTypePassword AuthType = "password"
+)

--- a/gpMgmt/bin/go-tools/internal/enums/deployment_type.go
+++ b/gpMgmt/bin/go-tools/internal/enums/deployment_type.go
@@ -1,0 +1,8 @@
+package enums
+
+type DeploymentType string
+
+const (
+	DeploymentTypeMirrored   DeploymentType = "mirrored"
+	DeploymentTypeMirrorless DeploymentType = "mirrorless"
+)

--- a/gpMgmt/bin/go-tools/test/data/gpdeploy.testconf
+++ b/gpMgmt/bin/go-tools/test/data/gpdeploy.testconf
@@ -1,0 +1,59 @@
+{
+  "database": {
+    "deploymentType": "mirrorless",
+    "admin": {
+      "name": "gpadmin",
+      "password": "asdfqwsfd"
+    },
+    "segmentsPerSegmentHost": 3
+  },
+  "artifact": {
+    "greenplum": "/tpm/rpms/gpdb.rpm",
+    "dependencyList": [
+      "/tpm/rpms/rpm-1.rpm",
+      "/tpm/rpms/rpm-2.rpm"
+    ]
+  },
+  "infra": {
+    "requestPort": 4506,
+    "publishPort": 4505,
+    "coordinatorHost": {
+      "ip": "10.202.89.77",
+      "hostname": "cdw",
+      "domainName": "example.com",
+      "authentication": {
+        "type": "password",
+        "password": "dssdfwef"
+      }
+    },
+    "standbyHost": {
+      "ip": "10.202.89.76",
+      "hostname": "custom-name",
+      "domainName": "example.com",
+      "authentication": {
+        "type": "password",
+        "password": "dssdfwef"
+      }
+    },
+    "segmentHost": {
+      "segmentHostsCount": 10,
+      "network": {
+        "internalCidr": "192.168.100.1/24",
+        "ipRange": {
+          "first": "192.168.100.1",
+          "last": "192.168.100.25"
+        },
+        "ipList": [
+          "192.168.100.1",
+          "192.168.100.2"
+        ]
+      },
+      "authentication": {
+        "type": "password",
+        "password": "asdfasdf"
+      },
+      "hostnamePrefix": "custom",
+      "domainName": "example.com"
+    }
+  }
+}

--- a/gpMgmt/bin/go-tools/test/data/gpdeploy_override.testconf
+++ b/gpMgmt/bin/go-tools/test/data/gpdeploy_override.testconf
@@ -1,0 +1,59 @@
+{
+  "database": {
+    "deploymentType": "mirrorless",
+    "admin": {
+      "name": "gpadmin",
+      "password": "asdfqwsfd"
+    },
+    "segmentsPerSegmentHost": 3
+  },
+  "artifact": {
+    "greenplum": "/tpm/rpms/gpdb.rpm",
+    "dependencyList": [
+      "/tpm/rpms/rpm-1.rpm",
+      "/tpm/rpms/rpm-2.rpm"
+    ]
+  },
+  "infra": {
+    "requestPort": 5001,
+    "publishPort": 5002,
+    "coordinatorHost": {
+      "ip": "10.202.89.77",
+      "hostname": "cdw",
+      "domainName": "example.com",
+      "authentication": {
+        "type": "password",
+        "password": "dssdfwef"
+      }
+    },
+    "standbyHost": {
+      "ip": "10.202.89.76",
+      "hostname": "custom-name",
+      "domainName": "example.com",
+      "authentication": {
+        "type": "password",
+        "password": "dssdfwef"
+      }
+    },
+    "segmentHost": {
+      "segmentHostsCount": 10,
+      "network": {
+        "internalCidr": "192.168.100.1/24",
+        "ipRange": {
+          "first": "192.168.100.1",
+          "last": "192.168.100.25"
+        },
+        "ipList": [
+          "192.168.100.1",
+          "192.168.100.2"
+        ]
+      },
+      "authentication": {
+        "type": "password",
+        "password": "asdfasdf"
+      },
+      "hostnamePrefix": "custom",
+      "domainName": "example.com"
+    }
+  }
+}

--- a/gpMgmt/bin/go-tools/testutils/testutils.go
+++ b/gpMgmt/bin/go-tools/testutils/testutils.go
@@ -219,3 +219,13 @@ func getMockDBConn(t *testing.T, utility bool, errs ...error) (*dbconn.DBConn, s
 
 	return connection, mock
 }
+
+func Assert(t *testing.T, expected any, actual any, log string) {
+	if expected != actual {
+		if len(strings.TrimSpace(log)) > 0 {
+			t.Fatalf("Expected %v, got %v , %s", expected, actual, log)
+		} else {
+			t.Fatalf("Expected %v, got %v", expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
We are extending go-tools to manage OS configuration in a greenplum cluster.

This commit has following changes in go-tools :
* added package internal/pkg/config, with configuration details for remote hosts to be used for OS configirations
* added package internal/pkg/enums, with enums for authentication type and greenplum deployment type
