### PR TITLE
fix a bug in getTables to obtain the amname of heap table.

### DIFF
--- a/src/bin/pg_dump/pg_dump.c
+++ b/src/bin/pg_dump/pg_dump.c
@@ -6613,7 +6613,7 @@ getTables(Archive *fout, int *numTables)
 						  "am.amname, ");
 	else
 		appendPQExpBufferStr(query,
-						  "NULL AS amname, ");
+						  "CASE WHEN c.relstorage = 'h' THEN 'heap' ELSE NULL END AS amname, ");
 
 	if (fout->remoteVersion >= 90600)
 		appendPQExpBufferStr(query,


### PR DESCRIPTION
fix a bug in getTables to obtain the amname of the heap table in lower versions of postgres. In the version upgrade from GPDB6 to GPDB7, amname will be used as the value of default_table_access_method to specify whether the heap table or ao table will be created next. In the getAOTableInfo function, the amname of the ao table is obtained, but the amname of the heap table is missing. This will cause some heap tables to be created as ao tables.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
