### PR TITLE
fix panic when concurrent update with before row update trigger

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -2527,7 +2527,11 @@ ExecBRUpdateTriggers(EState *estate, EPQState *epqstate,
 	 */
 	if (newSlot != NULL)
 	{
-		slot = ExecFilterJunk(estate->es_junkFilter, newSlot);
+		/*
+		 * estate->es_junkFilter is used for SELECT,
+		 * Here we should use relinfo->ri_junkFilter instead of estate->es_junkFilter.
+		 */
+		slot = ExecFilterJunk(relinfo->ri_junkFilter, newSlot);
 		slottuple = ExecFetchSlotHeapTuple(slot);
 		newtuple = slottuple;
 	}

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -377,3 +377,32 @@ DROP
 
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- test concurrent update with before row update trigger
+create table t_trigger (tc1 int, tc2 int, update_time timestamp without time zone DEFAULT now() NOT NULL);
+CREATE
+-- create a function which is used by trigger
+CREATE FUNCTION update_update_time() RETURNS trigger AS $$ /*in func*/ BEGIN /*in func*/ NEW.update_time = now(); /*in func*/ return NEW; /*in func*/ END; /*in func*/ $$ /*in func*/ LANGUAGE plpgsql;
+CREATE
+
+CREATE TRIGGER trig BEFORE INSERT OR UPDATE ON t_trigger FOR EACH ROW EXECUTE PROCEDURE update_update_time();
+CREATE
+insert into t_trigger values (1, 1, now());
+INSERT 1
+1: begin;
+BEGIN
+1: update t_trigger set tc2 = 2 where tc1 = 1;
+UPDATE 1
+2&: update t_trigger set tc2 = 3 where tc1 = 1;  <waiting ...>
+1: commit;
+COMMIT
+2<:  <... completed>
+UPDATE 1
+1: drop trigger trig on t_trigger;
+DROP
+1: drop function update_update_time();
+DROP
+1: drop table t_trigger;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/expected/gdd/concurrent_update.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update.out
@@ -387,8 +387,8 @@ CREATE
 
 CREATE TRIGGER trig BEFORE INSERT OR UPDATE ON t_trigger FOR EACH ROW EXECUTE PROCEDURE update_update_time();
 CREATE
-insert into t_trigger values (1, 1, now());
-INSERT 1
+/* original time is a very very old timestamp */ insert into t_trigger values (1, 1, '1000-01-01');
+/* 1
 1: begin;
 BEGIN
 1: update t_trigger set tc2 = 2 where tc1 = 1;
@@ -398,6 +398,12 @@ UPDATE 1
 COMMIT
 2<:  <... completed>
 UPDATE 1
+-- verify that trigger works. The case running time must larger then the old original data for years.
+select tc1, tc2, extract(epoch from (update_time - '1000-01-01'))/3600/24/365 > 2 from t_trigger;
+ tc1 | tc2 | ?column? 
+-----+-----+----------
+ 1   | 3   | t        
+(1 row)
 1: drop trigger trig on t_trigger;
 DROP
 1: drop function update_update_time();

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -392,8 +392,8 @@ CREATE
 
 CREATE TRIGGER trig BEFORE INSERT OR UPDATE ON t_trigger FOR EACH ROW EXECUTE PROCEDURE update_update_time();
 CREATE
-insert into t_trigger values (1, 1, now());
-INSERT 1
+/* original time is a very very old timestamp */ insert into t_trigger values (1, 1, '1000-01-01');
+/* 1
 1: begin;
 BEGIN
 1: update t_trigger set tc2 = 2 where tc1 = 1;
@@ -403,6 +403,12 @@ UPDATE 1
 COMMIT
 2<:  <... completed>
 UPDATE 1
+-- verify that trigger works. The case running time must larger then the old original data for years.
+select tc1, tc2, extract(epoch from (update_time - '1000-01-01'))/3600/24/365 > 2 from t_trigger;
+ tc1 | tc2 | ?column? 
+-----+-----+----------
+ 1   | 3   | t        
+(1 row)
 1: drop trigger trig on t_trigger;
 DROP
 1: drop function update_update_time();

--- a/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
+++ b/src/test/isolation2/expected/gdd/concurrent_update_optimizer.out
@@ -382,3 +382,32 @@ DROP
 
 1q: ... <quitting>
 2q: ... <quitting>
+
+-- test concurrent update with before row update trigger
+create table t_trigger (tc1 int, tc2 int, update_time timestamp without time zone DEFAULT now() NOT NULL);
+CREATE
+-- create a function which is used by trigger
+CREATE FUNCTION update_update_time() RETURNS trigger AS $$ /*in func*/ BEGIN /*in func*/ NEW.update_time = now(); /*in func*/ return NEW; /*in func*/ END; /*in func*/ $$ /*in func*/ LANGUAGE plpgsql;
+CREATE
+
+CREATE TRIGGER trig BEFORE INSERT OR UPDATE ON t_trigger FOR EACH ROW EXECUTE PROCEDURE update_update_time();
+CREATE
+insert into t_trigger values (1, 1, now());
+INSERT 1
+1: begin;
+BEGIN
+1: update t_trigger set tc2 = 2 where tc1 = 1;
+UPDATE 1
+2&: update t_trigger set tc2 = 3 where tc1 = 1;  <waiting ...>
+1: commit;
+COMMIT
+2<:  <... completed>
+UPDATE 1
+1: drop trigger trig on t_trigger;
+DROP
+1: drop function update_update_time();
+DROP
+1: drop table t_trigger;
+DROP
+1q: ... <quitting>
+2q: ... <quitting>

--- a/src/test/isolation2/sql/gdd/concurrent_update.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_update.sql
@@ -233,12 +233,15 @@ $$ /*in func*/
 LANGUAGE plpgsql;
 
 CREATE TRIGGER trig BEFORE INSERT OR UPDATE ON t_trigger FOR EACH ROW EXECUTE PROCEDURE update_update_time();
-insert into t_trigger values (1, 1, now());
+/* original time is a very very old timestamp */
+insert into t_trigger values (1, 1, '1000-01-01');
 1: begin;
 1: update t_trigger set tc2 = 2 where tc1 = 1;
 2&: update t_trigger set tc2 = 3 where tc1 = 1;
 1: commit;
 2<:
+-- verify that trigger works. The case running time must larger then the old original data for years.
+select tc1, tc2, extract(epoch from (update_time - '1000-01-01'))/3600/24/365 > 2 from t_trigger;
 1: drop trigger trig on t_trigger;
 1: drop function update_update_time();
 1: drop table t_trigger;

--- a/src/test/isolation2/sql/gdd/concurrent_update.sql
+++ b/src/test/isolation2/sql/gdd/concurrent_update.sql
@@ -220,3 +220,27 @@ drop table test;
 
 1q:
 2q:
+
+-- test concurrent update with before row update trigger
+create table t_trigger (tc1 int, tc2 int, update_time timestamp without time zone DEFAULT now() NOT NULL);
+-- create a function which is used by trigger
+CREATE FUNCTION update_update_time() RETURNS trigger AS $$ /*in func*/
+BEGIN /*in func*/
+	NEW.update_time = now(); /*in func*/
+	return NEW; /*in func*/
+END; /*in func*/
+$$ /*in func*/
+LANGUAGE plpgsql;
+
+CREATE TRIGGER trig BEFORE INSERT OR UPDATE ON t_trigger FOR EACH ROW EXECUTE PROCEDURE update_update_time();
+insert into t_trigger values (1, 1, now());
+1: begin;
+1: update t_trigger set tc2 = 2 where tc1 = 1;
+2&: update t_trigger set tc2 = 3 where tc1 = 1;
+1: commit;
+2<:
+1: drop trigger trig on t_trigger;
+1: drop function update_update_time();
+1: drop table t_trigger;
+1q:
+2q:


### PR DESCRIPTION
Panic occurs when we meet the following three conditions at the same time:
1. set gp_enable_global_deadlock_detector=true;
2. The table should have a before row update trigger.  
3. There is a concurrence when executing update statement.

In ExecBRUpdateTriggers
```
if (newSlot != NULL)
{
	slot = ExecFilterJunk(estate->es_junkFilter, newSlot);
	slottuple = ExecFetchSlotHeapTuple(slot);
	newtuple = slottuple;
}
```
We use estate->es_junkFilter, But it is null, so it is panic.
estate->es_junkFilter is used for select and resultRelInfo->ri_junkFilter
used for DML.We should use resultRelInfo->ri_junkFilter instead of
estate->es_junkFilter here.

GPDB7 uses resultRelInfo->ri_junkFilter from the beginning, So it is ok.
GPDB6 uses estate->es_junkFilter from the beginning.
I think there is something wrong when do merge working in GPDB6.