### PR TITLE
Avoid replay dtx info in checkpoint for newly expanded segments

### DIFF
--- a/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpexpand.feature
@@ -727,3 +727,28 @@ Feature: expand the cluster by adding more segments
         And verify that the path "gpperfmon/logs" in each segment data directory does not exist
         And verify that the path "promote" in each segment data directory does not exist
         And verify that the path "db_analyze" in each segment data directory does not exist
+
+    @gpexpand_no_mirrors
+    @gpexpand_segment
+    @gpexpand_verify_dtx
+    Scenario: Gpexpand should succeed when xlog has DTX info
+        Given the database is not running
+        And the user runs command "rm -rf ~/gpAdminLogs/gpinitsystem*"
+        And a working directory of the test as '/data/gpdata/gpexpand'
+        And the user runs command "rm -rf /data/gpdata/gpexpand/*"
+        And a temporary directory under "/data/gpdata/gpexpand/expandedData" to expand into
+        And the cluster is generated with "3" primaries only
+        And database "gptest" exists
+        And the user runs psql with "-c 'create extension IF NOT EXISTS gp_inject_fault;create table ttt(tc1 int);'" against database "gptest"
+        And the user runs psql with "-c "SELECT gp_inject_fault('before_notify_commited_dtx_transaction', 'suspend', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"" against database "gptest"
+        And the user runs the command "psql gptest -c 'insert into ttt select generate_series(1,100);'" in the background without sleep
+        And waiting "1" seconds
+        And there are no gpexpand_inputfiles
+        And the cluster is setup for an expansion on hosts "localhost"
+        When the user runs gpexpand interview to add 1 new segment and 0 new host "ignored.host"
+        Then the number of segments have been saved
+        When the user runs gpexpand with the latest gpexpand_inputfile with additional parameters "--silent"
+        And the user runs psql with "-c "SELECT gp_inject_fault('before_notify_commited_dtx_transaction', 'reset', dbid) FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"" against database "gptest"
+        And waiting "1" seconds
+        And the user runs psql with "-c 'drop table ttt;'" against database "gptest"
+        Then verify that the cluster has 1 new segments

--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -2739,6 +2739,7 @@ CommitTransaction(void)
 
 	if (notifyCommittedDtxTransactionIsNeeded())
 	{
+		SIMPLE_FAULT_INJECTOR("before_notify_commited_dtx_transaction");
 		/*
 		 * Do 2nd phase of commit to all QE. NOTE: we can't process
 		 * signals (which may attempt to abort our now partially-completed

--- a/src/backend/access/transam/xlog.c
+++ b/src/backend/access/transam/xlog.c
@@ -8618,8 +8618,14 @@ ReadCheckpointRecord(XLogReaderState *xlogreader, XLogRecPtr RecPtr,
 		/*
 		 * Find Xacts that are distributed committed from the checkpoint record and
 		 * store them such that they can utilized later during DTM recovery.
+		 *
+		 * The coordinator may execute write DTX during gpexpand, so the newly
+		 * added segment may contain DTX info in checkpoint XLOG. However, this step
+		 * is useless and should be avoided for segments, or fatal may be thrown since
+		 * max_tm_gxacts is 0 in segments.
 		 */
-		XLogProcessCheckpointRecord(record);
+		if(IS_QUERY_DISPATCHER())
+			XLogProcessCheckpointRecord(record);
 	}
 
 	return record;


### PR DESCRIPTION
gpexpand will create new segment by doing pg_basebackup from coordinator,
and DTX can be started in coordinator during that phase. So the newly added
segment's checkpoint XLOG may contain DTX info, which will result in the start
of the segment failed.
The definition of CheckpointExtendedRecord is different between GPDB6 and GPDB7.
In GPDB6 there is an extra field prepared_transaction_agg_state to store all the prepared
transactions on the checkpoint.
```
typedef struct CheckpointExtendedRecord
{
	struct TMGXACT_CHECKPOINT *dtxCheckpoint;
	uint32				dtxCheckpointLen;
	struct prepared_transaction_agg_state  *ptas;
} CheckpointExtendedRecord;
```
In GPDB6 we should skip XLogProcessCheckpointRecord for QE,
But should not skip SetupCheckpointPreparedTransactionList.

backport form https://github.com/greenplum-db/gpdb/pull/17346