### PR TITLE
Resolve Deadlock: Allow Concurrent Creation of Non-First Index on AO

### DIFF
--- a/src/backend/commands/indexcmds.c
+++ b/src/backend/commands/indexcmds.c
@@ -730,6 +730,8 @@ DefineIndex(Oid relationId,
 				 errmsg("cannot use more than %d columns in an index",
 						INDEX_MAX_KEYS)));
 
+	SIMPLE_FAULT_INJECTOR("defineindex_before_acquire_lock");
+
 	/*
 	 * Only SELECT ... FOR UPDATE/SHARE are allowed while doing a standard
 	 * index build; but for concurrent builds we allow INSERT/UPDATE/DELETE
@@ -1351,9 +1353,10 @@ DefineIndex(Oid relationId,
 
 	/*
 	 * Create block directory if this is an appendoptimized
-	 * relation
+	 * relation and one not present currently
 	 */
-	AlterTableCreateAoBlkdirTable(RelationGetRelid(rel));
+	if (!OidIsValid(blkdirrelid))
+		AlterTableCreateAoBlkdirTable(RelationGetRelid(rel));
 
 	/*
 	 * Make the catalog entries for the index, including constraints. This

--- a/src/test/isolation2/sql/concurrent_index_creation_should_not_deadlock.sql
+++ b/src/test/isolation2/sql/concurrent_index_creation_should_not_deadlock.sql
@@ -1,15 +1,17 @@
+-- Test to make sure non-first concurrent index creations don't deadlock
 -- Create an append only table, popluated with data
 CREATE TABLE index_deadlocking_test_table (value int) WITH (appendonly=true);
+CREATE INDEX index_deadlocking_test_table_initial_index on index_deadlocking_test_table (value);
 
--- Setup a fault to ensure that the first session pauses while creating an index,
+-- Setup a fault to ensure that both sessions pauses while creating an index,
 -- ensuring a concurrent index creation.
-SELECT gp_inject_fault('before_acquire_lock_during_create_ao_blkdir_table', 'suspend', 1);
+SELECT gp_inject_fault('defineindex_before_acquire_lock', 'suspend', 1);
 
 -- Attempt to concurrently create an index
 1>: CREATE INDEX index_deadlocking_test_table_idx1 ON index_deadlocking_test_table (value);
-SELECT gp_wait_until_triggered_fault('before_acquire_lock_during_create_ao_blkdir_table', 1, 1);
 2>: CREATE INDEX index_deadlocking_test_table_idx2 ON index_deadlocking_test_table (value);
-SELECT gp_inject_fault('before_acquire_lock_during_create_ao_blkdir_table', 'reset', 1);
+SELECT gp_wait_until_triggered_fault('defineindex_before_acquire_lock', 2, 1);
+SELECT gp_inject_fault('defineindex_before_acquire_lock', 'reset', 1);
 
 -- Both index creation attempts should succeed
 1<:


### PR DESCRIPTION
AlterTableCreateAoBlkdirTable() is being called unconditionally, it upgrades ShareLock to ShareRowExclusiveLock hence may result in deadlock for concurrent index creation even if block directory is present on the append-optimized table. This is regression in 7X compared to 6X. As a fix avoiding call to
AlterTableCreateAoBlkdirTable() if block directory is present which is checked already in DefineIndex() with ShareLock held.

Just note: the deadlock case for concurrent index creations in absence of block directory (which is initial index) still exists, as in absence of block directory, lock upgrade from ShareLock to ShareRowExclusiveLock in DefineIndex() still exists and is hard to resolve. Existing test 
concurrent_index_creation_should_not_deadlock wasn't testing the case correctly. Hence modifying that test to only validate for now non-first index creation case.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
