### PR TITLE
[6X Backport] Stream WAL archiving status from primaries to mirrors

### DIFF
--- a/.abi-check/6.27.0/postgres.symbols.ignore
+++ b/.abi-check/6.27.0/postgres.symbols.ignore
@@ -1,0 +1,1 @@
+ConfigureNamesInt_gp

--- a/src/backend/postmaster/pgstat.c
+++ b/src/backend/postmaster/pgstat.c
@@ -2435,6 +2435,47 @@ pgstat_fetch_global(void)
 	return &globalStats;
 }
 
+/*
+ * ---------
+ * pgstat_use_stale_snapshot() -
+ *
+ * Take a "snapshot" of the current stats into backend-private memory.
+ * pgstat_fetch_*() functions can then be used to interrogate the stats.
+ *
+ * The first call pgstat_fetch_*() in a transaction will take a snapshot
+ * implicitly, so this is normally not required. But this can be used if
+ * you don't want to wait for fresh stats, like pgstat_fetch_*() functions will
+ * ---------
+ */
+void
+pgstat_use_stale_snapshot(void)
+{
+	pgstat_clear_snapshot();
+
+	/* For all the current callers, shallow stats are enough.
+	 *
+	 * XXX: There is no way to request global stats only; we'll get stats
+	 * for all databases.
+	 */
+	pgStatDBHash = pgstat_read_statsfiles(InvalidOid, false, false);
+}
+
+/*
+ * ---------
+ * pgstat_request_update() -
+ *
+ * Ask the stats collector to refresh the stats file. Normally,
+ * pgstat_fetch_*() will do this automatically, but this can be used together
+ * with pgstat_take_snapshot() to wait for poll for updated stats
+ * asynchronously.
+ * ---------
+ */
+void
+pgstat_request_update(TimestampTz cur_ts, TimestampTz min_ts)
+{
+	pgstat_send_inquiry(cur_ts, min_ts, InvalidOid);
+}
+
 
 /* ------------------------------------------------------------
  * Functions for management of the shared-memory PgBackendStatus array

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -120,6 +120,7 @@ static void WalRcvDie(int code, Datum arg);
 static void XLogWalRcvProcessMsg(unsigned char type, char *buf, Size len);
 static void XLogWalRcvWrite(char *buf, Size nbytes, XLogRecPtr recptr);
 static void XLogWalRcvFlush(bool dying);
+static void XLogWalRcvClose(XLogRecPtr recptr);
 static void XLogWalRcvSendReply(bool force, bool requestReply);
 static void XLogWalRcvSendHSFeedback(bool immed);
 static void ProcessWalSndrMessage(XLogRecPtr walEnd, TimestampTz sendTime);
@@ -891,43 +892,16 @@ XLogWalRcvWrite(char *buf, Size nbytes, XLogRecPtr recptr)
 	{
 		int			segbytes;
 
-		if (recvFile < 0 || !XLByteInSeg(recptr, recvSegNo))
+		/* Close the current segment if it's completed */
+		if (recvFile >= 0 && !XLByteInSeg(recptr, recvSegNo))
+			XLogWalRcvClose(recptr);
+
+		if (recvFile < 0)
 		{
-			bool		use_existent;
-
-			/*
-			 * fsync() and close current file before we switch to next one. We
-			 * would otherwise have to reopen this file to fsync it later
-			 */
-			if (recvFile >= 0)
-			{
-				char		xlogfname[MAXFNAMELEN];
-
-				XLogWalRcvFlush(false);
-
-				/*
-				 * XLOG segment files will be re-read by recovery in startup
-				 * process soon, so we don't advise the OS to release cache
-				 * pages associated with the file like XLogFileClose() does.
-				 */
-				if (close(recvFile) != 0)
-					ereport(PANIC,
-							(errcode_for_file_access(),
-							 errmsg("could not close log segment %s: %m",
-									XLogFileNameP(recvFileTLI, recvSegNo))));
-
-				/*
-				 * Create .done file forcibly to prevent the streamed segment
-				 * from being archived later.
-				 */
-				XLogFileName(xlogfname, recvFileTLI, recvSegNo);
-				XLogArchiveForceDone(xlogfname);
-			}
-			recvFile = -1;
+			bool		use_existent = true;
 
 			/* Create/use new log file */
 			XLByteToSeg(recptr, recvSegNo);
-			use_existent = true;
 			recvFile = XLogFileInit(recvSegNo, &use_existent, true);
 			recvFileTLI = ThisTimeLineID;
 			recvOff = 0;
@@ -988,6 +962,15 @@ XLogWalRcvWrite(char *buf, Size nbytes, XLogRecPtr recptr)
 			   (uint32) (LogstreamResult.Write >> 32),
 			   (uint32) LogstreamResult.Write);
 	}
+
+	/*
+	 * Close the current segment if it's fully written up in the last cycle of
+	 * the loop, to create its archive notification file soon. Otherwise WAL
+	 * archiving of the segment will be delayed until any data in the next
+	 * segment is received and written.
+	 */
+	if (recvFile >= 0 && !XLByteInSeg(recptr, recvSegNo))
+		XLogWalRcvClose(recptr);
 }
 
 /*
@@ -1047,6 +1030,49 @@ XLogWalRcvFlush(bool dying)
 			XLogWalRcvSendHSFeedback(false);
 		}
 	}
+}
+
+/*
+ * Close the current segment.
+ *
+ * Flush the segment to disk before closing it. Otherwise we have to
+ * reopen and fsync it later.
+ *
+ * Create an archive notification file since the segment is known completed.
+ */
+static void
+XLogWalRcvClose(XLogRecPtr recptr)
+{
+	char		xlogfname[MAXFNAMELEN];
+
+	Assert(recvFile >= 0 && !XLByteInSeg(recptr, recvSegNo));
+
+	/*
+	 * fsync() and close current file before we switch to next one. We would
+	 * otherwise have to reopen this file to fsync it later
+	 */
+
+	XLogWalRcvFlush(false);
+
+	XLogFileName(xlogfname, recvFileTLI, recvSegNo);
+
+	/*
+	 * XLOG segment files will be re-read by recovery in startup process soon,
+	 * so we don't advise the OS to release cache pages associated with the
+	 * file like XLogFileClose() does.
+	 */
+	if (close(recvFile) != 0)
+		ereport(PANIC,
+				(errcode_for_file_access(),
+				errmsg("could not close log segment %s: %m",
+					xlogfname)));
+
+	/* Create .done file forcibly to prevent the streamed segment from
+	 * being archived later.
+	 */
+	XLogArchiveForceDone(xlogfname);
+
+	recvFile = -1;
 }
 
 /*

--- a/src/backend/replication/walreceiver.c
+++ b/src/backend/replication/walreceiver.c
@@ -52,6 +52,8 @@
 #include "libpq/pqformat.h"
 #include "libpq/pqsignal.h"
 #include "miscadmin.h"
+#include "pgstat.h"
+#include "postmaster/pgarch.h"
 #include "replication/walreceiver.h"
 #include "replication/walsender.h"
 #include "storage/ipc.h"
@@ -110,6 +112,9 @@ static struct
 	XLogRecPtr	Flush;			/* last byte + 1 flushed in the standby */
 }	LogstreamResult;
 
+/* Last archived WAL segment file obtained from the primary */
+static char primary_last_archived[MAX_XFN_CHARS + 1];
+
 static StringInfoData reply_message;
 static StringInfoData incoming_message;
 
@@ -124,6 +129,7 @@ static void XLogWalRcvClose(XLogRecPtr recptr);
 static void XLogWalRcvSendReply(bool force, bool requestReply);
 static void XLogWalRcvSendHSFeedback(bool immed);
 static void ProcessWalSndrMessage(XLogRecPtr walEnd, TimestampTz sendTime);
+static void ProcessArchivalReport(void);
 
 /* Signal handlers */
 static void WalRcvSigHupHandler(SIGNAL_ARGS);
@@ -564,9 +570,18 @@ WalReceiverMain(void)
 			/*
 			 * Create .done file forcibly to prevent the streamed segment from
 			 * being archived later.
+			 *
+			 * GPDB: The WAL archiving status reporting will be active if the GUC
+			 * wal_sender_archiving_status_interval is non-zero and archiving is
+			 * enabled. This will enable creation of .ready files instead of .done
+			 * The .ready files will be transitioned to .done files after receiving
+			 * WAL archiving status update messages from the primary segment.
 			 */
 			XLogFileName(xlogfname, recvFileTLI, recvSegNo);
-			XLogArchiveForceDone(xlogfname);
+			if (XLogArchivingStatusReportingActive())
+				XLogArchiveNotify(xlogfname);
+			else
+				XLogArchiveForceDone(xlogfname);
 		}
 		recvFile = -1;
 
@@ -871,6 +886,26 @@ XLogWalRcvProcessMsg(unsigned char type, char *buf, Size len)
 					XLogWalRcvSendReply(true, false);
 				break;
 			}
+		case 'a':               /* Archival Report */
+			{
+				/* the content of the message is a filename */
+				if (len >= sizeof(primary_last_archived))
+					ereport(ERROR,
+							(errcode(ERRCODE_PROTOCOL_VIOLATION),
+							errmsg_internal("invalid archival report message with length %d",
+							(int) len)));
+				memcpy(primary_last_archived, buf, len);
+				primary_last_archived[len] = '\0';
+				if (strspn(buf, VALID_XFN_CHARS) != len)
+				{
+					primary_last_archived[0] = '\0';
+					ereport(ERROR,
+							(errcode(ERRCODE_PROTOCOL_VIOLATION),
+								errmsg_internal("unexpected character in primary's last archived filename")));
+				}
+				ProcessArchivalReport();
+				break;
+			}
 		default:
 			ereport(ERROR,
 					(errcode(ERRCODE_PROTOCOL_VIOLATION),
@@ -1069,8 +1104,17 @@ XLogWalRcvClose(XLogRecPtr recptr)
 
 	/* Create .done file forcibly to prevent the streamed segment from
 	 * being archived later.
+	 *
+	 * GPDB: The WAL archiving status reporting will be active if the GUC
+	 * wal_sender_archiving_status_interval is non-zero and archiving is
+	 * enabled. This will enable creation of .ready files instead of .done.
+	 * The .ready files will be transitioned to .done files after receiving
+	 * WAL archiving status update messages from the primary segment.
 	 */
-	XLogArchiveForceDone(xlogfname);
+	if (XLogArchivingStatusReportingActive())
+		XLogArchiveNotify(xlogfname);
+	else
+		XLogArchiveForceDone(xlogfname);
 
 	recvFile = -1;
 }
@@ -1310,4 +1354,56 @@ ProcessWalSndrMessage(XLogRecPtr walEnd, TimestampTz sendTime)
 		pfree(sendtime);
 		pfree(receipttime);
 	}
+}
+
+/*
+ * Create .done files, based on the primary's last archival report.
+ */
+static void
+ProcessArchivalReport(void)
+{
+	DIR		   *xldir;
+	struct dirent *xlde;
+
+	elog(DEBUG2, "received archival report from primary: %s", primary_last_archived);
+
+	if (wal_sender_archiving_status_interval <= 0)
+		return;
+
+	/* Check that the wal filename reported by primary looks valid */
+	if (strlen(primary_last_archived) < 24 ||
+		strspn(primary_last_archived, "0123456789ABCDEF") != 24)
+		return;
+
+	xldir = AllocateDir(XLOGDIR);
+	if (xldir == NULL)
+		ereport(ERROR,
+			(errcode_for_file_access(),
+			errmsg("could not open transaction log directory \"%s\": %m",
+				XLOGDIR)));
+	while ((xlde = ReadDir(xldir, XLOGDIR)) != NULL)
+	{
+		/*
+		 * We ignore the timeline part of the XLOG segment identifiers in
+		 * deciding whether a segment is still needed.  This ensures that we
+		 * won't prematurely remove a segment from a parent timeline.
+		 *
+		 * We use the alphanumeric sorting property of the filenames to decide
+		 * which ones are earlier than the lastoff segment.
+		 */
+		if (strlen(xlde->d_name) == 24 &&
+			strspn(xlde->d_name, "0123456789ABCDEF") == 24 &&
+			strcmp(xlde->d_name + 8, primary_last_archived + 8) <= 0)
+		{
+			XLogArchiveForceDone(xlde->d_name);
+		}
+	}
+	FreeDir(xldir);
+
+	/*
+	 * Remember this location in pgstat as well. This makes it visible in
+	 * pg_stat_archiver, and allows the location to be relayed to cascaded
+	 * standbys.
+	 */
+	pgstat_send_archiver(primary_last_archived, false);
 }

--- a/src/backend/replication/walsender.c
+++ b/src/backend/replication/walsender.c
@@ -65,6 +65,7 @@
 #include "libpq/pqformat.h"
 #include "miscadmin.h"
 #include "nodes/replnodes.h"
+#include "pgstat.h"
 #include "replication/basebackup.h"
 #include "replication/decode.h"
 #include "replication/logical.h"
@@ -104,6 +105,13 @@
  * default 8k blocks) seems like a reasonable guess for now.
  */
 #define MAX_SEND_SIZE (XLOG_BLCKSZ * 16)
+
+/*
+ * After requesting the stats collector for fresh stats, we poll
+ * for the result this often.
+ * A new request is sent after each poll.
+ */
+#define ARCHIVAL_REQUEST_INTERVAL 1000
 
 /* Array of WalSnds in shared memory */
 WalSndCtlData *WalSndCtl = NULL;
@@ -206,6 +214,19 @@ static volatile sig_atomic_t replication_active = false;
 static LogicalDecodingContext *logical_decoding_ctx = NULL;
 static XLogRecPtr logical_startptr = InvalidXLogRecPtr;
 
+/*
+ * Last file archived. This is updated from pgstats, last update was at
+ * last_archival_report_timestamp.
+ */
+static char last_archived_file[MAX_XFN_CHARS + 1] = "";
+static TimestampTz last_archival_report_timestamp = 0;
+
+/*
+ * Have we requested fresh stats from the stats collector? And when?
+ */
+static bool	archival_status_requested = false;
+static TimestampTz last_archival_request_timestamp = 0;
+
 /* Signal handlers */
 static void WalSndLastCycleHandler(SIGNAL_ARGS);
 
@@ -231,6 +252,8 @@ static void ProcessRepliesIfAny(void);
 static const char *WalSndGetStateString(WalSndState state);
 static void WalSndKeepalive(bool requestReply);
 static void WalSndKeepaliveIfNecessary(void);
+static void WalSndArchivalReport(void);
+static void WalSndArchivalReportIfNecessary(TimestampTz now);
 static void WalSndCheckTimeOut(void);
 static long WalSndComputeSleeptime(TimestampTz now);
 static void WalSndPrepareWrite(LogicalDecodingContext *ctx, XLogRecPtr lsn, TransactionId xid, bool last_write);
@@ -1832,41 +1855,69 @@ ProcessStandbyHSFeedbackMessage(void)
  * If wal_sender_timeout is enabled we want to wake up in time to send
  * keepalives and to abort the connection if wal_sender_timeout has been
  * reached.
+ *
+ * GPDB: If WAL archiving and WAL archiving status streaming are enabled, we
+ * also want to wake up in time to send the archival report.
  */
 static long
 WalSndComputeSleeptime(TimestampTz now)
 {
-	long		sleeptime = 10000;		/* 10 s */
+	long        sleeptime;
+	long        sec_to_timeout;
+	int         microsec_to_timeout;
+	TimestampTz wakeup_time;
+	TimestampTz w;
+
+	/*
+	 * If we have no other reason to wake up, wake up every 10 seconds,
+	 * just in case we miss something.
+	 */
+	wakeup_time = TimestampTzPlusMilliseconds(now, 10000);
 
 	if (wal_sender_timeout > 0 && last_reply_timestamp > 0)
 	{
-		TimestampTz wakeup_time;
-		long		sec_to_timeout;
-		int			microsec_to_timeout;
-
 		/*
 		 * At the latest stop sleeping once wal_sender_timeout has been
 		 * reached.
-		 */
-		wakeup_time = TimestampTzPlusMilliseconds(last_reply_timestamp,
-												  wal_sender_timeout);
-
-		/*
+		 *
 		 * If no ping has been sent yet, wakeup when it's time to do so.
 		 * WalSndKeepaliveIfNecessary() wants to send a keepalive once half of
 		 * the timeout passed without a response.
 		 */
-		if (!waiting_for_ping_response)
-			wakeup_time = TimestampTzPlusMilliseconds(last_reply_timestamp,
+		if (waiting_for_ping_response)
+			w = TimestampTzPlusMilliseconds(last_reply_timestamp,
+													  wal_sender_timeout);
+		else
+			w = TimestampTzPlusMilliseconds(last_reply_timestamp,
 													  wal_sender_timeout / 2);
-
-		/* Compute relative time until wakeup. */
-		TimestampDifference(now, wakeup_time,
-							&sec_to_timeout, &microsec_to_timeout);
-
-		sleeptime = sec_to_timeout * 1000 +
-			microsec_to_timeout / 1000;
+		if (w < wakeup_time)
+			wakeup_time = w;
 	}
+
+	/* If archiving is enabled, send a status report to the client */
+	if (XLogArchivingStatusReportingActive())
+	{
+		/*
+		 * If we requested an update from pgstat, poll every
+		 * ARCHIVE_REQUEST_INTERVAL for the result. Otherwise wait until it's
+		 * time to send a new report.
+		 */
+		if (archival_status_requested)
+			w = TimestampTzPlusMilliseconds(last_archival_request_timestamp,
+											ARCHIVAL_REQUEST_INTERVAL);
+		else
+			w = TimestampTzPlusMilliseconds(last_archival_report_timestamp,
+											wal_sender_archiving_status_interval);
+		if (w < wakeup_time)
+			wakeup_time = w;
+	}
+
+	/* Compute relative time until wakeup. */
+	TimestampDifference(now, wakeup_time,
+						&sec_to_timeout, &microsec_to_timeout);
+
+	sleeptime = sec_to_timeout * 1000 +
+		microsec_to_timeout / 1000;
 
 	return sleeptime;
 }
@@ -3451,6 +3502,12 @@ WalSndKeepaliveIfNecessary(void)
 	TimestampTz ping_time;
 
 	/*
+	 * Send an archival status message, if necessary.
+	 */
+	if (XLogArchivingStatusReportingActive())
+		WalSndArchivalReportIfNecessary(GetCurrentTimestamp());
+
+	/*
 	 * Don't send keepalive messages if timeouts are globally disabled or
 	 * we're doing something not partaking in timeouts.
 	 */
@@ -3475,6 +3532,88 @@ WalSndKeepaliveIfNecessary(void)
 		/* Try to flush pending output to the client */
 		if (pq_flush_if_writable() != 0)
 			WalSndShutdown();
+	}
+}
+
+/*
+ * This function is used to send archival report message to standby.
+ */
+static void
+WalSndArchivalReport(void)
+{
+	elog(LOG, "sending archival report: %s", last_archived_file);
+
+	/* construct the message... */
+	resetStringInfo(&output_message);
+	pq_sendbyte(&output_message, 'a');
+	pq_sendbytes(&output_message, last_archived_file, strlen(last_archived_file));
+
+	/* ... and send it wrapped in CopyData */
+	pq_putmessage_noblock('d', output_message.data, output_message.len);
+}
+
+/*
+ * This function sends an archival report message to the standby when
+ * wal_sender_archiving_status_interval has elapsed.
+ */
+static void
+WalSndArchivalReportIfNecessary(TimestampTz now)
+{
+	TimestampTz report_time;
+
+	/*
+	 * If we had already asked pgstat for an update, wait until it's had
+	 * some time to update the stats file before we retry.
+	 */
+	if (archival_status_requested)
+	{
+		TimestampTz next_retry;
+
+		next_retry =
+				TimestampTzPlusMilliseconds(last_archival_request_timestamp,
+											ARCHIVAL_REQUEST_INTERVAL);
+		if (now < next_retry)
+			return;
+	}
+
+	/*
+	 * If more than wal_sender_archiving_status_interval has elapsed since we got
+	 * the archival status from pgstat, poll.
+	 */
+	report_time = TimestampTzPlusMilliseconds(last_archival_report_timestamp,
+												wal_sender_archiving_status_interval);
+	if (now >= report_time)
+	{
+		PgStat_ArchiverStats *archiver_stats;
+		PgStat_GlobalStats *global_stats;
+		TimestampTz min_ts;
+
+		pgstat_use_stale_snapshot();
+		archiver_stats = pgstat_fetch_stat_archiver();
+		global_stats = pgstat_fetch_global();
+
+		last_archival_report_timestamp = global_stats->stats_timestamp;
+
+		if (strcmp(last_archived_file, archiver_stats->last_archived_wal) != 0)
+		{
+			strlcpy(last_archived_file, archiver_stats->last_archived_wal,
+										sizeof(last_archived_file));
+			WalSndArchivalReport();
+		}
+
+		/* If this wasn't fresh enough, request an update */
+		min_ts = TimestampTzPlusMilliseconds(now, -wal_sender_archiving_status_interval);
+		if (last_archival_report_timestamp > min_ts)
+			archival_status_requested = false;
+		else
+		{
+			/* Not fresh enough. Request an update */
+			pgstat_request_update(now, min_ts);
+			last_archival_request_timestamp = now;
+			archival_status_requested = true;
+		}
+
+		pgstat_clear_snapshot();
 	}
 }
 

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -476,6 +476,9 @@ bool		gp_log_endpoints = false;
 /* optional reject to  parse ambigous 5-digits date in YYYMMDD format */
 bool		gp_allow_date_field_width_5digits = false;
 
+/* GUC to set interval for streaming archival status */
+int wal_sender_archiving_status_interval;
+
 static const struct config_enum_entry gp_log_format_options[] = {
 	{"text", 0},
 	{"csv", 1},
@@ -4772,6 +4775,16 @@ struct config_int ConfigureNamesInt_gp[] =
 		},
 		&gp_max_parallel_cursors,
 		-1, -1, 1024,
+		NULL, NULL, NULL
+	},
+
+	{
+		{"wal_sender_archiving_status_interval", PGC_SIGHUP, REPLICATION_SENDING,
+			gettext_noop("Sets the maximum interval for streaming archival status to standby"),
+			NULL, GUC_UNIT_MS
+		},
+		&wal_sender_archiving_status_interval,
+		10000, 0, INT_MAX,
 		NULL, NULL, NULL
 	},
 

--- a/src/backend/utils/misc/postgresql.conf.sample
+++ b/src/backend/utils/misc/postgresql.conf.sample
@@ -238,6 +238,8 @@ max_prepared_transactions = 250		# can be 0 or more
 				# comma-separated list of application_name
 				# from standby(s); '*' = all
 #vacuum_defer_cleanup_age = 0	# number of xacts by which cleanup is delayed
+#wal_sender_archiving_status_interval = 0 # send archival status to standby this often
+											# in milliseconds; 0 disables
 
 # - Standby Servers -
 

--- a/src/bin/pg_basebackup/receivelog.c
+++ b/src/bin/pg_basebackup/receivelog.c
@@ -1141,6 +1141,10 @@ HandleCopyStream(PGconn *conn, XLogRecPtr startpos, uint32 timeline,
 			}
 			/* No more data left to write, receive next copy packet */
 		}
+		else if (copybuf[0] == 'a')
+		{
+			/* GPDB: Skip archive report message. */
+		}
 		else
 		{
 			fprintf(stderr, _("%s: unrecognized streaming header: \"%c\"\n"),

--- a/src/include/access/xlog.h
+++ b/src/include/access/xlog.h
@@ -214,6 +214,9 @@ extern int	wal_level;
 
 #define XLogArchivingActive()	(XLogArchiveMode && wal_level >= WAL_LEVEL_ARCHIVE)
 #define XLogArchiveCommandSet() (XLogArchiveCommand[0] != '\0')
+/* Is WAL archiving status streaming enabled? */
+#define XLogArchivingStatusReportingActive() \
+	(XLogArchivingActive() && wal_sender_archiving_status_interval > 0)
 
 /*
  * Is WAL-logging necessary for archival or log-shipping, or can we skip

--- a/src/include/pgstat.h
+++ b/src/include/pgstat.h
@@ -941,6 +941,8 @@ extern void pgstat_vacuum_stat(void);
 extern void pgstat_report_queuestat(void); /* GPDB */
 extern void pgstat_drop_database(Oid databaseid);
 
+extern void pgstat_request_update(TimestampTz cur_ts, TimestampTz min_ts);
+extern void pgstat_use_stale_snapshot(void);
 extern void pgstat_clear_snapshot(void);
 extern void pgstat_reset_counters(void);
 extern void pgstat_reset_shared_counters(const char *);

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -356,6 +356,8 @@ extern bool gp_perfmon_print_packet_info;
 extern bool gp_enable_relsize_collection;
 extern bool gp_keep_partition_children_locks;
 
+extern int wal_sender_archiving_status_interval;
+
 /* Debug DTM Action */
 typedef enum
 {

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -544,6 +544,7 @@
 		"wal_receiver_status_interval",
 		"wal_receiver_timeout",
 		"wal_segment_size",
+		"wal_sender_archiving_status_interval",
 		"wal_sender_timeout",
 		"wal_sync_method",
 		"wal_writer_delay",

--- a/src/test/recovery/t/121_streaming_and_archiving.pl
+++ b/src/test/recovery/t/121_streaming_and_archiving.pl
@@ -1,0 +1,221 @@
+use strict;
+use warnings;
+use PostgresNode;
+use TestLib;
+use Test::More tests => 17;
+use File::Copy;
+
+my $node_master;
+my $node_standby;
+
+##################### Test with wal_sender_archiving_status_interval disabled #####################
+
+# Initialize master node with WAL archiving setup and wal_sender_archiving_status_interval as disabled
+$node_master = get_new_node('master');
+$node_master->init(
+    has_archiving    => 1,
+    allows_streaming => 1);
+
+$node_master->append_conf('postgresql.conf', 'wal_sender_archiving_status_interval = 0');
+$node_master->start;
+my $master_data = $node_master->data_dir;
+
+# Set an incorrect archive_command so that archiving fails
+my $incorrect_command = "exit 1";
+$node_master->safe_psql(
+'postgres', qq{
+ALTER SYSTEM SET archive_command TO '$incorrect_command';
+SELECT pg_reload_conf();
+});
+
+# Take backup
+$node_master->backup('my_backup');
+
+# Initialize the standby node. It will inherit wal_sender_archiving_status_interval from the master
+$node_standby = get_new_node('standby');
+$node_standby->init_from_backup($node_master, 'my_backup', has_streaming => 1);
+my $standby_data = $node_standby->data_dir;
+$node_standby->start;
+
+$node_master->safe_psql(
+	'postgres', q{
+	CREATE TABLE test1 AS SELECT generate_series(1,10) AS x;
+});
+
+my $current_walfile = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location());");
+$node_master->safe_psql(
+	'postgres', q{
+	SELECT pg_switch_xlog();
+	CHECKPOINT;
+});
+
+# After switching wal, the current wal file will be marked as ready to be archived on the master. But this wal file
+# won't get archived because of the incorrect archive_command
+my $walfile_ready = "pg_xlog/archive_status/$current_walfile.ready";
+my $walfile_done = "pg_xlog/archive_status/$current_walfile.done";
+
+# Wait for the standby to catch up
+$node_master->wait_for_catchup($node_standby, 'write',
+	$node_master->lsn('insert'));
+
+# Wait for archive failure
+$node_master->poll_query_until('postgres',
+q{SELECT failed_count > 0 FROM pg_stat_archiver}, 't')
+or die "Timed out while waiting for archiving to fail";
+
+# Due to archival failure, check if master has only .ready wal file and not .done
+# Check if standby has .done created as wal_sender_archiving_status_interval is disabled.
+ok( -f "$master_data/$walfile_ready",
+	".ready file exists on master for WAL segment $current_walfile"
+);
+ok( !-f "$master_data/$walfile_done",
+	".done file does not exist on master for WAL segment $current_walfile"
+);
+
+ok( !-f "$standby_data/$walfile_ready",
+	".ready file does not exist on standby for WAL segment $current_walfile when wal_sender_archiving_status_interval=0"
+);
+ok( -f "$standby_data/$walfile_done",
+	".done file exists on standby for WAL segment $current_walfile when wal_sender_archiving_status_interval=0"
+);
+
+##################### Test with wal_sender_archiving_status_interval enabled #####################
+$node_master->append_conf('postgresql.conf', 'wal_sender_archiving_status_interval = 50ms');
+$node_master->reload;
+# We need to enable wal_sender_archiving_status_interval on the standby as well. Technically the value doesn't matter
+# since the wal_receiver process only cares about this guc being set and not the actual value.
+$node_standby->append_conf('postgresql.conf', 'wal_sender_archiving_status_interval = 50ms');
+$node_standby->reload;
+
+$node_master->safe_psql(
+	'postgres', q{
+	CREATE TABLE test2 AS SELECT generate_series(1,10) AS x;
+});
+
+my $current_walfile2 = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location())");
+my $walfile_ready2 = "pg_xlog/archive_status/$current_walfile2.ready";
+my $walfile_done2 = "pg_xlog/archive_status/$current_walfile2.done";
+
+$node_master->safe_psql(
+	'postgres', q{
+	SELECT pg_switch_xlog();
+	CHECKPOINT;
+});
+
+# Wait for standby to catch up
+$node_master->wait_for_catchup($node_standby, 'write',
+	$node_master->lsn('insert'));
+
+# Check if master and standby have created .ready file for the wal that failed to archive
+ok( -f "$master_data/$walfile_ready2",
+	".ready file exists on master for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+ok( -f "$standby_data/$walfile_ready2",
+	".ready file exists on standby for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+
+ok( !-f "$master_data/$walfile_done2",
+	".done file does not exist on master for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f "$standby_data/$walfile_done2",
+	".done file does not exist on standby for WAL segment $current_walfile2 when wal_sender_archiving_status_interval=50ms"
+);
+
+# Make WAL archiving work again for master by resetting the archive_command
+$node_master->safe_psql(
+	'postgres', q{
+	ALTER SYSTEM RESET archive_command;
+	SELECT pg_reload_conf();
+});
+
+# Force the archiver process to wake up and start archiving
+$node_master->safe_psql(
+   'postgres', q{
+   SELECT pg_switch_xlog();
+});
+
+# Check if master has .done file created for the archived segment and also that the file gets uploaded to the archive
+wait_until_file_exists("$master_data/$walfile_done2", ".done file to exist on master for WAL segment $current_walfile2");
+
+ok( !-f "$master_data/$walfile_ready2",
+	".ready file does not exist for WAL segment $current_walfile2");
+
+wait_until_file_exists($node_master->archive_dir . "/$current_walfile2",
+	"$current_walfile2 to be archived by the master");
+
+# Check if standby has .done file created for the archived segment
+wait_until_file_exists("$standby_data/$walfile_done2",
+	".done file to exist on standby for WAL segment $current_walfile2"
+);
+ok( !-f "$standby_data/$walfile_ready2",
+	".ready file does not exist on standby for WAL segment $current_walfile2");
+
+ok( !-f $node_standby->archive_dir . "/$current_walfile2",
+	"$current_walfile2 does not exist in standby's archive");
+
+################### Now again make archiving fail but this time promote the standby and let the standby archive the wal
+$node_master->safe_psql(
+	'postgres', qq{
+	ALTER SYSTEM SET archive_command TO '$incorrect_command';
+	SELECT pg_reload_conf();
+});
+# make archiving work for the standby node
+$node_standby->safe_psql(
+	'postgres', q{
+	ALTER SYSTEM RESET archive_command;
+	SELECT pg_reload_conf();
+});
+
+$node_master->safe_psql(
+	'postgres', q{
+	CREATE TABLE test3 AS SELECT generate_series(1,10) AS x;
+});
+my $current_walfile3 = $node_master->safe_psql('postgres', "SELECT pg_xlogfile_name(pg_current_xlog_location())");
+$node_master->safe_psql(
+	'postgres', q{
+	SELECT pg_switch_xlog();
+	CHECKPOINT;
+});
+my $walfile_ready3 = "pg_xlog/archive_status/$current_walfile3.ready";
+my $walfile_done3 = "pg_xlog/archive_status/$current_walfile3.done";
+
+# Wait for the standby to catch up
+$node_master->wait_for_catchup($node_standby, 'write',
+	$node_master->lsn('insert'));
+
+ok( -f "$standby_data/$walfile_ready3",
+	".ready file exists on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f "$standby_data/$walfile_done3",
+	".done file does not exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f $node_master->archive_dir . "/$current_walfile3",
+	"$current_walfile3 does not exist in the archive");
+
+# Now promote the standby
+$node_standby->promote;
+
+# Wait for promotion to complete
+$node_standby->poll_query_until('postgres', "SELECT NOT pg_is_in_recovery();")
+or die "Timed out while waiting for promotion";
+
+# Wait until the wal file gets archived by the standby, Note that the archive dir is master's archive dir and not standby's.
+# This is because archive_command (which has the cp command) gets copied over from the master node when we initialize the standby
+wait_until_file_exists($node_master->archive_dir . "/$current_walfile3",
+	"$current_walfile3 to be archived by the standby");
+
+ok( -f "$master_data/$walfile_ready3",
+	".ready file exists on master for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+# master won't be able to archive and hence won't have the .done file
+ok( !-f "$master_data/$walfile_done3",
+	".done file does not exist on master for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+wait_until_file_exists("$standby_data/$walfile_done3",
+	".done file to exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+ok( !-f "$standby_data/$walfile_ready3",
+	".ready file does not exist on standby for WAL segment $current_walfile3 when wal_sender_archiving_status_interval=50ms"
+);
+
+done_testing();


### PR DESCRIPTION
Backported from 7x commit: c42ee49db3dcbcb42f5e82f958dae8664ada74f5 with some conflicts.


This commit introduces a GUC `wal_sender_archiving_status_interval` that will specify the interval at which primaries will send an archival status messages to their mirrors (including coordinator and standby coordinator). Any value greater than zero will enable this feature and set the interval.

Currently, if a primary loses connectivity to its archive repository while the streaming replication between the primary and its mirror is intact, it is likely that there will be WAL files that the mirror has but the archive repository does not. If primary goes down at this stage, those WAL files will be lost forever as they are marked as .done on the mirror as part of regular streaming replication logic. When the mirror is promoted, it will start archiving from the last WAL file that was streamed over. As a result, there will be holes in the sequence of WAL files in the archive repository that may negatively affect future restores from the archive repository.

With the GUC value set, the mirror will now mark all WAL files that are streamed over as .ready instead of .done. In parallel, the primary's WAL sender process will fetch the last archived WAL from the `pg_stat_archiver` view that gets updated by the primary's archiver process. This informartion is sent at regular intervals (set by the GUC) to the mirror's WAL receiver process via the existing WAL replication stream. Based on this information, the mirror will mark corresponding WAL files from .ready to .done status. When the mirror gets promoted, it may now have WAL files in .ready state which will then get archived accordingly.

There is a possibility that these WAL files may have already been archived by the primary because the archiving status updates sent to the mirror are not real-time. However, trying to re-archive them should be safe as long as the archive_command GUC is configured accordingly to check if the file is already in the archive repository, compare the checksums if so, and skip the file if the checksums are the same.

This patch was inspired by an unapplied patch from Heikki Linnakangas in the upstream pgsql-hackers thread:
https://www.postgresql.org/message-id/5550D20D.6090703%40iki.fi

There was a small bug in the original patch from Heikki. Essentially when pg_basebackup gets called with the -X stream option, it starts a wal sender and a wal receiver process. This wal sender is forked off the main wal sender process and will have the 'wal_receiver_status_interval' GUC enabled. Because of this, on startup, this wal sender process will send the archival report which will then be received by pg_basebackup's wal receiver. This report message wasn't handled by the original patch. We can safely ignore this message since it isn't really useful to pg_basebackup's wal receiver. Note that because of this change, gp_receivewal will also ignore this archive report which should be fine for now.
