### PR TITLE
Fix gppylib/operations unit tests 

### DIFF
--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_buildMirrorSegments.py
@@ -109,9 +109,9 @@ class BuildMirrorsTestCase(GpTestCase):
 
     def _setup_recovery_mocks(self, host_errors=[]):
         host1_recovery_output = gp.GpSegRecovery('test recover 1', 'dummy_info1', '/tmp/log1/', False, 1,
-                                                 'host1', 'dummy_era1', True)
+                                                 'host1', 'dummy_era1', True, None)
         host2_recovery_output = gp.GpSegRecovery('test recover 2', 'dummy_info2', '/tmp/log2/', True, 2,
-                                                 'host2', 'dummy_era2', False)
+                                                 'host2', 'dummy_era2', False, None)
 
         host1_result = CommandResult(0, ''.encode(), ''.encode(), True, False)
         host2_result = CommandResult(0, ''.encode(), ''.encode(), True, False)
@@ -477,7 +477,7 @@ class BuildMirrorsTestCase(GpTestCase):
         build_mirrors_obj._clean_up_failed_segments()
 
         self.mock_get_segments_by_hostname.assert_called_once_with([failed1, failed3])
-        self.mock_logger.info.called_once_with('Cleaning files from 3 segment(s)')
+        self.mock_logger.info.assert_called_once_with('Cleaning files from 2 segment(s)')
 
     def test_clean_up_failed_segments_no_segs_to_cleanup(self):
         failed2 = self._create_primary(dbid='3', status='d')

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_configurationImplGpdb.py
@@ -28,67 +28,67 @@ class ConfigurationImplGpdbTestCase(unittest.TestCase):
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveMirror_remove_acting_mirror(self, mockInsert, mockFetch):
         addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  6,\n  'foo: removed mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  6,\n  'foo: removed mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveMirror_remove_actual_mirror(self, mockInsert, mockFetch):
         addSQL = self.configProvider.updateSystemConfigRemoveMirror(self.conn, self.gpArray, self.mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  4,\n  'foo: removed mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  4,\n  'foo: removed mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[2])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemovePrimary(self, mockInsert, mockFetch):
         addSQL = self.configProvider.updateSystemConfigRemovePrimary(self.conn, self.gpArray, self.primary0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(2::int2, 0::int2, 'm', 'm', 'n', 'd', 40000, 'sdw1', 'sdw1', '/data/primary0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(2::int2, 0::int2, 'm', 'm', 'n', 'd', 40000, 'sdw1', 'sdw1', '/data/primary0');\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_remove_segment(2::int2)")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  2,\n  'foo: removed primary segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  2,\n  'foo: removed primary segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigAddMirror_add_acting_mirror(self, mockInsert, mockFetch):
         removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
-        self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2);\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'm', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  6,\n  'foo: inserted mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  6,\n  'foo: inserted mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigAddMirror_add_actual_mirror(self, mockInsert, mockFetch):
         removeSQL = self.configProvider.updateSystemConfigAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
-        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2);\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
         mockFetch.assert_called_with(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  4,\n  'foo: inserted mirror segment configuration'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  4,\n  'foo: inserted mirror segment configuration'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', side_effect=[ [2], [0] ])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigAddPrimary(self, mockInsert, mockFetch):
         removeSQL = self.configProvider.updateSystemConfigAddPrimary(self.conn, self.gpArray, self.primary0, "foo", {0: self.mirror0})
-        self.assertEqual(removeSQL, "SELECT gp_remove_segment_mirror(0::int2);\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
+        self.assertEqual(removeSQL, "SELECT gp_remove_segment_mirror(0::int2);\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t2,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 2'\n)")
         mockFetch.assert_any_call(self.conn, "SELECT content FROM pg_catalog.gp_segment_configuration WHERE dbId = 2")
         mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(2::int2, 0::int2, 'p', 'p', 'n', 'u', 40000, 'sdw1', 'sdw1', '/data/primary0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  2,\n  'foo: inserted primary segment configuration with contentid 0'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  2,\n  'foo: inserted primary segment configuration with contentid 0'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[6])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveAddMirror_remove_acting_mirror(self, mockInsert, mockFetch):
         addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.acting_mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'p', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t6,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 6'\n)")
         self.assertEqual(removeSQL, "SELECT gp_remove_segment(6::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(6::int2, 0::int2, 'm', 'm', 'n', 'd', 50002, 'sdw2', 'sdw2', '/data/acting_mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  6,\n  'foo: inserted segment configuration for full recovery or original dbid 6'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  6,\n  'foo: inserted segment configuration for full recovery or original dbid 6'\n)", 1)
 
     @patch('gppylib.system.configurationImplGpdb.GpConfigurationProviderUsingGpdbCatalog.fetchSingleOutputRow', return_value=[4])
     @patch('gppylib.db.dbconn.executeUpdateOrInsert')
     def test_updateSystemConfigRemoveAddMirror_remove_actual_mirror(self, mockInsert, mockFetch):
         addSQL, removeSQL = self.configProvider.updateSystemConfigRemoveAddMirror(self.conn, self.gpArray, self.mirror0, "foo")
-        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, description) VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
+        self.assertEqual(addSQL, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0');\nINSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\n\tnow(),\n\t4,\n\t'gprecoverseg: segment config for backout: inserted segment configuration for full recovery or original dbid 4'\n)")
         self.assertEqual(removeSQL, "SELECT gp_remove_segment(4::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_remove_segment_mirror(0::int2)")
         mockFetch.assert_any_call(self.conn, "SELECT gp_add_segment(4::int2, 0::int2, 'm', 'm', 'n', 'd', 50000, 'sdw2', 'sdw2', '/data/mirror0')")
-        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, description) VALUES(\nnow(),\n  4,\n  'foo: inserted segment configuration for full recovery or original dbid 4'\n)", 1)
+        mockInsert.assert_any_call(self.conn, "INSERT INTO gp_configuration_history (time, dbid, \"description\") VALUES(\nnow(),\n  4,\n  'foo: inserted segment configuration for full recovery or original dbid 4'\n)", 1)

--- a/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_on_segments.py
+++ b/gpMgmt/bin/gppylib/operations/test/unit/test_unit_update_pg_hba_on_segments.py
@@ -77,7 +77,8 @@ host replication gpadmin {ip_primary2}/32 trust"""
     @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
     @patch('gppylib.operations.update_pg_hba_on_segments.create_entries', 
             side_effect=[['entry0', 'entry1'], ['entry1', 'entry2']])
-    def test_update_pg_hba_on_segments_updated_successfully_all_failed_segments(self, mock_entry, mock_update):
+    @patch('gppylib.commands.pg.kill_existing_walsenders_on_primary')
+    def test_update_pg_hba_on_segments_updated_successfully_all_failed_segments(self, mock, mock_entry, mock_update):
         os.environ["GPHOME"] = "/usr/local/gpdb"
         expected_batch_size = 16
         update_pg_hba_on_segments(self.gparray, False, expected_batch_size)
@@ -100,7 +101,8 @@ host replication gpadmin {ip_primary2}/32 trust"""
 
     @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
     @patch('gppylib.operations.update_pg_hba_on_segments.create_entries', side_effect=[['entry0', 'entry1']])
-    def test_one_primary_seg_unreachable(self, mock_entries, mock_update):
+    @patch('gppylib.commands.pg.kill_existing_walsenders_on_primary')
+    def test_one_primary_seg_unreachable(self, mock, mock_entries, mock_update):
         pair0, pair1 = self.gparray.getSegmentList()
         pair0.primaryDB.unreachable = True
 
@@ -122,7 +124,8 @@ host replication gpadmin {ip_primary2}/32 trust"""
 
     @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
     @patch('gppylib.operations.update_pg_hba_on_segments.create_entries', side_effect=[['entry0', 'entry1']])
-    def test_mirror_seg_is_none(self, mock_entries, mock_update):
+    @patch('gppylib.commands.pg.kill_existing_walsenders_on_primary')
+    def test_mirror_seg_is_none(self, mock, mock_entries, mock_update):
         pair0, pair1 = self.gparray.getSegmentList()
         pair0.mirrorDB = None
         os.environ["GPHOME"] = "/usr/local/gpdb"
@@ -143,7 +146,8 @@ host replication gpadmin {ip_primary2}/32 trust"""
 
     @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
     @patch('gppylib.operations.update_pg_hba_on_segments.create_entries')
-    def test_both_seg_unreachable(self, mock_entries, mock_update):
+    @patch('gppylib.commands.pg.kill_existing_walsenders_on_primary')
+    def test_both_seg_unreachable(self, mock, mock_entries, mock_update):
         pair0, pair1 = self.gparray.getSegmentList()
         pair0.primaryDB.unreachable = True
         pair1.primaryDB.unreachable = True
@@ -158,7 +162,8 @@ host replication gpadmin {ip_primary2}/32 trust"""
 
     @patch('gppylib.operations.update_pg_hba_on_segments.update_on_segments')
     @patch('gppylib.operations.update_pg_hba_on_segments.create_entries', side_effect=[['entry0', 'entry1']])
-    def test_one_seg_to_update(self, mock_entries, mock_update):
+    @patch('gppylib.commands.pg.kill_existing_walsenders_on_primary')
+    def test_one_seg_to_update(self, mock, mock_entries, mock_update):
         pair0, pair1 = self.gparray.getSegmentList()
         os.environ["GPHOME"] = "/usr/local/gpdb"
         expected_batch_size = 16


### PR DESCRIPTION
- tests from gpMgmt/bin/gppylib/operations dir  were not being executed with 'make check' as __init__.py file was missing from gppylib/operations/test directory, added the file.

- Fixed few of the failing tests

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
