### PR TITLE
Gpinitsystem2.0 - Bug-Fix Validate port in use by dialing connection

### DIFF
--- a/gpMgmt/bin/go-tools/utils/sys_utils.go
+++ b/gpMgmt/bin/go-tools/utils/sys_utils.go
@@ -183,11 +183,13 @@ CheckIfPortFree returns error if port is not available otherwise returns nil
 */
 func CheckIfPortFree(ip string, port string) (bool, error) {
 	if ip == "" {
+		// to detect if socket created without specifying hostname
+		// listen fails to detect when the netcat ran without hostname
 		_, err := net.Dial("tcp", net.JoinHostPort(ip, port))
 		if err != nil {
 			return true, nil
 		} else {
-			return false, fmt.Errorf("able to dial on port:%s, port is already open", port)
+			return false, fmt.Errorf("able to dial on port: %s, port is already open", port)
 		}
 	}
 	listener, err := net.Listen("tcp", net.JoinHostPort(ip, port))

--- a/gpMgmt/bin/go-tools/utils/sys_utils.go
+++ b/gpMgmt/bin/go-tools/utils/sys_utils.go
@@ -145,7 +145,7 @@ Adds 0.0.0 and "::" to the list
 IPV6 addresses are appended with %interface-name to make them routable
 */
 func GetAllAddresses() (ipList []string, err error) {
-	ipList = []string{"0.0.0.0", "::"}
+	ipList = []string{"", "0.0.0.0", "::"}
 	// Get a list of network interfaces and their addresses
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -182,6 +182,14 @@ func GetAllAddresses() (ipList []string, err error) {
 CheckIfPortFree returns error if port is not available otherwise returns nil
 */
 func CheckIfPortFree(ip string, port string) (bool, error) {
+	if ip == "" {
+		_, err := net.Dial("tcp", net.JoinHostPort(ip, port))
+		if err != nil {
+			return true, nil
+		} else {
+			return false, fmt.Errorf("able to dial on port:%s, port is already open", port)
+		}
+	}
 	listener, err := net.Listen("tcp", net.JoinHostPort(ip, port))
 	if err != nil {
 		return false, err


### PR DESCRIPTION
When `netcat` listens on a port without mentioning the IP address, the current validation of the port in use fails. 
Added a check to confirm the port is not in use by dialing the connection. 
Verified by manually running validation when `netcat` is with host and also without host. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
