### PR TITLE
Add --direct-io option in gpcheckperf

### DIFF
--- a/gpMgmt/bin/gpcheckperf
+++ b/gpMgmt/bin/gpcheckperf
@@ -30,6 +30,7 @@ Usage: gpcheckperf <options>
     --duration : how long to run network test (default 5 seconds)
     --netperf  : use netperf instead of gpnetbenchServer/gpnetbenchClient
     --buffer-size : the size of the send buffer in kilobytes ( default 8 kilobytes)
+    --direct-io : use direct I/O for data
 """
 
 import datetime
@@ -69,7 +70,7 @@ class Global():
     opt = {'-d': [], '-D': False, '-v': False, '-V': False, '-r': '',
            '-B': 1024 * 32, '-S': 0, '-h': [], '-f': None,
            '--duration': 15, '--net': None, '--netserver': 'gpnetbenchServer',
-           '--netclient': 'gpnetbenchClient', '--buffer-size': 0}
+           '--netclient': 'gpnetbenchClient', '--buffer-size': 0, '--direct-io': None}
 
 
 GV = Global()
@@ -204,7 +205,7 @@ def print_version():
 
 def parseCommandLine():
     try:
-        (options, args) = getopt.getopt(sys.argv[1:], '?vVDd:r:B:S:p:h:f:', ['duration=', 'version', 'netperf', 'buffer-size='])
+        (options, args) = getopt.getopt(sys.argv[1:], '?vVDd:r:B:S:p:h:f:', ['duration=', 'version', 'netperf', 'buffer-size=', 'direct-io'])
     except Exception as e:
         usage('Error: ' + str(e))
         exit(1)
@@ -229,6 +230,8 @@ def parseCommandLine():
             GV.opt['--netclient'] = 'netperf'
         elif switch == '--buffer-size':
             GV.opt[switch] = int(val)
+        elif switch == '--direct-io':
+            GV.opt[switch] = True
 
     # run default tests (if not specified)
     if GV.opt['-r'] == '':
@@ -470,6 +473,8 @@ def runDiskWriteTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
+    if GV.opt['--direct-io']:
+        cmd = cmd + ' -D write'
     (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))
@@ -489,6 +494,8 @@ def runDiskReadTest(multidd):
         cmd = cmd + (' -B %d' % GV.opt['-B'])
     if GV.opt['-S']:
         cmd = cmd + (' -S %d' % GV.opt['-S'])
+    if GV.opt['--direct-io']:
+        cmd = cmd + ' -D read'
     (ok, out) = gpssh(cmd, GV.opt['-V'])
     if not ok:
         sys.exit('[Error] command failed: %s with output: %s' % (cmd, out))

--- a/gpMgmt/bin/lib/multidd
+++ b/gpMgmt/bin/lib/multidd
@@ -10,6 +10,7 @@ Usage: multidd {-i infile} {-o outfile} [-B blocksz] [-S filesz]
 			[default=8KB]
 	-S filesz	where filesz is the size of the file to write
 			[default=2X system RAM]
+    -D read/write  option to provide direct I/O for read or write data
 
 	Multiple -i and -o arguments may be specified but they must pair up.
 
@@ -94,7 +95,7 @@ def parseMemorySize(line):
 def parseCommandLine():
     global opt
     try:
-        (options, args) = getopt.getopt(sys.argv[1:], '?i:o:B:S:')
+        (options, args) = getopt.getopt(sys.argv[1:], '?i:o:B:S:D:')
     except:
         e = sys.exc_info()
         usage('Error: %s %s' % (e[0], e[1]))
@@ -106,6 +107,8 @@ def parseCommandLine():
             opt[switch].append(val)
         elif switch[1] in 'BS':
             opt[switch] = parseMemorySize(val)
+        elif switch == '-D':
+            opt[switch] = val
 
     if opt['-S'] == '?':
         sys.exit('Error: unable to obtain system RAM size')
@@ -121,7 +124,7 @@ def parseCommandLine():
         usage('Error: missing -i and -o parameters')
 
 
-opt = {'-i': [], '-o': [], '-B': parseMemorySize('8KB'), '-S': 0}
+opt = {'-i': [], '-o': [], '-B': parseMemorySize('8KB'), '-S': 0, '-D': ''}
 parseCommandLine()
 if opt['-S'] == 0:
     opt['-S'] = getMemory() * 2
@@ -132,10 +135,15 @@ pfile = []
 blocksz = opt['-B']
 cnt = int(math.ceil(opt['-S'] / blocksz))
 totalBytes = 0
+directIOFlag = ''
 for i in range(len(opt['-i'])):
     ifile = opt['-i'][i]
     ofile = opt['-o'][i]
-    cmd.append('dd if=%s of=%s count=%d bs=%d' % (ifile, ofile, cnt, blocksz))
+    if opt['-D'] == 'read':
+        directIOFlag = 'iflag=direct'
+    elif opt['-D'] == 'write':
+        directIOFlag = 'oflag=direct'
+    cmd.append('dd if=%s of=%s count=%d bs=%d %s' % (ifile, ofile, cnt, blocksz, directIOFlag))
     totalBytes += cnt * blocksz
 
 for c in cmd:

--- a/gpMgmt/doc/gpcheckperf_help
+++ b/gpMgmt/doc/gpcheckperf_help
@@ -8,12 +8,12 @@ SYNOPSIS
 
 gpcheckperf -d <test_directory> [-d <test_directory> ...] 
        {-f <hostfile_gpcheckperf> | -h <hostname> [-h <hostname> ...]} 
-       [-r ds] [-B <block_size>] [-S <file_size>] [-D] [-v|-V]
+       [-r ds] [-B <block_size>] [-S <file_size>] [-D] [-v|-V] [--buffer-size <kbytes>] [--direct-io]
 
 
 gpcheckperf -d <temp_directory>
         {-f <hostfile_gpchecknet> | -h <hostname> [-h <hostname> ...]} 
-        [ -r n|N|M [--duration <time>] [--netperf] ] [-D] [-v|-V] [--buffer-size <kbytes>]
+        [ -r n|N|M [--duration <time>] [--netperf] ] [-D] [-v|-V] [--buffer-size <kbytes>] [--direct-io]
 
 
 gpcheckperf -? 
@@ -168,6 +168,11 @@ page size. The maximum block size is 1 MB.
  option, you must download netperf from www.netperf.org and install 
  it into $GPHOME/bin/lib on all Greenplum hosts (coordinator and segments).
 
+--direct-io
+
+ Run the disk I/O bandwidth tests with iflag=direct and oflag=direct to
+ get direct performance.
+
 
 -r ds{n|N|M}
 
@@ -222,6 +227,9 @@ in the file host_file using the test directory of /data1 and /data2:
 
 $ gpcheckperf -f hostfile_gpcheckperf -d /data1 -d /data2 -r ds
 
+To use direct I/O for disk to get overcome OS cache behavior
+
+$ gpcheckperf -f hostfile_gpcheckperf -d /data1 -d /data2 -r ds --direct-io
 
 Run only the disk I/O test on the hosts named sdw1 and sdw2 
 using the test directory of /data1. Show individual host 

--- a/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpcheckperf.feature
@@ -6,7 +6,23 @@ Feature: Tests for gpcheckperf
     Given the database is running
     When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r ds"
     Then  gpcheckperf should return a return code of 0
+    And   gpcheckperf should print "disk write avg time" to stdout
     And   gpcheckperf should print "disk write tot bytes" to stdout
+    And   gpcheckperf should print "disk read avg time" to stdout
+    And   gpcheckperf should print "disk read tot bytes" to stdout
+    And   gpcheckperf should print "stream tot bandwidth" to stdout
+
+  @concourse_cluster
+  Scenario: gpcheckperf runs disk and memory tests with --direct-io
+    Given the database is running
+    When  the user runs "gpcheckperf -h cdw -h sdw1 -d /data/gpdata/ -r ds --direct-io"
+    Then  gpcheckperf should return a return code of 0
+    And   gpcheckperf should print "disk write avg time" to stdout
+    And   gpcheckperf should print "disk write tot bytes" to stdout
+    And   gpcheckperf should print "disk read avg time" to stdout
+    And   gpcheckperf should print "disk read tot bytes" to stdout
+    And   gpcheckperf should print "stream tot bandwidth" to stdout
+
 
   @concourse_cluster
   Scenario: gpcheckperf runs runs sequential network test


### PR DESCRIPTION
Issue: for I/O perf test gpcheckperf gives inconsistent results.

Reason: while doing read and write performance test gpcheckperf runs dd command, in dd command due to caching it doesn't give consistent and reliable results.

Fix: added iflag=direct and oflag=direct in dd command to run the test on direct io ignoring cache.
To support the backward compability direct-io option is default off and to enable it user needs to provide --direct-io flag to gpcheckperf.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
