### PR TITLE
Fix crash caused by vacuum ao_aux_only on AO partitioned table.

### DIFF
--- a/src/backend/commands/vacuum.c
+++ b/src/backend/commands/vacuum.c
@@ -1121,6 +1121,13 @@ expand_vacuum_rel(VacuumRelation *vrel, int options)
 				classForm = (Form_pg_class) GETSTRUCT(tuple);
 				if (IsAccessMethodAO(classForm->relam))
 				{
+					/* no aux tables for a parent AO table */
+					if (classForm->relkind == RELKIND_PARTITIONED_TABLE)
+					{
+						ReleaseSysCache(tuple);
+						continue;
+					}
+
 					Relation aorel = table_open(classForm->oid, AccessShareLock);
 					oldcontext = MemoryContextSwitchTo(vac_context);
 

--- a/src/test/regress/expected/vacuum_ao_aux_only.out
+++ b/src/test/regress/expected/vacuum_ao_aux_only.out
@@ -139,6 +139,14 @@ FROM gp_segment_configuration WHERE role = 'p' AND content != -1;
  Success:
 (3 rows)
 
+-- test against mixed partitioned appendonly table
+CREATE TABLE vac_example_ao(i int, j int) with (appendonly=true, orientation=column) PARTITION BY range (j) 
+(
+    start (1) end (3) with (appendonly=false),
+    start (3) end (6) with (appendonly=true, orientation=row),
+    start (6) end (10) with (appendonly=true, orientation=column)
+);
+VACUUM AO_AUX_ONLY vac_example_ao;
 ALTER SYSTEM RESET autovacuum;
 -- start_ignore
 \! gpstop -u;

--- a/src/test/regress/sql/vacuum_ao_aux_only.sql
+++ b/src/test/regress/sql/vacuum_ao_aux_only.sql
@@ -98,6 +98,14 @@ FROM gp_segment_configuration WHERE role = 'p' AND content != -1;
 SELECT gp_inject_fault('vacuum_rel_finished_one_relation', 'reset', dbid)
 FROM gp_segment_configuration WHERE role = 'p' AND content != -1;
 
+-- test against mixed partitioned appendonly table
+CREATE TABLE vac_example_ao(i int, j int) with (appendonly=true, orientation=column) PARTITION BY range (j) 
+(
+    start (1) end (3) with (appendonly=false),
+    start (3) end (6) with (appendonly=true, orientation=row),
+    start (6) end (10) with (appendonly=true, orientation=column)
+);
+VACUUM AO_AUX_ONLY vac_example_ao;
 
 ALTER SYSTEM RESET autovacuum;
 -- start_ignore


### PR DESCRIPTION
Appendonly partitioned table do not have any auxiliary table, so partitioned table itself should not participate in VACUUM AO_AUX_ONLY

Dev-pipeline: https://dev.ci.gpdb.pivotal.io/teams/main/pipelines/hw-fix_vacuum_aux_only

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
