### PR TITLE
Bypass the ICProxy addresses check of gpexpand when disable ENABLE_IC_PROXY

### DIFF
--- a/gpMgmt/bin/gpexpand
+++ b/gpMgmt/bin/gpexpand
@@ -2010,12 +2010,22 @@ class gpexpand:
         """
 
         # get GUC value
-        sql = "show gp_interconnect_proxy_addresses;"
         conn = dbconn.connect(_gp_expand.dburl, encoding='UTF8')
-        icproxy_addresses_string = dbconn.queryRow(conn, sql)[0].strip()
-        sql = "show gp_interconnect_type;"
-        ic_type = dbconn.queryRow(conn, sql)[0].strip()
-        conn.close()
+        try:
+            sql = "show gp_interconnect_proxy_addresses;"
+            icproxy_addresses_string = dbconn.queryRow(conn, sql)[0].strip()
+            sql = "show gp_interconnect_type;"
+            ic_type = dbconn.queryRow(conn, sql)[0].strip()
+        except DatabaseError as e:
+            if re.search('unrecognized configuration parameter', str(e)):
+                # no gp_interconnect_proxy_addresses in a distribution without `ENABLE_IC_PROXY`
+                # it means no need to check the proxy addresses, let's return directly
+                return
+            raise Exception("failed to query in validate_icproxy_addr, database error: %s" % str(e))
+        except Exception as e:
+            raise Exception("failed to query in validate_icproxy_addr, exception: %s" % str(e))
+        finally:
+            conn.close()
 
         # check if newly added dbid exists in gp_interconnect_proxy_addresses
         need_prompt = False


### PR DESCRIPTION
When user uses a distribution **without ENABLE_IC_PROXY**, gpexpand complains an error `unrecognized configuration parameter gp_interconnect_proxy_addresses` when checking the ICProxy addresses.

We cannot assume all GP distribution have this Guc (e.g. compile by source code), so add a simple try ... catch logic to prevent the error.

(As the follow up of https://github.com/greenplum-db/gpdb/pull/17316#issuecomment-2060232989)

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [x] Pass `make installcheck`
- [ ] Review a PR in return to support the community
