### PR TITLE
Fix memory allocation exception handling in ORCA, which may leads to corruption

### DIFF
--- a/src/backend/gpopt/CGPOptimizer.cpp
+++ b/src/backend/gpopt/CGPOptimizer.cpp
@@ -61,11 +61,20 @@ CGPOptimizer::GPOPTOptimizedPlan(
 	}
 	GPOS_CATCH_EX(ex)
 	{
-		// clone the error message before context free.
-		CHAR *serialized_error_msg =
-			gpopt_context.CloneErrorMsg(MessageContext);
-		// clean up context
-		gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlStmt);
+		CHAR *serialized_error_msg = NULL;
+		GPOS_TRY
+		{
+			// clone the error message before context free.
+			serialized_error_msg =
+				gpopt_context.CloneErrorMsg(MessageContext);
+			// clean up context
+			gpopt_context.Free(gpopt_context.epinQuery, gpopt_context.epinPlStmt);
+		}
+		GPOS_CATCH_EX(ex)
+		{
+			PG_RE_THROW();
+		}
+		GPOS_CATCH_END;
 
 		// Special handler for a few common user-facing errors. In particular,
 		// we want to use the correct error code for these, in case an application

--- a/src/backend/gpopt/gpdbwrappers.cpp
+++ b/src/backend/gpopt/gpdbwrappers.cpp
@@ -1542,6 +1542,9 @@ gpdb::MemCtxtStrdup(MemoryContext context, const char *string)
 {
 	GP_WRAP_START;
 	{
+#ifdef FAULT_INJECTOR
+		SIMPLE_FAULT_INJECTOR("gpdbwrappers_MemCtxtStrdup");
+#endif
 		return MemoryContextStrdup(context, string);
 	}
 	GP_WRAP_END;

--- a/src/test/regress/expected/gporca_faults.out
+++ b/src/test/regress/expected/gporca_faults.out
@@ -74,3 +74,34 @@ SELECT gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
  Success:
 (1 row)
 
+-- test corruption when MemCtxtStrdup throw ERROR in ORCA
+SELECT gp_inject_fault_infinite('gpdbwrappers_MemCtxtStrdup', 'error', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+set optimizer to on;
+EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
+ERROR:  fault triggered, fault name:'gpdbwrappers_MemCtxtStrdup' fault type:'error'
+-- Must let Planner reset the injected fault
+set optimizer to off;
+SELECT gp_inject_fault_infinite('gpdbwrappers_MemCtxtStrdup', 'reset', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+set optimizer to on;
+EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.25..10000001756.28 rows=86100 width=12)
+   ->  Nested Loop  (cost=10000000000.25..10000000608.28 rows=28700 width=12)
+         ->  Broadcast Motion 1:3  (slice2)  (cost=0.25..0.28 rows=1 width=4)
+               ->  Function Scan on func1_nosql_vol  (cost=0.25..0.26 rows=1 width=4)
+         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+reset optimizer;

--- a/src/test/regress/expected/gporca_faults_optimizer.out
+++ b/src/test/regress/expected/gporca_faults_optimizer.out
@@ -66,3 +66,34 @@ SELECT gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
  Success:
 (1 row)
 
+-- test corruption when MemCtxtStrdup throw ERROR in ORCA
+SELECT gp_inject_fault_infinite('gpdbwrappers_MemCtxtStrdup', 'error', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+set optimizer to on;
+EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
+ERROR:  fault triggered, fault name:'gpdbwrappers_MemCtxtStrdup' fault type:'error'
+-- Must let Planner reset the injected fault
+set optimizer to off;
+SELECT gp_inject_fault_infinite('gpdbwrappers_MemCtxtStrdup', 'reset', 1);
+ gp_inject_fault_infinite 
+--------------------------
+ Success:
+(1 row)
+
+set optimizer to on;
+EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=10000000000.25..10000001756.28 rows=86100 width=12)
+   ->  Nested Loop  (cost=10000000000.25..10000000608.28 rows=28700 width=12)
+         ->  Broadcast Motion 1:3  (slice2)  (cost=0.25..0.28 rows=1 width=4)
+               ->  Function Scan on func1_nosql_vol  (cost=0.25..0.26 rows=1 width=4)
+         ->  Seq Scan on foo  (cost=0.00..321.00 rows=28700 width=8)
+ Optimizer: Postgres-based planner
+(6 rows)
+
+reset optimizer;

--- a/src/test/regress/sql/gporca_faults.sql
+++ b/src/test/regress/sql/gporca_faults.sql
@@ -34,3 +34,16 @@ SELECT * FROM func1_nosql_vol(5), foo;
 
 -- The fault should *not* be hit above when optimizer = off, to reset it now.
 SELECT gp_inject_fault('opt_relcache_translator_catalog_access', 'reset', 1);
+
+-- test corruption when MemCtxtStrdup throw ERROR in ORCA
+SELECT gp_inject_fault_infinite('gpdbwrappers_MemCtxtStrdup', 'error', 1);
+set optimizer to on;
+EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
+
+-- Must let Planner reset the injected fault
+set optimizer to off;
+SELECT gp_inject_fault_infinite('gpdbwrappers_MemCtxtStrdup', 'reset', 1);
+set optimizer to on;
+EXPLAIN SELECT * FROM func1_nosql_vol(5), foo;
+
+reset optimizer;


### PR DESCRIPTION
When GPOPTOptimizedPlan catches exceptions, it clones the message from MessageContext but does not handle exceptions thrown by the MemoryContext. This may happen when MemoryContext fails to allocate memory.

This commit addresses the issue by capturing and re-throwing MemoryContext allocation exceptions, ensuring that ORCA handles these exceptions properly and avoids corruption.
