### PR TITLE
[backport 6x] Unassign pure-catalog query from resource group

### DIFF
--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -35,6 +35,7 @@
 #include "utils/lsyscache.h"
 #include "utils/metrics_utils.h"
 #include "utils/rel.h"
+#include "utils/resgroup.h"
 #include "utils/snapmgr.h"
 #include "utils/tuplesort.h"
 #include "utils/xml.h"
@@ -577,6 +578,7 @@ ExplainOnePlan(PlannedStmt *plannedstmt, IntoClause *into, ExplainState *es,
 	if (into)
 		eflags |= GetIntoRelEFlags(into);
 
+	check_and_unassign_from_resgroup(queryDesc->plannedstmt);
 	queryDesc->plannedstmt->query_mem =
 		ResourceManagerGetQueryMemoryLimit(queryDesc->plannedstmt);
 

--- a/src/backend/tcop/pquery.c
+++ b/src/backend/tcop/pquery.c
@@ -252,6 +252,7 @@ ProcessQuery(Portal portal,
 	if (query_info_collect_hook)
 		(*query_info_collect_hook)(METRICS_QUERY_SUBMIT, queryDesc);
 
+	check_and_unassign_from_resgroup(queryDesc->plannedstmt);
 	queryDesc->plannedstmt->query_mem = ResourceManagerGetQueryMemoryLimit(queryDesc->plannedstmt);
 
 	if (Gp_role == GP_ROLE_DISPATCH)
@@ -703,6 +704,7 @@ PortalStart(Portal portal, ParamListInfo params,
 					queryDesc->ddesc->parallelCursorName = queryDesc->portal_name;
 				}
 
+				check_and_unassign_from_resgroup(queryDesc->plannedstmt);
 				queryDesc->plannedstmt->query_mem = ResourceManagerGetQueryMemoryLimit(queryDesc->plannedstmt);
 
 				if (Gp_role == GP_ROLE_DISPATCH)

--- a/src/include/utils/resgroup.h
+++ b/src/include/utils/resgroup.h
@@ -189,6 +189,7 @@ extern void ResGroupDropFinish(const ResourceGroupCallbackContext *callbackCtx,
 extern void ResGroupCreateOnAbort(const ResourceGroupCallbackContext *callbackCtx);
 extern void ResGroupAlterOnCommit(const ResourceGroupCallbackContext *callbackCtx);
 extern void ResGroupCheckForDrop(Oid groupId, char *name);
+extern void check_and_unassign_from_resgroup(PlannedStmt* stmt);
 
 /*
  * Get resource group id of my proc.

--- a/src/test/isolation2/expected/resgroup/resgroup_bypass_catalog.out
+++ b/src/test/isolation2/expected/resgroup/resgroup_bypass_catalog.out
@@ -68,6 +68,110 @@ COMMIT
  1        
 (2 rows)
 
+ALTER RESOURCE GROUP rg_test_catalog SET CONCURRENCY 1;
+ALTER
+
+-- Session1: pure-catalog query will be unassigned and bypassed.
+1: SET ROLE role_test_catalog;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT relname FROM pg_class where relname='pg_class';  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_test_catalog;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_test_catalog' AND waiting = false;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ relname  
+----------
+ pg_class 
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
+
+-- simple query (no rangetable and no function) will be unassigned and bypassed
+1: SET ROLE role_test_catalog;
+SET
+1: SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'suspend', 1, current_setting('gp_session_id')::int);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+1&: SELECT 1;  <waiting ...>
+
+SELECT gp_wait_until_triggered_fault('check_and_unassign_from_resgroup_entry', 1, 1);
+ gp_wait_until_triggered_fault 
+-------------------------------
+ Success:                      
+(1 row)
+
+2: SET ROLE role_test_catalog;
+SET
+2&: BEGIN;  <waiting ...>
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_end', 'suspend', 1, sess_id) FROM pg_stat_activity WHERE rsgname = 'rg_test_catalog' AND waiting = false;
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_entry', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+2<:  <... completed>
+BEGIN
+2: COMMIT;
+COMMIT
+
+SELECT gp_inject_fault('check_and_unassign_from_resgroup_end', 'reset', 1);
+ gp_inject_fault 
+-----------------
+ Success:        
+(1 row)
+
+1<:  <... completed>
+ ?column? 
+----------
+ 1        
+(1 row)
+1q: ... <quitting>
+2q: ... <quitting>
 -- test for Github Issue 15416
 -- following SQLs should not throw "unrecognized node type" error.
 create table t_15416(s int);


### PR DESCRIPTION
When gp_resource_group_bypass_catalog_query is on, unassign the pure catalog query from resource group, and bypass the query.

Traverse the flattened rangetable entries to decide whether the query is pure-catalog query.

In addition, it's hard to see whether the query contains UDF, traverse the whole plan is expensive, so it will be ignored even if there can have non-catalog query in the sql commands inside the UDF. But for the special case like 'select UDF;', the query won't be bypassed. We have no need to consider the sql commands inside the UDF, they will also be bypassed or use the same resgroup as the outer query.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
