### PR TITLE
Forbid writable CTE with SELECT INTO clause.

### DIFF
--- a/src/backend/parser/analyze.c
+++ b/src/backend/parser/analyze.c
@@ -312,6 +312,25 @@ transformOptionalSelectInto(ParseState *pstate, Node *parseTree)
 			stmt->intoClause = NULL;
 
 			parseTree = (Node *) ctas;
+
+			if (stmt->withClause)
+			{
+				/*
+				 * Just transform to check p_hasModifyingCTE, cte list will be transformed inside SELECT stmt.
+				 */
+				transformWithClause(pstate, stmt->withClause);
+				/*
+				 * Since GPDB currently only support a single writer gang, only one
+				 * writable clause is permitted per CTE. Once we get flexible gangs
+				 * with more than one writer gang we can lift this restriction.
+				 */
+				if (pstate->p_hasModifyingCTE)
+					ereport(ERROR,
+							(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+							 errmsg("writable CTE queries cannot be used with writable queries"),
+							 errdetail("Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context."),
+							 errhint("Rewrite the query to only include one writable clause.")));
+			}
 		}
 	}
 

--- a/src/test/regress/expected/with.out
+++ b/src/test/regress/expected/with.out
@@ -2455,3 +2455,28 @@ select * from with_test;
 (1 row)
 
 drop table with_test;
+--
+-- ISSUE 17462
+--
+CREATE TABLE t_17462(a integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
+  INSERT INTO t_17462(a) VALUES (1), (2), (3)
+  RETURNING a
+)
+SELECT sum(a) INTO t_17462_1 FROM ins;
+ERROR:  writable CTE queries cannot be used with writable queies
+DETAIL:  Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context.
+HINT:  Rewrite the query to only include one writable clause.
+DROP TABLE t_17462;
+CREATE TABLE t_17462_relp(a integer) distributed replicated;
+EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
+  INSERT INTO t_17462_relp(a) VALUES (1), (2), (3)
+  RETURNING a
+)
+SELECT sum(a) INTO t_17462_relp_1 FROM ins;
+ERROR:  writable CTE queries cannot be used with writable queies
+DETAIL:  Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context.
+HINT:  Rewrite the query to only include one writable clause.
+DROP TABLE t_17462_relp;

--- a/src/test/regress/expected/with_optimizer.out
+++ b/src/test/regress/expected/with_optimizer.out
@@ -2471,3 +2471,28 @@ select * from with_test;
 (1 row)
 
 drop table with_test;
+--
+-- ISSUE 17462
+--
+CREATE TABLE t_17462(a integer);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
+  INSERT INTO t_17462(a) VALUES (1), (2), (3)
+  RETURNING a
+)
+SELECT sum(a) INTO t_17462_1 FROM ins;
+ERROR:  writable CTE queries cannot be used with writable queies
+DETAIL:  Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context.
+HINT:  Rewrite the query to only include one writable clause.
+DROP TABLE t_17462;
+CREATE TABLE t_17462_relp(a integer) distributed replicated;
+EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
+  INSERT INTO t_17462_relp(a) VALUES (1), (2), (3)
+  RETURNING a
+)
+SELECT sum(a) INTO t_17462_relp_1 FROM ins;
+ERROR:  writable CTE queries cannot be used with writable queies
+DETAIL:  Greenplum Database currently only support CTEs with one writable clause, called in a non-writable context.
+HINT:  Rewrite the query to only include one writable clause.
+DROP TABLE t_17462_relp;

--- a/src/test/regress/sql/with.sql
+++ b/src/test/regress/sql/with.sql
@@ -1187,3 +1187,22 @@ create temp table with_test (i int);
 with with_test as (select 42) insert into with_test select * from with_test;
 select * from with_test;
 drop table with_test;
+
+--
+-- ISSUE 17462
+--
+CREATE TABLE t_17462(a integer);
+EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
+  INSERT INTO t_17462(a) VALUES (1), (2), (3)
+  RETURNING a
+)
+SELECT sum(a) INTO t_17462_1 FROM ins;
+DROP TABLE t_17462;
+
+CREATE TABLE t_17462_relp(a integer) distributed replicated;
+EXPLAIN(COSTS OFF, VERBOSE) WITH ins AS (
+  INSERT INTO t_17462_relp(a) VALUES (1), (2), (3)
+  RETURNING a
+)
+SELECT sum(a) INTO t_17462_relp_1 FROM ins;
+DROP TABLE t_17462_relp;


### PR DESCRIPTION
Fix issue https://github.com/greenplum-db/gpdb/issues/17462

GPDB currently only support CTEs with one writable clause, SELECT INTO caluse with a writable CTE should also be forbidden as it will create a new table with data inserted.

Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
