### PR TITLE
Fix writable CTE on replicated tables EXCEPT partition tables.

### DIFF
--- a/src/backend/cdb/cdbsetop.c
+++ b/src/backend/cdb/cdbsetop.c
@@ -81,6 +81,7 @@ choose_setop_type(List *pathlist)
 				break;
 
 			case CdbLocusType_Replicated:
+				ok_partitioned = false;
 				break;
 
 			case CdbLocusType_Null:
@@ -196,6 +197,7 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 					case CdbLocusType_Hashed:
 					case CdbLocusType_HashedOJ:
 					case CdbLocusType_Strewn:
+					case CdbLocusType_Replicated:
 						/* Gather to QE.  No need to keep ordering. */
 						CdbPathLocus_MakeSingleQE(&locus, getgpsegmentCount());
 						adjusted_path = cdbpath_create_motion_path(root, subpath, NULL, false,
@@ -218,7 +220,6 @@ adjust_setop_arguments(PlannerInfo *root, List *pathlist, List *tlist_list, GpSe
 
 					case CdbLocusType_Entry:
 					case CdbLocusType_Null:
-					case CdbLocusType_Replicated:
 					case CdbLocusType_End:
 						ereport(ERROR, (errcode(ERRCODE_INTERNAL_ERROR),
 										errmsg("unexpected argument locus to set operation")));

--- a/src/test/regress/expected/union_gp.out
+++ b/src/test/regress/expected/union_gp.out
@@ -2312,6 +2312,38 @@ select json_data,id from my_table  where json_data->>'age' = '30' union all sele
 set optimizer_parallel_union to off;
 drop table if exists my_table;
 --
+-- test Github issue https://github.com/greenplum-db/gpdb/issues/17474
+--
+create table r_17474(a int) distributed replicated;
+insert into r_17474 select generate_series(1,10);
+create table p1_17474(a int) distributed by (a);
+insert into p1_17474 select generate_series(1,3);
+explain(costs off) with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ HashSetOp Except
+   ->  Append
+         ->  Explicit Gather Motion 3:1  (slice1; segments: 3)
+               ->  Subquery Scan on "*SELECT* 1"
+                     ->  Update on r_17474
+                           ->  Seq Scan on r_17474
+                                 Filter: (a < 5)
+         ->  Gather Motion 3:1  (slice2; segments: 3)
+               ->  Subquery Scan on "*SELECT* 2"
+                     ->  Seq Scan on p1_17474
+ Optimizer: Postgres-based planner
+(11 rows)
+
+with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
+ a 
+---
+ 5
+ 4
+(2 rows)
+
+drop table r_17474;
+drop table p1_17474;
+--
 -- Clean up
 --
 DROP TABLE IF EXISTS T_a1 CASCADE;

--- a/src/test/regress/expected/union_gp_optimizer.out
+++ b/src/test/regress/expected/union_gp_optimizer.out
@@ -2443,6 +2443,42 @@ select json_data,id from my_table  where json_data->>'age' = '30' union all sele
 set optimizer_parallel_union to off;
 drop table if exists my_table;
 --
+-- test Github issue https://github.com/greenplum-db/gpdb/issues/17474
+--
+create table r_17474(a int) distributed replicated;
+insert into r_17474 select generate_series(1,10);
+create table p1_17474(a int) distributed by (a);
+insert into p1_17474 select generate_series(1,3);
+explain(costs off) with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ HashSetOp Except
+   ->  Append
+         ->  Explicit Gather Motion 3:1  (slice1; segments: 3)
+               ->  Subquery Scan on "*SELECT* 1"
+                     ->  Update on r_17474
+                           ->  Seq Scan on r_17474
+                                 Filter: (a < 5)
+         ->  Gather Motion 3:1  (slice2; segments: 3)
+               ->  Subquery Scan on "*SELECT* 2"
+                     ->  Seq Scan on p1_17474
+ Optimizer: Postgres-based planner
+(11 rows)
+
+with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
+INFO:  GPORCA failed to produce a plan, falling back to Postgres-based planner
+DETAIL:  Falling back to Postgres-based planner because GPORCA does not support the following feature: RETURNING clause
+ a 
+---
+ 5
+ 4
+(2 rows)
+
+drop table r_17474;
+drop table p1_17474;
+--
 -- Clean up
 --
 DROP TABLE IF EXISTS T_a1 CASCADE;

--- a/src/test/regress/sql/union_gp.sql
+++ b/src/test/regress/sql/union_gp.sql
@@ -713,6 +713,18 @@ set optimizer_parallel_union to off;
 drop table if exists my_table;
 
 --
+-- test Github issue https://github.com/greenplum-db/gpdb/issues/17474
+--
+create table r_17474(a int) distributed replicated;
+insert into r_17474 select generate_series(1,10);
+create table p1_17474(a int) distributed by (a);
+insert into p1_17474 select generate_series(1,3);
+explain(costs off) with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
+with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
+drop table r_17474;
+drop table p1_17474;
+
+--
 -- Clean up
 --
 


### PR DESCRIPTION
Fix issue: https://github.com/greenplum-db/gpdb/issues/17474

Replicated locus could EXCEPT Partitioned locus when there is writable CTE on replicated tables.
We could make them SingleQE or Entry to do the set operation.
```sql
with result as (update r_17474 set a = a +1 where a < 5 returning *) select * from result except select * from p1_17474;
                          QUERY PLAN
---------------------------------------------------------------
 HashSetOp Except
   ->  Append
         ->  Explicit Gather Motion 3:1  (slice1; segments: 3)
               ->  Subquery Scan on "*SELECT* 1"
                     ->  Update on r_17474
                           ->  Seq Scan on r_17474
                                 Filter: (a < 5)
         ->  Gather Motion 3:1  (slice2; segments: 3)
               ->  Subquery Scan on "*SELECT* 2"
                     ->  Seq Scan on p1_17474
 Optimizer: Postgres-based planner
(11 rows)
```
Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
