### PR TITLE
Disable offsetnumber assertion in ginPostingListDecodeAllSegments()

### DIFF
--- a/src/backend/access/gin/ginpostinglist.c
+++ b/src/backend/access/gin/ginpostinglist.c
@@ -337,7 +337,13 @@ ginPostingListDecodeAllSegments(GinPostingList *segment, int len, int *ndecoded_
 		}
 
 		/* copy the first item */
+		/*
+		 * Keep this commented out.
+		 * See comments in itemptr_to_uint64().
+		 */
+#if 0
 		Assert(OffsetNumberIsValid(ItemPointerGetOffsetNumber(&segment->first)));
+#endif
 		Assert(ndecoded == 0 || ginCompareItemPointers(&segment->first, &result[ndecoded - 1]) > 0);
 		result[ndecoded] = segment->first;
 		ndecoded++;

--- a/src/test/regress/expected/gin.out
+++ b/src/test/regress/expected/gin.out
@@ -80,3 +80,14 @@ select count(*) > 0 as ok from gin_test_tbl where i @> array[1];
 (1 row)
 
 reset gin_fuzzy_search_limit;
+--
+-- Github issue: https://github.com/greenplum-db/gpdb/issues/17456
+--
+begin;
+create table t_issue_17456(i int4[]) with (appendonly=true);
+NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'i' as the Greenplum Database data distribution key for this table.
+HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
+create index t_issue_17456_idx on t_issue_17456 using gin (i)
+  with (fastupdate = on, gin_pending_list_limit = 4096);
+insert into t_issue_17456 select array[1, 2, g] from generate_series(1, 400000) g;
+abort;

--- a/src/test/regress/sql/gin.sql
+++ b/src/test/regress/sql/gin.sql
@@ -51,3 +51,13 @@ select count(*) > 0 as ok from gin_test_tbl where i @> array[1];
 select count(*) > 0 as ok from gin_test_tbl where i @> array[1];
 
 reset gin_fuzzy_search_limit;
+
+--
+-- Github issue: https://github.com/greenplum-db/gpdb/issues/17456
+--
+begin;
+create table t_issue_17456(i int4[]) with (appendonly=true);
+create index t_issue_17456_idx on t_issue_17456 using gin (i)
+  with (fastupdate = on, gin_pending_list_limit = 4096);
+insert into t_issue_17456 select array[1, 2, g] from generate_series(1, 400000) g;
+abort;


### PR DESCRIPTION
Fix issue: https://github.com/greenplum-db/gpdb/issues/17456

As comments in itemptr_to_uint64:
Greenplum allow 16 bits for the offsetnumber, which turns the below upstream assertion into an always-true comparison which generates a compiler warning; thus we need to keep this commented out.

For sql in issue 17456, we will get assert failure as:

DETAIL:  FailedAssertion("!(((_Bool) ((( ((void) ((_Bool) (! (!(((_Bool) (((const void*)(&segment->first) != ((void *)0)) && ((&segment->first)->ip_posid != 0))))) ||
(ExceptionalCondition("!(((_Bool) (((const void*)(&segment->first) != ((void *)0)) && ((&segment->first)->ip_posid != 0))))", ("FailedAssertion"), "ginpostinglist.c", 340), 0)))), ( (&segment->first)->ip_posid ) ) != ((OffsetNumber) 0)) && (( ((void) ((_Bool) (! (!(((_Bool) (((const void*)(&segment->first) != ((void *)0)) && ((&segment->first)->ip_posid != 0))))) ||
(ExceptionalCondition("!(((_Bool) (((const void*)(&segment->first) != ((void *)0)) && ((&segment->first)->ip_posid != 0))))", ("FailedAssertion"), "ginpostinglist.c", 340), 0)))), ( (&segment->first)->ip_posid ) ) <= ((OffsetNumber) (32768 / sizeof(ItemIdData)))))))", File: "ginpostinglist.c", Line: 340)

Authored-by: Zhang Mingli avamingli@gmail.com

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
