### PR TITLE
Remove useless assert check during GIN index build. 

### DIFF
--- a/src/backend/access/gin/ginpostinglist.c
+++ b/src/backend/access/gin/ginpostinglist.c
@@ -337,7 +337,6 @@ ginPostingListDecodeAllSegments(GinPostingList *segment, int len, int *ndecoded_
 		}
 
 		/* copy the first item */
-		Assert(OffsetNumberIsValid(ItemPointerGetOffsetNumber(&segment->first)));
 		Assert(ndecoded == 0 || ginCompareItemPointers(&segment->first, &result[ndecoded - 1]) > 0);
 		result[ndecoded] = segment->first;
 		ndecoded++;

--- a/src/test/isolation2/expected/ao_gin_index.out
+++ b/src/test/isolation2/expected/ao_gin_index.out
@@ -1,0 +1,94 @@
+-- Create an appendonly columnar distribut replicated table to make the citd increase control easier.
+-- Insert 60921 rows into segment1. The row count is very exactly to trigger the bug. As we need to
+-- hit three conner cases:
+-- 1. GIN index posting list must put the first tuple of a new aoco segment at the end to one list segment.
+-- for example: encoded delta value is [1,2,10000]. 10000 is the delta of first tuple of the new segment ctid.
+-- 2. For a GinPostingListSegmentTargetSize(256) length segment, we need to make sure the left space for the
+-- first tuple of the new segment is 6 bytes. Can not be less or more. So it can reach the memory overflow.
+-- 3. Next time palloc must do the real malloc. not choose a free space from the memory context. This means
+-- we need to consume all the free space in the memory context before we reach the point in step.1.
+-- Above the three conner cases must be hit. So we need to control the inserted rows.
+-- Make some dead segment by abort transaction, to make a big jump of ctid.
+
+CREATE TABLE test_gin_aoco(a int, org_name varchar(20)) with (appendonly = true, orientation = column) distributed replicated;
+CREATE
+
+1: begin;
+BEGIN
+1: insert into test_gin_aoco select i, 'test' from generate_series(1,60921) i;
+INSERT 60921
+2: begin;
+BEGIN
+2: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+3: begin;
+BEGIN
+3: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+4: begin;
+BEGIN
+4: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+5: begin;
+BEGIN
+5: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+6: begin;
+BEGIN
+6: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+7: begin;
+BEGIN
+7: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+8: begin;
+BEGIN
+8: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+9: begin;
+BEGIN
+9: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+INSERT 100
+10: begin;
+BEGIN
+10: insert into test_gin_aoco select i, 'test' from generate_series(1,4189) i;
+INSERT 4189
+
+1: commit;
+COMMIT
+2: abort;
+ABORT
+3: abort;
+ABORT
+4: abort;
+ABORT
+5: abort;
+ABORT
+6: abort;
+ABORT
+7: abort;
+ABORT
+8: abort;
+ABORT
+9: abort;
+ABORT
+10: commit;
+COMMIT
+
+1q: ... <quitting>
+2q: ... <quitting>
+3q: ... <quitting>
+4q: ... <quitting>
+5q: ... <quitting>
+6q: ... <quitting>
+7q: ... <quitting>
+8q: ... <quitting>
+9q: ... <quitting>
+10q: ... <quitting>
+
+-- Create GIN Index to hit the bug.
+CREATE INDEX test_gin_aoco_to_tsvector_idx ON test_gin_aoco USING gin (to_tsvector('english', (org_name)::text));
+CREATE
+
+-- Clear
+DROP TABLE test_gin_aoco;

--- a/src/test/isolation2/isolation2_schedule
+++ b/src/test/isolation2/isolation2_schedule
@@ -241,6 +241,7 @@ test: uao/collected_stats_views_column
 test: uao/fast_analyze_column
 test: ao_blkdir
 test: ao_partial_scan
+test: ao_gin_index
 
 # this case contains fault injection, must be put in a separate test group
 test: terminate_in_gang_creation

--- a/src/test/isolation2/sql/ao_gin_index.sql
+++ b/src/test/isolation2/sql/ao_gin_index.sql
@@ -1,0 +1,62 @@
+-- Create an appendonly columnar distribut replicated table to make the citd increase control easier. 
+-- Insert 60921 rows into segment1. The row count is very exactly to trigger the bug. As we need to 
+-- hit three conner cases: 
+-- 1. GIN index posting list must put the first tuple of a new aoco segment at the end to one list segment.
+-- for example: encoded delta value is [1,2,10000]. 10000 is the delta of first tuple of the new segment ctid.
+-- 2. For a GinPostingListSegmentTargetSize(256) length segment, we need to make sure the left space for the
+-- first tuple of the new segment is 6 bytes. Can not be less or more. So it can reach the memory overflow.
+-- 3. Next time palloc must do the real malloc. not choose a free space from the memory context. This means
+-- we need to consume all the free space in the memory context before we reach the point in step.1.
+-- Above the three conner cases must be hit. So we need to control the inserted rows.
+-- Make some dead segment by abort transaction, to make a big jump of ctid.
+
+CREATE TABLE test_gin_aoco(a int, org_name varchar(20)) with (appendonly = true, orientation = column) distributed replicated;
+
+1: begin;
+1: insert into test_gin_aoco select i, 'test' from generate_series(1,60921) i;
+2: begin;
+2: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+3: begin;
+3: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+4: begin;
+4: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+5: begin;
+5: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+6: begin;
+6: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+7: begin;
+7: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+8: begin;
+8: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+9: begin;
+9: insert into test_gin_aoco select i, 'test' from generate_series(1,100) i;
+10: begin;
+10: insert into test_gin_aoco select i, 'test' from generate_series(1,4189) i;
+
+1: commit;
+2: abort;
+3: abort;
+4: abort;
+5: abort;
+6: abort;
+7: abort;
+8: abort;
+9: abort;
+10: commit;
+
+1q:
+2q:
+3q:
+4q:
+5q:
+6q:
+7q:
+8q:
+9q:
+10q:
+
+-- Create GIN Index to hit the bug.
+CREATE INDEX test_gin_aoco_to_tsvector_idx ON test_gin_aoco USING gin (to_tsvector('english', (org_name)::text));
+
+-- Clear
+DROP TABLE test_gin_aoco;


### PR DESCRIPTION
This commit include two part:
1. Remove useless assert check during GIN index build. As the commit 6b7819a 'Fix overflow check and comment in GIN posting list encoding.' has fixed the overflow problem. But the offset number assert check still check incorrect range. 
2. Add a conner case that will lead to memory corruption caused by it. As the commit 6b7819a do not add any test case for it.

If we do not have the fix of commit 6b7819a and enable assert. The test case will hit `Assert(OffsetNumberIsValid(ItemPointerGetOffsetNumber(&segment->first)));` that should be removed. And if we disable assert. It will lead to coredump during malloc.

![image](https://github.com/greenplum-db/gpdb/assets/13748374/a61a69ec-1ffd-42b7-b82f-315385c5d999)
