### PR TITLE
Set the synchronous_standby_names default value to "gp_walreceiver" o…

### DIFF
--- a/src/backend/replication/gp_replication.c
+++ b/src/backend/replication/gp_replication.c
@@ -592,7 +592,7 @@ GetMirrorStatus(FtsResponse *response, bool *ready_for_syncrep)
 
 /*
  * Set WalSndCtl->sync_standbys_defined to true to enable synchronous segment
- * WAL replication and insert synchronous_standby_names="*" into the
+ * WAL replication and insert synchronous_standby_names="gp_walreceiver" into the
  * gp_replication.conf to persist this state in case of segment crash.
  */
 void
@@ -600,10 +600,10 @@ SetSyncStandbysDefined(void)
 {
 	if (!WalSndCtl->sync_standbys_defined)
 	{
-		set_gp_replication_config("synchronous_standby_names", "*");
+		set_gp_replication_config("synchronous_standby_names", "gp_walreceiver");
 
 		/* Signal a reload to the postmaster. */
-		elog(LOG, "signaling configuration reload: setting synchronous_standby_names to '*'");
+		elog(LOG, "signaling configuration reload: setting synchronous_standby_names to 'gp_walreceiver'");
 		DirectFunctionCall1(pg_reload_conf, PointerGetDatum(NULL) /* unused */);
 	}
 }


### PR DESCRIPTION
…n segment.

If the default value of synchronous_standby_names is "*", then all replication slot->priority will be larger than 0 which means sync mode. For logical replication slot, the decoding normally from a source database, so other database's transaction will not be processed, so not all wal logs are process and so the flush value could not updated as fast as sync mode. So it may cause segment hang on commit SyncRepWaitForLSN waiting for logical replication slot->flush to update.

With synchronous_standby_names set to "gp_walreceiver", logical replication slot ->priority will be set to 0 which means not sync mode which is reasonable.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
