### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/bin/pg_waldump/pg_waldump.c
+++ b/src/bin/pg_waldump/pg_waldump.c
@@ -1129,13 +1129,13 @@ main(int argc, char **argv)
 		char		xlogfname[MAXFNAMELEN];
 		if (!timeline_specified)
 		{
-			pg_log_error("timeline not specified.", strerror(errno));
+			pg_log_error("timeline not specified");
 			goto bad_argument;
 		}
 
 		if (!path_specified)
 		{
-			pg_log_error("path not specified.", strerror(errno));
+			pg_log_error("path not specified");
 			goto bad_argument;
 		}
 

--- a/src/bin/pg_waldump/t/001_basic.pl
+++ b/src/bin/pg_waldump/t/001_basic.pl
@@ -21,7 +21,7 @@ $node->command_ok(['pg_waldump', '-p', "$pgdata/pg_wal/", '-t', '1', '--last-val
 $node->command_checks_all(['pg_waldump', '-p', "$pgdata/pg_wal/", '--last-valid-walname'],
     1,
     [qr{^$}],
-    [qr/pg_waldump: error: timeline not specified.\nTry "pg_waldump --help" for more information./],
+    [qr/pg_waldump: error: timeline not specified\nTry "pg_waldump --help" for more information./],
 	'pg_waldump fails if timeline not provided');
 
 $node->command_checks_all(['pg_waldump', '-p', "$pgdata/pg_wal/", '-t', 'st', '--last-valid-walname'],
@@ -33,7 +33,7 @@ $node->command_checks_all(['pg_waldump', '-p', "$pgdata/pg_wal/", '-t', 'st', '-
 $node->command_checks_all(['pg_waldump', '-t', '1', '--last-valid-walname'],
     1,
     [qr{^$}],
-    [qr/pg_waldump: error: path not specified.\nTry "pg_waldump --help" for more information./],
+    [qr/pg_waldump: error: path not specified\nTry "pg_waldump --help" for more information./],
     'pg_waldump fails if pg_wal path not provided using -p');
 
 $node->command_checks_all(['pg_waldump', '-p', "/tmp/pg_wal/", '-t', '1', '--last-valid-walname'],


### PR DESCRIPTION
Removed strerror(errno) from error messages as it is not required for argument checks.

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
