### PR TITLE
Fix Addmirror valid range port error

### DIFF
--- a/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
+++ b/gpMgmt/bin/gppylib/programs/clsAddMirrors.py
@@ -450,8 +450,8 @@ class GpAddMirrorsProgram:
         maxAllowedPort = 61000
         minAllowedPort = 6432
 
-        minPort = min([seg.getSegmentPort() for seg in gpArray.getDbList()])
-        maxPort = max([seg.getSegmentPort() for seg in gpArray.getDbList()])
+        minPort = min([seg.getSegmentPort() for seg in gpArray.getSegDbList()])
+        maxPort = max([seg.getSegmentPort() for seg in gpArray.getSegDbList()])
 
         if self.__options.mirrorOffset < 0:
             minPort = minPort + 3 * self.__options.mirrorOffset

--- a/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
+++ b/gpMgmt/test/behave/mgmt_utils/gpaddmirrors.feature
@@ -195,6 +195,18 @@ Feature: Tests for gpaddmirrors
         And check segment conf: postgresql.conf
         And all files in gpAdminLogs directory are deleted
 
+    Scenario: gpaddmirrors should create mirror on offset to primary port
+        Given the cluster is generated with "1" primaries only
+        And all files in gpAdminLogs directory are deleted
+        And a gaddmirrors directory under '/tmp' with mode '0700' is created
+        When gpaddmirrors adds mirror with port offset "500"
+        Then gpaddmirrors should return a return code of 0
+        And all the segments are running
+        And mirror port should have offset of 500 from primary
+        And check segment conf: postgresql.conf
+        And all files in gpAdminLogs directory are deleted
+
+
 
 #    Scenario: gpaddmirrors deletes progress file on SIGINT
 #        Given the cluster is generated with "3" primaries only


### PR DESCRIPTION
Issue: gpaddmirrors with -p option produces ports outside of the valid rangeMirror error

RCA: gpaddmirrors with -p option was considering the coordinator port number while calculating the mirror port, because of that it lands up error case if the coordinator port is 5432 and calulcated mirror port will come 5432 + 500 = 5932 which is less than allowed minPort for mirror (6432).

Fix: with this fix now the mirror port will be calulated from min segment port available.

for example :
Coordinator port : 5432
Primary base port : 8000
Mirror base port will be 8000 + offset.

Added behave test case to validate the same. 

## Here are some reminders before you submit the pull request
- [ ] Add tests for the change
- [ ] Document changes
- [ ] Communicate in the mailing list if needed
- [ ] Pass `make installcheck`
- [ ] Review a PR in return to support the community
