### PR TITLE
Fix AT SETAM for heap/ao_row to ao_column when attnum >= 10

### DIFF
--- a/src/backend/catalog/pg_attribute_encoding.c
+++ b/src/backend/catalog/pg_attribute_encoding.c
@@ -931,7 +931,9 @@ ExistValidLastrownums(Oid relid, int natts)
 }
 
 /*
- * Determine which attnums have an entry present in pg_attribute_encoding
+ * Determine which attnums have an entry present in pg_attribute_encoding and
+ * populate that information in 'attnum_entry_present', an array of size
+ * MaxHeapAttributeNumber.
  */
 void
 check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
@@ -944,7 +946,7 @@ check_attribute_encoding_entry_exist(Oid relid, bool *attnum_entry_present)
 
 	Assert(OidIsValid(relid));
 
-	MemSet(attnum_entry_present, false, sizeof(attnum_entry_present));
+	MemSet(attnum_entry_present, false, MaxHeapAttributeNumber);
 
 	rel = heap_open(AttributeEncodingRelationId, AccessShareLock);
 

--- a/src/test/regress/expected/alter_table_set_am.out
+++ b/src/test/regress/expected/alter_table_set_am.out
@@ -1121,7 +1121,7 @@ SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compressle
 CREATE TABLE heap2co(a int, b int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
-CREATE TABLE heap2co2(a int, b int);
+CREATE TABLE heap2co2(a int, b int, c int, d int, e int, f int, g int, h int, i int);
 NOTICE:  Table doesn't have 'DISTRIBUTED BY' clause -- Using column named 'a' as the Greenplum Database data distribution key for this table.
 HINT:  The 'DISTRIBUTED BY' clause determines the distribution of data. Make sure column(s) chosen are the optimal data distribution key to minimize skew.
 CREATE TABLE heap2co3(a int, b int);
@@ -1257,13 +1257,20 @@ SELECT c.relname, a.attnum, a.filenum, a.attoptions FROM pg_attribute_encoding a
 ----------+--------+---------+-----------------------------------------------------
  heap2co  |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
  heap2co  |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      9 |       9 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      8 |       8 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      7 |       7 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      6 |       6 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      5 |       5 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      4 |       4 | {compresstype=zlib,blocksize=65536,compresslevel=5}
+ heap2co2 |      3 |       3 | {compresstype=zlib,blocksize=65536,compresslevel=5}
  heap2co2 |      2 |       2 | {compresstype=zlib,blocksize=65536,compresslevel=5}
  heap2co2 |      1 |       1 | {compresstype=zlib,blocksize=65536,compresslevel=5}
  heap2co3 |      2 |       2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
  heap2co3 |      1 |       1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
  heap2co4 |      2 |       2 | {blocksize=32768,compresslevel=3,compresstype=zlib}
  heap2co4 |      1 |       1 | {blocksize=32768,compresslevel=3,compresstype=zlib}
-(8 rows)
+(15 rows)
 
 -- AM and reloptions changed accordingly
 SELECT c.relname, a.amname, c.reloptions FROM pg_class c JOIN pg_am a ON c.relam = a.oid WHERE c.relname LIKE 'heap2co%';

--- a/src/test/regress/sql/alter_table_set_am.sql
+++ b/src/test/regress/sql/alter_table_set_am.sql
@@ -580,7 +580,7 @@ DROP TABLE co2ao4;
 -- Scenario 8: Heap to AOCO
 SET gp_default_storage_options = 'blocksize=65536, compresstype=zlib, compresslevel=5, checksum=true';
 CREATE TABLE heap2co(a int, b int);
-CREATE TABLE heap2co2(a int, b int);
+CREATE TABLE heap2co2(a int, b int, c int, d int, e int, f int, g int, h int, i int);
 CREATE TABLE heap2co3(a int, b int);
 CREATE TABLE heap2co4(a int, b int);
 CREATE INDEX index_heap2co ON heap2co(b);


### PR DESCRIPTION
Changing access method of heap/ao_row tables to ao_column tables fail when

the attribute of heap/ao_row is bigger than 10. The error message is

could not find tuple for attnum 10 for relid, which roots from a

misinitialization of the attnum_entry_present flag. This commit fixes the issue.