### PR TITLE
Add GUC to stop penalizing correlated Left Outer NLJ operator

### DIFF
--- a/src/backend/gpopt/config/CConfigParamMapping.cpp
+++ b/src/backend/gpopt/config/CConfigParamMapping.cpp
@@ -304,6 +304,10 @@ CConfigParamMapping::SConfigMappingElem CConfigParamMapping::m_elements[] = {
 	{EopttraceDisableInnerNLJ, &optimizer_enable_nljoin,
 	 true,	// m_negate_param
 	 GPOS_WSZ_LIT("Enable nested loop join alternatives")},
+	{EopttraceEnablePenalizeCorrelatedLeftOuterNLJ,
+	 &optimizer_enable_penalize_correlated_left_outer_nljoin,
+	 false,	 // m_negate_param
+	 GPOS_WSZ_LIT("Penalize correlated left outer nested loop join")},
 
 };
 

--- a/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnyPredicate-Over-UnionOfConsts.mdp
@@ -211,7 +211,7 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="284340">
+    <dxl:Plan Id="0" SpaceSize="418386">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="441344.123871" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
+++ b/src/backend/gporca/data/dxl/minidump/AnySubq-With-NonScalarSubqueryChild-1.mdp
@@ -440,669 +440,329 @@
       </dxl:LogicalSelect>
     </dxl:Query>
     <dxl:Plan Id="0" SpaceSize="1426">
-      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
-        <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1389253302320.306396" Rows="1.000000" Width="15"/>
-        </dxl:Properties>
-        <dxl:ProjList>
-          <dxl:ProjElem ColId="0" Alias="a">
-            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="1" Alias="b">
-            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-          </dxl:ProjElem>
-          <dxl:ProjElem ColId="2" Alias="c">
-            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-          </dxl:ProjElem>
-        </dxl:ProjList>
-        <dxl:Filter/>
-        <dxl:SortingColumnList/>
-        <dxl:NestedLoopJoin JoinType="In" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-          <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1389253302320.306396" Rows="1.000000" Width="15"/>
-          </dxl:Properties>
-          <dxl:ProjList>
-            <dxl:ProjElem ColId="0" Alias="a">
-              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="1" Alias="b">
-              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-            </dxl:ProjElem>
-            <dxl:ProjElem ColId="2" Alias="c">
-              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
-          <dxl:TableScan>
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="15"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="0" Alias="a">
-                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="1" Alias="b">
-                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="2" Alias="c">
-                <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
-              <dxl:Columns>
-                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="7"/>
-                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-              </dxl:Columns>
-            </dxl:TableDescriptor>
-          </dxl:TableScan>
-          <dxl:Materialize Eager="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691816.047135" Rows="5.400000" Width="1"/>
-            </dxl:Properties>
-            <dxl:ProjList/>
-            <dxl:Filter/>
-            <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356691816.047133" Rows="5.400000" Width="1"/>
-              </dxl:Properties>
-              <dxl:ProjList/>
-              <dxl:Filter/>
-              <dxl:SortingColumnList/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356691816.047101" Rows="1.800000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356691816.047101" Rows="1.800000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:GroupingColumns>
-                    <dxl:GroupingColumn ColId="10"/>
-                    <dxl:GroupingColumn ColId="11"/>
-                    <dxl:GroupingColumn ColId="13"/>
-                    <dxl:GroupingColumn ColId="19"/>
-                    <dxl:GroupingColumn ColId="20"/>
-                    <dxl:GroupingColumn ColId="41"/>
-                    <dxl:GroupingColumn ColId="42"/>
-                  </dxl:GroupingColumns>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="a">
-                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="11" Alias="b">
-                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="13" Alias="ctid">
-                      <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                      <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="20" Alias="b">
-                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                      <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:Sort SortDiscardDuplicates="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1356691816.047079" Rows="1.800000" Width="22"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="10" Alias="a">
-                        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="11" Alias="b">
-                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="13" Alias="ctid">
-                        <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                        <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="20" Alias="b">
-                        <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                        <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:SortingColumnList>
-                      <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      <dxl:SortingColumn ColId="42" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                    </dxl:SortingColumnList>
-                    <dxl:LimitCount/>
-                    <dxl:LimitOffset/>
-                    <dxl:Result>
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1356691816.046829" Rows="1.800000" Width="22"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="10" Alias="a">
-                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="11" Alias="b">
-                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="13" Alias="ctid">
-                          <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                          <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="20" Alias="b">
-                          <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                          <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                          <dxl:And>
-                            <dxl:If TypeMdid="0.16.1.0">
-                              <dxl:Not>
-                                <dxl:IsNull>
-                                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                </dxl:IsNull>
-                              </dxl:Not>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                            </dxl:If>
-                            <dxl:If TypeMdid="0.16.1.0">
-                              <dxl:Not>
-                                <dxl:IsNull>
-                                  <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                                </dxl:IsNull>
-                              </dxl:Not>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                            </dxl:If>
-                          </dxl:And>
-                          <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                        </dxl:Comparison>
-                      </dxl:Filter>
-                      <dxl:OneTimeFilter/>
-                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1356691816.046632" Rows="4.500000" Width="22"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="10" Alias="a">
-                            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="11" Alias="b">
-                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="13" Alias="ctid">
-                            <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                            <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="20" Alias="b">
-                            <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                            <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                            <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:JoinFilter>
-                        <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324032.351409" Rows="2.250000" Width="21"/>
-                          </dxl:Properties>
-                          <dxl:GroupingColumns>
-                            <dxl:GroupingColumn ColId="10"/>
-                            <dxl:GroupingColumn ColId="11"/>
-                            <dxl:GroupingColumn ColId="13"/>
-                            <dxl:GroupingColumn ColId="19"/>
-                            <dxl:GroupingColumn ColId="20"/>
-                            <dxl:GroupingColumn ColId="41"/>
-                          </dxl:GroupingColumns>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="10" Alias="a">
-                              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="11" Alias="b">
-                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="13" Alias="ctid">
-                              <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                              <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="20" Alias="b">
-                              <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                              <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:Sort SortDiscardDuplicates="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324032.351376" Rows="2.250000" Width="21"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="10" Alias="a">
-                                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="11" Alias="b">
-                                <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="13" Alias="ctid">
-                                <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="20" Alias="b">
-                                <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList>
-                              <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                              <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                            </dxl:SortingColumnList>
-                            <dxl:LimitCount/>
-                            <dxl:LimitOffset/>
-                            <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="1324032.351138" Rows="2.250000" Width="21"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="10" Alias="a">
-                                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="11" Alias="b">
-                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="13" Alias="ctid">
-                                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="20" Alias="b">
-                                  <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:SortingColumnList/>
-                              <dxl:HashExprList>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                                </dxl:HashExpr>
-                                <dxl:HashExpr>
-                                  <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                </dxl:HashExpr>
-                              </dxl:HashExprList>
-                              <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="1324032.351084" Rows="2.250000" Width="21"/>
-                                </dxl:Properties>
-                                <dxl:GroupingColumns>
-                                  <dxl:GroupingColumn ColId="10"/>
-                                  <dxl:GroupingColumn ColId="11"/>
-                                  <dxl:GroupingColumn ColId="13"/>
-                                  <dxl:GroupingColumn ColId="19"/>
-                                  <dxl:GroupingColumn ColId="20"/>
-                                  <dxl:GroupingColumn ColId="41"/>
-                                </dxl:GroupingColumns>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="10" Alias="a">
-                                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="11" Alias="b">
-                                    <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="13" Alias="ctid">
-                                    <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                    <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="20" Alias="b">
-                                    <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:Sort SortDiscardDuplicates="false">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="1324032.351016" Rows="6.000000" Width="21"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="20" Alias="b">
-                                      <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="10" Alias="a">
-                                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="11" Alias="b">
-                                      <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="13" Alias="ctid">
-                                      <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                      <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList>
-                                    <dxl:SortingColumn ColId="10" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                    <dxl:SortingColumn ColId="11" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                    <dxl:SortingColumn ColId="13" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                    <dxl:SortingColumn ColId="19" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                    <dxl:SortingColumn ColId="20" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                    <dxl:SortingColumn ColId="41" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                                  </dxl:SortingColumnList>
-                                  <dxl:LimitCount/>
-                                  <dxl:LimitOffset/>
-                                  <dxl:Result>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="1324032.350778" Rows="6.000000" Width="21"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="20" Alias="b">
-                                        <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="104">
-                                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                        </dxl:CoerceViaIO>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="10" Alias="a">
-                                        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="11" Alias="b">
-                                        <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="13" Alias="ctid">
-                                        <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                        <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:OneTimeFilter/>
-                                    <dxl:RandomMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                      <dxl:Properties>
-                                        <dxl:Cost StartupCost="0" TotalCost="1324032.350736" Rows="6.000000" Width="20"/>
-                                      </dxl:Properties>
-                                      <dxl:ProjList>
-                                        <dxl:ProjElem ColId="10" Alias="a">
-                                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="11" Alias="b">
-                                          <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="13" Alias="ctid">
-                                          <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                          <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                        </dxl:ProjElem>
-                                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                          <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                        </dxl:ProjElem>
-                                      </dxl:ProjList>
-                                      <dxl:Filter/>
-                                      <dxl:SortingColumnList/>
-                                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                                        <dxl:Properties>
-                                          <dxl:Cost StartupCost="0" TotalCost="1324032.350564" Rows="6.000000" Width="20"/>
-                                        </dxl:Properties>
-                                        <dxl:ProjList>
-                                          <dxl:ProjElem ColId="10" Alias="a">
-                                            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="11" Alias="b">
-                                            <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="13" Alias="ctid">
-                                            <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                            <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                          </dxl:ProjElem>
-                                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                            <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                          </dxl:ProjElem>
-                                        </dxl:ProjList>
-                                        <dxl:Filter/>
-                                        <dxl:JoinFilter>
-                                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                        </dxl:JoinFilter>
-                                        <dxl:TableScan>
-                                          <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="19"/>
-                                          </dxl:Properties>
-                                          <dxl:ProjList>
-                                            <dxl:ProjElem ColId="10" Alias="a">
-                                              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="11" Alias="b">
-                                              <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="13" Alias="ctid">
-                                              <dxl:Ident ColId="13" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                            </dxl:ProjElem>
-                                            <dxl:ProjElem ColId="19" Alias="gp_segment_id">
-                                              <dxl:Ident ColId="19" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                            </dxl:ProjElem>
-                                          </dxl:ProjList>
-                                          <dxl:Filter/>
-                                          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
-                                            <dxl:Columns>
-                                              <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
-                                              <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                              <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                              <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                            </dxl:Columns>
-                                          </dxl:TableDescriptor>
-                                        </dxl:TableScan>
-                                        <dxl:Materialize Eager="false">
-                                          <dxl:Properties>
-                                            <dxl:Cost StartupCost="0" TotalCost="431.000055" Rows="6.000000" Width="1"/>
-                                          </dxl:Properties>
-                                          <dxl:ProjList>
-                                            <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                              <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                            </dxl:ProjElem>
-                                          </dxl:ProjList>
-                                          <dxl:Filter/>
-                                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                            <dxl:Properties>
-                                              <dxl:Cost StartupCost="0" TotalCost="431.000053" Rows="6.000000" Width="1"/>
-                                            </dxl:Properties>
-                                            <dxl:ProjList>
-                                              <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                                <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.16.1.0"/>
-                                              </dxl:ProjElem>
-                                            </dxl:ProjList>
-                                            <dxl:Filter/>
-                                            <dxl:SortingColumnList/>
-                                            <dxl:Result>
-                                              <dxl:Properties>
-                                                <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="2.000000" Width="1"/>
-                                              </dxl:Properties>
-                                              <dxl:ProjList>
-                                                <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                                </dxl:ProjElem>
-                                              </dxl:ProjList>
-                                              <dxl:Filter/>
-                                              <dxl:OneTimeFilter/>
-                                              <dxl:TableScan>
-                                                <dxl:Properties>
-                                                  <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="1"/>
-                                                </dxl:Properties>
-                                                <dxl:ProjList/>
-                                                <dxl:Filter/>
-                                                <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
-                                                  <dxl:Columns>
-                                                    <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                                    <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                                    <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                                  </dxl:Columns>
-                                                </dxl:TableDescriptor>
-                                              </dxl:TableScan>
-                                            </dxl:Result>
-                                          </dxl:BroadcastMotion>
-                                        </dxl:Materialize>
-                                      </dxl:NestedLoopJoin>
-                                    </dxl:RandomMotion>
-                                  </dxl:Result>
-                                </dxl:Sort>
-                              </dxl:Aggregate>
-                            </dxl:RedistributeMotion>
-                          </dxl:Sort>
-                        </dxl:Aggregate>
-                        <dxl:Materialize Eager="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                              <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="31" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Result>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:NestedLoopJoin>
-                    </dxl:Result>
-                  </dxl:Sort>
-                </dxl:Aggregate>
-              </dxl:Result>
-            </dxl:BroadcastMotion>
-          </dxl:Materialize>
-        </dxl:NestedLoopJoin>
-      </dxl:GatherMotion>
-    </dxl:Plan>
+     <dxl:Result>
+       <dxl:Properties>
+         <dxl:Cost StartupCost="0" TotalCost="1357588679.059423" Rows="1.000000" Width="15"/>
+       </dxl:Properties>
+       <dxl:ProjList>
+         <dxl:ProjElem ColId="0" Alias="a">
+           <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+         </dxl:ProjElem>
+         <dxl:ProjElem ColId="1" Alias="b">
+           <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+         </dxl:ProjElem>
+         <dxl:ProjElem ColId="2" Alias="c">
+           <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+         </dxl:ProjElem>
+       </dxl:ProjList>
+       <dxl:Filter>
+         <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ScalarSubPlan">
+           <dxl:TestExpr/>
+           <dxl:ParamList/>
+           <dxl:Result>
+             <dxl:Properties>
+               <dxl:Cost StartupCost="0" TotalCost="1324908.194037" Rows="400.000000" Width="1"/>
+             </dxl:Properties>
+             <dxl:ProjList>
+               <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+               </dxl:ProjElem>
+             </dxl:ProjList>
+             <dxl:Filter/>
+             <dxl:OneTimeFilter/>
+             <dxl:Materialize Eager="true">
+               <dxl:Properties>
+                 <dxl:Cost StartupCost="0" TotalCost="1324908.194037" Rows="400.000000" Width="1"/>
+               </dxl:Properties>
+               <dxl:ProjList>
+                 <dxl:ProjElem ColId="20" Alias="b">
+                   <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                 </dxl:ProjElem>
+               </dxl:ProjList>
+               <dxl:Filter/>
+               <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                 <dxl:Properties>
+                   <dxl:Cost StartupCost="0" TotalCost="1324908.193637" Rows="400.000000" Width="1"/>
+                 </dxl:Properties>
+                 <dxl:ProjList>
+                   <dxl:ProjElem ColId="20" Alias="b">
+                     <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                   </dxl:ProjElem>
+                 </dxl:ProjList>
+                 <dxl:Filter/>
+                 <dxl:SortingColumnList/>
+                 <dxl:Result>
+                   <dxl:Properties>
+                     <dxl:Cost StartupCost="0" TotalCost="1324908.192146" Rows="400.000000" Width="1"/>
+                   </dxl:Properties>
+                   <dxl:ProjList>
+                     <dxl:ProjElem ColId="20" Alias="b">
+                       <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                     </dxl:ProjElem>
+                   </dxl:ProjList>
+                   <dxl:Filter>
+                     <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+                       <dxl:And>
+                         <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.16.1.0"/>
+                         <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.16.1.0"/>
+                       </dxl:And>
+                       <dxl:Ident ColId="20" ColName="b" TypeMdid="0.16.1.0"/>
+                     </dxl:Comparison>
+                   </dxl:Filter>
+                   <dxl:OneTimeFilter/>
+                   <dxl:Result>
+                     <dxl:Properties>
+                       <dxl:Cost StartupCost="0" TotalCost="1324908.159246" Rows="1000.000000" Width="3"/>
+                     </dxl:Properties>
+                     <dxl:ProjList>
+                       <dxl:ProjElem ColId="20" Alias="b">
+                         <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="104">
+                           <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                         </dxl:CoerceViaIO>
+                       </dxl:ProjElem>
+                       <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                         <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ExistsSubPlan">
+                           <dxl:TestExpr/>
+                           <dxl:ParamList/>
+                           <dxl:Result>
+                             <dxl:Properties>
+                               <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="6.000000" Width="5"/>
+                             </dxl:Properties>
+                             <dxl:ProjList>
+                               <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                                 <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.16.1.0"/>
+                               </dxl:ProjElem>
+                             </dxl:ProjList>
+                             <dxl:Filter/>
+                             <dxl:OneTimeFilter/>
+                             <dxl:Result>
+                               <dxl:Properties>
+                                 <dxl:Cost StartupCost="0" TotalCost="431.000182" Rows="6.000000" Width="5"/>
+                               </dxl:Properties>
+                               <dxl:ProjList>
+                                 <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                 </dxl:ProjElem>
+                                 <dxl:ProjElem ColId="21" Alias="a">
+                                   <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+                                 </dxl:ProjElem>
+                               </dxl:ProjList>
+                               <dxl:Filter/>
+                               <dxl:OneTimeFilter/>
+                               <dxl:Materialize Eager="false">
+                                 <dxl:Properties>
+                                   <dxl:Cost StartupCost="0" TotalCost="431.000172" Rows="6.000000" Width="4"/>
+                                 </dxl:Properties>
+                                 <dxl:ProjList>
+                                   <dxl:ProjElem ColId="21" Alias="a">
+                                     <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+                                   </dxl:ProjElem>
+                                 </dxl:ProjList>
+                                 <dxl:Filter/>
+                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                   <dxl:Properties>
+                                     <dxl:Cost StartupCost="0" TotalCost="431.000164" Rows="6.000000" Width="4"/>
+                                   </dxl:Properties>
+                                   <dxl:ProjList>
+                                     <dxl:ProjElem ColId="21" Alias="a">
+                                       <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+                                     </dxl:ProjElem>
+                                   </dxl:ProjList>
+                                   <dxl:Filter/>
+                                   <dxl:SortingColumnList/>
+                                   <dxl:TableScan>
+                                     <dxl:Properties>
+                                       <dxl:Cost StartupCost="0" TotalCost="431.000015" Rows="2.000000" Width="4"/>
+                                     </dxl:Properties>
+                                     <dxl:ProjList>
+                                       <dxl:ProjElem ColId="21" Alias="a">
+                                         <dxl:Ident ColId="21" ColName="a" TypeMdid="0.23.1.0"/>
+                                       </dxl:ProjElem>
+                                     </dxl:ProjList>
+                                     <dxl:Filter/>
+                                     <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                                       <dxl:Columns>
+                                         <dxl:Column ColId="21" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="24" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                         <dxl:Column ColId="25" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="26" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="27" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="28" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="29" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="30" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                       </dxl:Columns>
+                                     </dxl:TableDescriptor>
+                                   </dxl:TableScan>
+                                 </dxl:BroadcastMotion>
+                               </dxl:Materialize>
+                             </dxl:Result>
+                           </dxl:Result>
+                         </dxl:SubPlan>
+                       </dxl:ProjElem>
+                       <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                         <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="NotExistsSubPlan">
+                           <dxl:TestExpr/>
+                           <dxl:ParamList/>
+                           <dxl:Result>
+                             <dxl:Properties>
+                               <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                             </dxl:Properties>
+                             <dxl:ProjList>
+                               <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                 <dxl:Ident ColId="44" ColName="ColRef_0044" TypeMdid="0.16.1.0"/>
+                               </dxl:ProjElem>
+                             </dxl:ProjList>
+                             <dxl:Filter/>
+                             <dxl:OneTimeFilter/>
+                             <dxl:Result>
+                               <dxl:Properties>
+                                 <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                               </dxl:Properties>
+                               <dxl:ProjList>
+                                 <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                   <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                                 </dxl:ProjElem>
+                                 <dxl:ProjElem ColId="31" Alias="a">
+                                   <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+                                 </dxl:ProjElem>
+                               </dxl:ProjList>
+                               <dxl:Filter/>
+                               <dxl:OneTimeFilter/>
+                               <dxl:Materialize Eager="true">
+                                 <dxl:Properties>
+                                   <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="3.000000" Width="4"/>
+                                 </dxl:Properties>
+                                 <dxl:ProjList>
+                                   <dxl:ProjElem ColId="31" Alias="a">
+                                     <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+                                   </dxl:ProjElem>
+                                 </dxl:ProjList>
+                                 <dxl:Filter/>
+                                 <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                   <dxl:Properties>
+                                     <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
+                                   </dxl:Properties>
+                                   <dxl:ProjList>
+                                     <dxl:ProjElem ColId="31" Alias="a">
+                                       <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+                                     </dxl:ProjElem>
+                                   </dxl:ProjList>
+                                   <dxl:Filter/>
+                                   <dxl:SortingColumnList/>
+                                   <dxl:TableScan>
+                                     <dxl:Properties>
+                                       <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+                                     </dxl:Properties>
+                                     <dxl:ProjList>
+                                       <dxl:ProjElem ColId="31" Alias="a">
+                                         <dxl:Ident ColId="31" ColName="a" TypeMdid="0.23.1.0"/>
+                                       </dxl:ProjElem>
+                                     </dxl:ProjList>
+                                     <dxl:Filter/>
+                                     <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
+                                       <dxl:Columns>
+                                         <dxl:Column ColId="31" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="34" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                         <dxl:Column ColId="35" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="36" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="37" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="38" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="39" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                         <dxl:Column ColId="40" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                       </dxl:Columns>
+                                     </dxl:TableDescriptor>
+                                   </dxl:TableScan>
+                                 </dxl:BroadcastMotion>
+                               </dxl:Materialize>
+                             </dxl:Result>
+                           </dxl:Result>
+                         </dxl:SubPlan>
+                       </dxl:ProjElem>
+                     </dxl:ProjList>
+                     <dxl:Filter/>
+                     <dxl:OneTimeFilter/>
+                     <dxl:TableScan>
+                       <dxl:Properties>
+                         <dxl:Cost StartupCost="0" TotalCost="1324046.140645" Rows="1000.000000" Width="9"/>
+                       </dxl:Properties>
+                       <dxl:ProjList>
+                         <dxl:ProjElem ColId="11" Alias="b">
+                           <dxl:Ident ColId="11" ColName="b" TypeMdid="0.25.1.0"/>
+                         </dxl:ProjElem>
+                       </dxl:ProjList>
+                       <dxl:Filter/>
+                       <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
+                         <dxl:Columns>
+                           <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                           <dxl:Column ColId="11" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                           <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                           <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                           <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                           <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                           <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                           <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                           <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                         </dxl:Columns>
+                       </dxl:TableDescriptor>
+                     </dxl:TableScan>
+                   </dxl:Result>
+                 </dxl:Result>
+               </dxl:GatherMotion>
+             </dxl:Materialize>
+           </dxl:Result>
+         </dxl:SubPlan>
+       </dxl:Filter>
+       <dxl:OneTimeFilter/>
+       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+         <dxl:Properties>
+           <dxl:Cost StartupCost="0" TotalCost="431.000073" Rows="1.000000" Width="15"/>
+         </dxl:Properties>
+         <dxl:ProjList>
+           <dxl:ProjElem ColId="0" Alias="a">
+             <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+           </dxl:ProjElem>
+           <dxl:ProjElem ColId="1" Alias="b">
+             <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+           </dxl:ProjElem>
+           <dxl:ProjElem ColId="2" Alias="c">
+             <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+           </dxl:ProjElem>
+         </dxl:ProjList>
+         <dxl:Filter/>
+         <dxl:SortingColumnList/>
+         <dxl:TableScan>
+           <dxl:Properties>
+             <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="15"/>
+           </dxl:Properties>
+           <dxl:ProjList>
+             <dxl:ProjElem ColId="0" Alias="a">
+               <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+             </dxl:ProjElem>
+             <dxl:ProjElem ColId="1" Alias="b">
+               <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+             </dxl:ProjElem>
+             <dxl:ProjElem ColId="2" Alias="c">
+               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
+             </dxl:ProjElem>
+           </dxl:ProjList>
+           <dxl:Filter/>
+           <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
+             <dxl:Columns>
+               <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+               <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="7"/>
+               <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+               <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+               <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+               <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+               <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+               <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+               <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+               <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+             </dxl:Columns>
+           </dxl:TableDescriptor>
+         </dxl:TableScan>
+       </dxl:GatherMotion>
+     </dxl:Result>
+   </dxl:Plan>
   </dxl:Thread>
 </dxl:DXLMessage>

--- a/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Coalesce-With-Subquery.mdp
@@ -790,7 +790,7 @@
     <dxl:Plan Id="0" SpaceSize="4186">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="38915.798285" Rows="4.000000" Width="269"/>
+          <dxl:Cost StartupCost="0" TotalCost="7786.755609" Rows="4.000000" Width="269"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="datname">
@@ -799,11 +799,131 @@
           <dxl:ProjElem ColId="88" Alias="coalesce">
             <dxl:Coalesce TypeMdid="0.19.1.0">
               <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
-              <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+              <dxl:SubPlan TypeMdid="0.19.1.0" SubPlanType="ScalarSubPlan">
+                <dxl:TestExpr/>
+                <dxl:ParamList/>
+                <dxl:HashJoin JoinType="Inner">
+                  <dxl:Properties>
+                    <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="64"/>
+                  </dxl:Properties>
+                  <dxl:ProjList>
+                    <dxl:ProjElem ColId="44" Alias="rolname">
+                      <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+                    </dxl:ProjElem>
+                  </dxl:ProjList>
+                  <dxl:Filter/>
+                  <dxl:JoinFilter/>
+                  <dxl:HashCondList>
+                    <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                      <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
+                      <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                    </dxl:Comparison>
+                  </dxl:HashCondList>
+                  <dxl:TableScan>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="44" Alias="rolname">
+                        <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
+                      </dxl:ProjElem>
+                      <dxl:ProjElem ColId="62" Alias="oid">
+                        <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:TableDescriptor Mdid="6.1260.1.1" TableName="pg_authid">
+                      <dxl:Columns>
+                        <dxl:Column ColId="44" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                        <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                        <dxl:Column ColId="62" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="63" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="64" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="65" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                        <dxl:Column ColId="66" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                        <dxl:Column ColId="67" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                        <dxl:Column ColId="68" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                      </dxl:Columns>
+                    </dxl:TableDescriptor>
+                  </dxl:TableScan>
+                  <dxl:Assert ErrorCode="P0003">
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="6.000756" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="70" Alias="datdba">
+                        <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:AssertConstraintList>
+                      <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
+                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
+                          <dxl:Ident ColId="106" ColName="row_number" TypeMdid="0.20.1.0"/>
+                          <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
+                            <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                          </dxl:Cast>
+                        </dxl:Comparison>
+                      </dxl:AssertConstraint>
+                    </dxl:AssertConstraintList>
+                    <dxl:Window PartitionColumns="">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="6.000752" Rows="1.200000" Width="12"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="106" Alias="row_number">
+                          <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="70" Alias="datdba">
+                          <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:IndexScan IndexScanDirection="Forward">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="6.000743" Rows="1.200000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="70" Alias="datdba">
+                            <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:IndexCondList>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
+                            <dxl:Ident ColId="69" ColName="datname" TypeMdid="0.19.1.0"/>
+                            <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGVtcGxhdGUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#xA;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
+                          </dxl:Comparison>
+                        </dxl:IndexCondList>
+                        <dxl:Partitions/>
+                        <dxl:IndexDescriptor Mdid="0.2671.1.0" IndexName="pg_database_datname_index"/>
+                        <dxl:TableDescriptor Mdid="6.1262.1.1" TableName="pg_database">
+                          <dxl:Columns>
+                            <dxl:Column ColId="69" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
+                            <dxl:Column ColId="70" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                            <dxl:Column ColId="81" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="82" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="83" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="84" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                            <dxl:Column ColId="85" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                            <dxl:Column ColId="86" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                            <dxl:Column ColId="87" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                          </dxl:Columns>
+                        </dxl:TableDescriptor>
+                      </dxl:IndexScan>
+                      <dxl:WindowKeyList>
+                        <dxl:WindowKey>
+                          <dxl:SortingColumnList/>
+                        </dxl:WindowKey>
+                      </dxl:WindowKeyList>
+                    </dxl:Window>
+                  </dxl:Assert>
+                </dxl:HashJoin>
+              </dxl:SubPlan>
             </dxl:Coalesce>
           </dxl:ProjElem>
           <dxl:ProjElem ColId="89" Alias="pg_encoding_to_char">
-            <dxl:FuncExpr FuncId="0.1597.1.0" FuncRetSet="false" TypeMdid="0.19.1.0">
+            <dxl:FuncExpr FuncId="0.1597.1.0" FuncRetSet="false" TypeMdid="0.19.1.0" FuncVariadic="false">
               <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
             </dxl:FuncExpr>
           </dxl:ProjElem>
@@ -856,9 +976,9 @@
         </dxl:ProjList>
         <dxl:Filter/>
         <dxl:OneTimeFilter/>
-        <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+        <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="6920.082238" Rows="8.000000" Width="205"/>
+            <dxl:Cost StartupCost="0" TotalCost="862.011733" Rows="4.000000" Width="141"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="datname">
@@ -882,17 +1002,16 @@
             <dxl:ProjElem ColId="19" Alias="rolname">
               <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="44" Alias="rolname">
-              <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-            </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
-          <dxl:JoinFilter>
-            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-          </dxl:JoinFilter>
-          <dxl:Sort SortDiscardDuplicates="false">
+          <dxl:SortingColumnList>
+            <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
+          </dxl:SortingColumnList>
+          <dxl:LimitCount/>
+          <dxl:LimitOffset/>
+          <dxl:HashJoin JoinType="Left">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="862.011733" Rows="4.000000" Width="141"/>
+              <dxl:Cost StartupCost="0" TotalCost="862.005337" Rows="4.000000" Width="141"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="datname">
@@ -918,18 +1037,23 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:SortingColumnList>
-              <dxl:SortingColumn ColId="0" SortOperatorMdid="0.660.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-            </dxl:SortingColumnList>
-            <dxl:LimitCount/>
-            <dxl:LimitOffset/>
-            <dxl:HashJoin JoinType="Left">
+            <dxl:JoinFilter/>
+            <dxl:HashCondList>
+              <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
+                <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
+                <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
+              </dxl:Comparison>
+            </dxl:HashCondList>
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="862.005337" Rows="4.000000" Width="141"/>
+                <dxl:Cost StartupCost="0" TotalCost="431.000761" Rows="3.000000" Width="81"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="0" Alias="datname">
                   <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="1" Alias="datdba">
+                  <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="2" Alias="encoding">
                   <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
@@ -946,255 +1070,60 @@
                 <dxl:ProjElem ColId="10" Alias="datacl">
                   <dxl:Ident ColId="10" ColName="datacl" TypeMdid="0.1034.1.0"/>
                 </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter>
+                <dxl:Ident ColId="4" ColName="datallowconn" TypeMdid="0.16.1.0"/>
+              </dxl:Filter>
+              <dxl:TableDescriptor Mdid="6.1262.1.1" TableName="pg_database">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="2" Attno="3" ColName="encoding" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="3" Attno="4" ColName="datistemplate" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="4" Attno="5" ColName="datallowconn" TypeMdid="0.16.1.0"/>
+                  <dxl:Column ColId="5" Attno="6" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
+                  <dxl:Column ColId="8" Attno="9" ColName="dattablespace" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="10" Attno="11" ColName="datacl" TypeMdid="0.1034.1.0"/>
+                  <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="12" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+            <dxl:TableScan>
+              <dxl:Properties>
+                <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
+              </dxl:Properties>
+              <dxl:ProjList>
                 <dxl:ProjElem ColId="19" Alias="rolname">
                   <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
                 </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter/>
-              <dxl:HashCondList>
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                  <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
+                <dxl:ProjElem ColId="37" Alias="oid">
                   <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
-                </dxl:Comparison>
-              </dxl:HashCondList>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000761" Rows="3.000000" Width="81"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="datname">
-                    <dxl:Ident ColId="0" ColName="datname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="datdba">
-                    <dxl:Ident ColId="1" ColName="datdba" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="encoding">
-                    <dxl:Ident ColId="2" ColName="encoding" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="datistemplate">
-                    <dxl:Ident ColId="3" ColName="datistemplate" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="5" Alias="datconnlimit">
-                    <dxl:Ident ColId="5" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="dattablespace">
-                    <dxl:Ident ColId="8" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="10" Alias="datacl">
-                    <dxl:Ident ColId="10" ColName="datacl" TypeMdid="0.1034.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Ident ColId="4" ColName="datallowconn" TypeMdid="0.16.1.0"/>
-                </dxl:Filter>
-                <dxl:TableDescriptor Mdid="6.1262.1.1" TableName="pg_database">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="2" Attno="3" ColName="encoding" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="3" Attno="4" ColName="datistemplate" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="4" Attno="5" ColName="datallowconn" TypeMdid="0.16.1.0"/>
-                    <dxl:Column ColId="5" Attno="6" ColName="datconnlimit" TypeMdid="0.23.1.0"/>
-                    <dxl:Column ColId="8" Attno="9" ColName="dattablespace" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="10" Attno="11" ColName="datacl" TypeMdid="0.1034.1.0"/>
-                    <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="12" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="13" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="14" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="15" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="16" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="17" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="18" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="19" Alias="rolname">
-                    <dxl:Ident ColId="19" ColName="rolname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="37" Alias="oid">
-                    <dxl:Ident ColId="37" ColName="oid" TypeMdid="0.26.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.1260.1.1" TableName="pg_authid">
-                  <dxl:Columns>
-                    <dxl:Column ColId="19" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    <dxl:Column ColId="37" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="38" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="39" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="40" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                    <dxl:Column ColId="41" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                    <dxl:Column ColId="42" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                    <dxl:Column ColId="43" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-            </dxl:HashJoin>
-          </dxl:Sort>
-          <dxl:Assert ErrorCode="P0003">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="437.001650" Rows="1.000000" Width="64"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="44" Alias="rolname">
-                <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:AssertConstraintList>
-              <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                  <dxl:Ident ColId="107" ColName="row_number" TypeMdid="0.20.1.0"/>
-                  <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:Cast>
-                </dxl:Comparison>
-              </dxl:AssertConstraint>
-            </dxl:AssertConstraintList>
-            <dxl:Window PartitionColumns="">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="72"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="107" Alias="row_number">
-                  <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="44" Alias="rolname">
-                  <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
                 </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:HashJoin JoinType="Inner">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="437.001586" Rows="1.000000" Width="64"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="44" Alias="rolname">
-                    <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:JoinFilter/>
-                <dxl:HashCondList>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.607.1.0">
-                    <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
-                    <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
-                  </dxl:Comparison>
-                </dxl:HashCondList>
-                <dxl:TableScan>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000064" Rows="1.000000" Width="72"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="44" Alias="rolname">
-                      <dxl:Ident ColId="44" ColName="rolname" TypeMdid="0.19.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="62" Alias="oid">
-                      <dxl:Ident ColId="62" ColName="oid" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:TableDescriptor Mdid="6.1260.1.1" TableName="pg_authid">
-                    <dxl:Columns>
-                      <dxl:Column ColId="44" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
-                      <dxl:Column ColId="61" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      <dxl:Column ColId="62" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="63" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="64" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="65" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                      <dxl:Column ColId="66" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                      <dxl:Column ColId="67" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                      <dxl:Column ColId="68" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:Columns>
-                  </dxl:TableDescriptor>
-                </dxl:TableScan>
-                <dxl:Assert ErrorCode="P0003">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6.000756" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="70" Alias="datdba">
-                      <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:AssertConstraintList>
-                    <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                      <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                        <dxl:Ident ColId="106" ColName="row_number" TypeMdid="0.20.1.0"/>
-                        <dxl:Cast TypeMdid="0.20.1.0" FuncId="0.481.1.0">
-                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                        </dxl:Cast>
-                      </dxl:Comparison>
-                    </dxl:AssertConstraint>
-                  </dxl:AssertConstraintList>
-                  <dxl:Window PartitionColumns="">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="6.000752" Rows="1.200000" Width="12"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="106" Alias="row_number">
-                        <dxl:WindowFunc Mdid="0.7000.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="70" Alias="datdba">
-                        <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:IndexScan IndexScanDirection="Forward">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="6.000743" Rows="1.200000" Width="4"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="70" Alias="datdba">
-                          <dxl:Ident ColId="70" ColName="datdba" TypeMdid="0.26.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:IndexCondList>
-                        <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.93.1.0">
-                          <dxl:Ident ColId="69" ColName="datname" TypeMdid="0.19.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.19.1.0" Value="dGVtcGxhdGUwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA&#10;AAAAAAAAAAAAAAAAAAAAAAAAAA=="/>
-                        </dxl:Comparison>
-                      </dxl:IndexCondList>
-	<dxl:Partitions/>
-                      <dxl:IndexDescriptor Mdid="0.2671.1.0" IndexName="pg_database_datname_index"/>
-                      <dxl:TableDescriptor Mdid="6.1262.1.1" TableName="pg_database">
-                        <dxl:Columns>
-                          <dxl:Column ColId="69" Attno="1" ColName="datname" TypeMdid="0.19.1.0"/>
-                          <dxl:Column ColId="70" Attno="2" ColName="datdba" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="80" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          <dxl:Column ColId="81" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="82" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="83" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="84" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                          <dxl:Column ColId="85" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                          <dxl:Column ColId="86" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                          <dxl:Column ColId="87" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:Columns>
-                      </dxl:TableDescriptor>
-                    </dxl:IndexScan>
-                    <dxl:WindowKeyList>
-                      <dxl:WindowKey>
-                        <dxl:SortingColumnList/>
-                      </dxl:WindowKey>
-                    </dxl:WindowKeyList>
-                  </dxl:Window>
-                </dxl:Assert>
-              </dxl:HashJoin>
-              <dxl:WindowKeyList>
-                <dxl:WindowKey>
-                  <dxl:SortingColumnList/>
-                </dxl:WindowKey>
-              </dxl:WindowKeyList>
-            </dxl:Window>
-          </dxl:Assert>
-        </dxl:NestedLoopJoin>
+              <dxl:TableDescriptor Mdid="6.1260.1.1" TableName="pg_authid">
+                <dxl:Columns>
+                  <dxl:Column ColId="19" Attno="1" ColName="rolname" TypeMdid="0.19.1.0"/>
+                  <dxl:Column ColId="36" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                  <dxl:Column ColId="37" Attno="-2" ColName="oid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="38" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="39" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="40" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                  <dxl:Column ColId="41" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                  <dxl:Column ColId="42" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                  <dxl:Column ColId="43" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
+          </dxl:HashJoin>
+        </dxl:Sort>
       </dxl:Result>
     </dxl:Plan>
   </dxl:Thread>

--- a/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CollapseNot.mdp
@@ -289,7 +289,7 @@ SELECT 1 FROM inverse WHERE NOT (cidr <<= ANY(SELECT * FROM inverse));
         </dxl:LogicalSelect>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="66">
+    <dxl:Plan Id="0" SpaceSize="68">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.001770" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedAntiSemiJoin-True.mdp
@@ -799,7 +799,7 @@ SELECT pn, cn, vn FROM sale s WHERE NOT EXISTS (SELECT * FROM customer WHERE NOT
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="52">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.027601" Rows="12.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedIN-LeftSemiNotIn-True.mdp
@@ -520,7 +520,7 @@ create table customer
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="12">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.000441" Rows="1.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
+++ b/src/backend/gporca/data/dxl/minidump/CorrelatedSemiJoin-True.mdp
@@ -794,7 +794,7 @@ SELECT pn, cn, vn FROM sale s WHERE EXISTS (SELECT * FROM customer WHERE EXISTS 
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="52">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="2155.027601" Rows="12.000000" Width="12"/>

--- a/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
+++ b/src/backend/gporca/data/dxl/minidump/ExistentialSubquriesInsideScalarExpression.mdp
@@ -412,7 +412,7 @@
     <dxl:Plan Id="0" SpaceSize="77">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356691750.443794" Rows="1.600000" Width="13"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324917.678163" Rows="1.600000" Width="13"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="a">
@@ -429,7 +429,7 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356691750.443717" Rows="1.600000" Width="13"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324917.678085" Rows="1.600000" Width="13"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="a">
@@ -442,21 +442,174 @@
               <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
-          <dxl:Filter/>
+          <dxl:Filter>
+            <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
+              <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="32">
+                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
+              </dxl:CoerceViaIO>
+              <dxl:And>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="ExistsSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                        <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="32" Alias="ColRef_0032">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="10" Alias="a">
+                          <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="false">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="3.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="10" Alias="a">
+                            <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="10" Alias="a">
+                              <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="10" Alias="a">
+                                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
+                              <dxl:Columns>
+                                <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:SubPlan>
+                <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="NotExistsSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                        <dxl:Ident ColId="33" ColName="ColRef_0033" TypeMdid="0.16.1.0"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000091" Rows="3.000000" Width="5"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                        <dxl:ProjElem ColId="20" Alias="a">
+                          <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Materialize Eager="true">
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000086" Rows="3.000000" Width="4"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="20" Alias="a">
+                            <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000082" Rows="3.000000" Width="4"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="20" Alias="a">
+                              <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:SortingColumnList/>
+                          <dxl:TableScan>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="4"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="20" Alias="a">
+                                <dxl:Ident ColId="20" ColName="a" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
+                              <dxl:Columns>
+                                <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                              </dxl:Columns>
+                            </dxl:TableDescriptor>
+                          </dxl:TableScan>
+                        </dxl:BroadcastMotion>
+                      </dxl:Materialize>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:SubPlan>
+              </dxl:And>
+            </dxl:Comparison>
+          </dxl:Filter>
           <dxl:OneTimeFilter/>
-          <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356691750.443717" Rows="1.600000" Width="13"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324055.616626" Rows="1000.000000" Width="17"/>
             </dxl:Properties>
-            <dxl:GroupingColumns>
-              <dxl:GroupingColumn ColId="0"/>
-              <dxl:GroupingColumn ColId="1"/>
-              <dxl:GroupingColumn ColId="2"/>
-              <dxl:GroupingColumn ColId="3"/>
-              <dxl:GroupingColumn ColId="9"/>
-              <dxl:GroupingColumn ColId="30"/>
-              <dxl:GroupingColumn ColId="31"/>
-            </dxl:GroupingColumns>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
@@ -467,393 +620,23 @@
               <dxl:ProjElem ColId="2" Alias="c">
                 <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="3" Alias="ctid">
-                <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Sort SortDiscardDuplicates="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1356691750.443688" Rows="1.600000" Width="25"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="c">
-                  <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="3" Alias="ctid">
-                  <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                  <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                  <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                  <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:SortingColumnList>
-                <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                <dxl:SortingColumn ColId="31" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-              </dxl:SortingColumnList>
-              <dxl:LimitCount/>
-              <dxl:LimitOffset/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1356691750.443405" Rows="1.600000" Width="25"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="c">
-                    <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="3" Alias="ctid">
-                    <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                    <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                    <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                    <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter>
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.91.1.0">
-                    <dxl:CoerceViaIO TypeMdid="0.16.1.0" CoercionForm="1" Location="32">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                    </dxl:CoerceViaIO>
-                    <dxl:And>
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Not>
-                          <dxl:IsNull>
-                            <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                          </dxl:IsNull>
-                        </dxl:Not>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:If>
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Not>
-                          <dxl:IsNull>
-                            <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                          </dxl:IsNull>
-                        </dxl:Not>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:If>
-                    </dxl:And>
-                  </dxl:Comparison>
-                </dxl:Filter>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1356691750.443207" Rows="4.000000" Width="25"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="c">
-                      <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="3" Alias="ctid">
-                      <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                      <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                      <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                      <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324032.287320" Rows="2.000000" Width="24"/>
-                    </dxl:Properties>
-                    <dxl:GroupingColumns>
-                      <dxl:GroupingColumn ColId="0"/>
-                      <dxl:GroupingColumn ColId="1"/>
-                      <dxl:GroupingColumn ColId="2"/>
-                      <dxl:GroupingColumn ColId="3"/>
-                      <dxl:GroupingColumn ColId="9"/>
-                      <dxl:GroupingColumn ColId="30"/>
-                    </dxl:GroupingColumns>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="b">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="c">
-                        <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="3" Alias="ctid">
-                        <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                        <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                        <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Sort SortDiscardDuplicates="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324032.287259" Rows="4.000000" Width="24"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="c">
-                          <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="3" Alias="ctid">
-                          <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                          <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                          <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList>
-                        <dxl:SortingColumn ColId="0" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="1" SortOperatorMdid="0.664.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="2" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="3" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="9" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        <dxl:SortingColumn ColId="30" SortOperatorMdid="0.58.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                      </dxl:SortingColumnList>
-                      <dxl:LimitCount/>
-                      <dxl:LimitOffset/>
-                      <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324032.286987" Rows="4.000000" Width="24"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="0" Alias="a">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="c">
-                            <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="3" Alias="ctid">
-                            <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                            <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                            <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:JoinFilter>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:JoinFilter>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000024" Rows="2.000000" Width="23"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="0" Alias="a">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="b">
-                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.25.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="c">
-                              <dxl:Ident ColId="2" ColName="c" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="3" Alias="ctid">
-                              <dxl:Ident ColId="3" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="9" Alias="gp_segment_id">
-                              <dxl:Ident ColId="9" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
-                            <dxl:Columns>
-                              <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
-                              <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                        <dxl:Materialize Eager="false">
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                              <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                                <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:SortingColumnList/>
-                            <dxl:Result>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                                  <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:OneTimeFilter/>
-                              <dxl:TableScan>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
-                                </dxl:Properties>
-                                <dxl:ProjList/>
-                                <dxl:Filter/>
-                                <dxl:TableDescriptor Mdid="6.16391.1.0" TableName="t2">
-                                  <dxl:Columns>
-                                    <dxl:Column ColId="10" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="13" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                    <dxl:Column ColId="14" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="15" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="16" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="17" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="18" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                    <dxl:Column ColId="19" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  </dxl:Columns>
-                                </dxl:TableDescriptor>
-                              </dxl:TableScan>
-                            </dxl:Result>
-                          </dxl:BroadcastMotion>
-                        </dxl:Materialize>
-                      </dxl:NestedLoopJoin>
-                    </dxl:Sort>
-                  </dxl:Aggregate>
-                  <dxl:Materialize Eager="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000028" Rows="3.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                        <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000027" Rows="3.000000" Width="1"/>
-                      </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                          <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.16.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:SortingColumnList/>
-                      <dxl:Result>
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000009" Rows="1.000000" Width="1"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:OneTimeFilter/>
-                        <dxl:TableScan>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000008" Rows="1.000000" Width="1"/>
-                          </dxl:Properties>
-                          <dxl:ProjList/>
-                          <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.16394.1.0" TableName="t3">
-                            <dxl:Columns>
-                              <dxl:Column ColId="20" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="23" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                              <dxl:Column ColId="24" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="25" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="26" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="27" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="28" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                              <dxl:Column ColId="29" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:Result>
-                    </dxl:BroadcastMotion>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
-              </dxl:Result>
-            </dxl:Sort>
-          </dxl:Aggregate>
+            <dxl:TableDescriptor Mdid="6.16385.1.0" TableName="t1">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.25.1.0" ColWidth="5"/>
+                <dxl:Column ColId="2" Attno="3" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="9" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
+++ b/src/backend/gporca/data/dxl/minidump/HAWQ-TPCH-Stat-Derivation.mdp
@@ -6319,7 +6319,7 @@ ORDER BY s_name;
         </dxl:LogicalJoin>
       </dxl:LogicalLimit>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4053120">
+    <dxl:Plan Id="0" SpaceSize="4070580">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="24685091.846062" Rows="49.989277" Width="65"/>

--- a/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
+++ b/src/backend/gporca/data/dxl/minidump/IndexScanWithNestedCTEAndSetOp.mdp
@@ -333,7 +333,7 @@ SELECT a FROM y WHERE (a IN (SELECT b FROM bar WHERE b = 2));
         </dxl:LogicalCTEAnchor>
       </dxl:LogicalCTEAnchor>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="380">
+    <dxl:Plan Id="0" SpaceSize="416">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="868.000741" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/Least-Greatest-Subselect.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Least-Greatest-Subselect.mdp
@@ -238,10 +238,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="8">
+    <dxl:Plan Id="0" SpaceSize="72">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="904314014.342512" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="883135.948858" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="13" Alias="least">
@@ -252,16 +252,70 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="904314014.342497" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="883135.948843" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="13" Alias="least">
               <dxl:Minimum TypeMdid="0.23.1.0">
-                <dxl:Ident ColId="10" ColName="?column?" TypeMdid="0.23.1.0"/>
+                <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                  <dxl:TestExpr/>
+                  <dxl:ParamList/>
+                  <dxl:Result>
+                    <dxl:Properties>
+                      <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                    </dxl:Properties>
+                    <dxl:ProjList>
+                      <dxl:ProjElem ColId="10" Alias="?column?">
+                        <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
+                      </dxl:ProjElem>
+                    </dxl:ProjList>
+                    <dxl:Filter/>
+                    <dxl:OneTimeFilter/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="9" Alias="">
+                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                    </dxl:Result>
+                  </dxl:Result>
+                </dxl:SubPlan>
                 <dxl:Maximum TypeMdid="0.23.1.0">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                   <dxl:ConstValue TypeMdid="0.23.1.0" IsNull="true"/>
-                  <dxl:Ident ColId="12" ColName="?column?" TypeMdid="0.23.1.0"/>
+                  <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList/>
+                    <dxl:Result>
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
+                        <dxl:ProjElem ColId="12" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
+                        </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="11" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:SubPlan>
                 </dxl:Maximum>
                 <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
               </dxl:Minimum>
@@ -269,9 +323,9 @@
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:OneTimeFilter/>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
+          <dxl:TableScan>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="904314014.342496" Rows="4.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="882704.924520" Rows="1000.000000" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="a">
@@ -280,135 +334,22 @@
               <dxl:ProjElem ColId="1" Alias="b">
                 <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="?column?">
-                <dxl:Ident ColId="10" ColName="?column?" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="12" Alias="?column?">
-                <dxl:Ident ColId="12" ColName="?column?" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:JoinFilter>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="882688.154350" Rows="2.000000" Width="12"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="0" Alias="a">
-                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="1" Alias="b">
-                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="10" Alias="?column?">
-                  <dxl:Ident ColId="10" ColName="?column?" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000021" Rows="1.000000" Width="8"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.36574.1.0" TableName="foo" LockMode="1" AclMode="2">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="10" Alias="?column?">
-                    <dxl:Ident ColId="10" ColName="?column?" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="5"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="9" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
-              </dxl:Materialize>
-            </dxl:NestedLoopJoin>
-            <dxl:Materialize Eager="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="12" Alias="?column?">
-                  <dxl:Ident ColId="12" ColName="?column?" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="12" Alias="?column?">
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="11" Alias="">
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                </dxl:Result>
-              </dxl:Result>
-            </dxl:Materialize>
-          </dxl:NestedLoopJoin>
+            <dxl:TableDescriptor Mdid="6.36574.1.0" TableName="foo" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="3" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="8" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
+++ b/src/backend/gporca/data/dxl/minidump/LeftJoin-With-Col-Const-Pred.mdp
@@ -1993,7 +1993,7 @@
     <dxl:Plan Id="0" SpaceSize="1028">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="69941.462832" Rows="896.720000" Width="238"/>
+          <dxl:Cost StartupCost="0" TotalCost="11668.511336" Rows="896.720000" Width="238"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="36" Alias="tableoid">
@@ -2156,7 +2156,7 @@
         <dxl:OneTimeFilter/>
         <dxl:Sort SortDiscardDuplicates="false">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="69941.159741" Rows="1000.000000" Width="241"/>
+            <dxl:Cost StartupCost="0" TotalCost="11668.208245" Rows="1000.000000" Width="241"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="relname">

--- a/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
+++ b/src/backend/gporca/data/dxl/minidump/MultipleSubqueriesInSelectClause.mdp
@@ -1171,10 +1171,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="163431">
+    <dxl:Plan Id="0" SpaceSize="165991">
       <dxl:Result>
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="9309.074116" Rows="3000000.000000" Width="32"/>
+          <dxl:Cost StartupCost="0" TotalCost="2399.345982" Rows="3000000.000000" Width="32"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="0" Alias="field1">
@@ -1215,7 +1215,7 @@
         <dxl:OneTimeFilter/>
         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="9213.074116" Rows="1000.000000" Width="23"/>
+            <dxl:Cost StartupCost="0" TotalCost="2303.345982" Rows="1000.000000" Width="23"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="0" Alias="field1">
@@ -1244,7 +1244,7 @@
           <dxl:SortingColumnList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="9212.970846" Rows="1000.000000" Width="23"/>
+              <dxl:Cost StartupCost="0" TotalCost="2303.242712" Rows="1000.000000" Width="23"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="0" Alias="field1">
@@ -1288,7 +1288,7 @@
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="8" Alias="a">
-                          <dxl:FuncExpr FuncId="0.9255091.1.0" FuncRetSet="true" TypeMdid="0.23.1.0"/>
+                          <dxl:FuncExpr FuncId="0.9255091.1.0" FuncRetSet="true" TypeMdid="0.23.1.0" FuncVariadic="false"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
@@ -1338,7 +1338,7 @@
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="11" Alias="b">
-                          <dxl:FuncExpr FuncId="0.9255091.1.0" FuncRetSet="true" TypeMdid="0.23.1.0"/>
+                          <dxl:FuncExpr FuncId="0.9255091.1.0" FuncRetSet="true" TypeMdid="0.23.1.0" FuncVariadic="false"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
@@ -1388,7 +1388,7 @@
                           <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                         </dxl:ProjElem>
                         <dxl:ProjElem ColId="14" Alias="c">
-                          <dxl:FuncExpr FuncId="0.9255091.1.0" FuncRetSet="true" TypeMdid="0.23.1.0"/>
+                          <dxl:FuncExpr FuncId="0.9255091.1.0" FuncRetSet="true" TypeMdid="0.23.1.0" FuncVariadic="false"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>

--- a/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Project-With-NonScalar-Func.mdp
@@ -193,7 +193,7 @@
         </dxl:LogicalConstTable>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="60">
       <dxl:Result>
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="441344.272112" Rows="1.000000" Width="1"/>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-AnyAllAggregates.mdp
@@ -508,14 +508,14 @@
     <dxl:Plan Id="0" SpaceSize="439">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356698084.004784" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324915.583926" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -525,7 +525,7 @@
           <dxl:ProjElem ColId="28" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -536,43 +536,139 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356698084.004777" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324915.583919" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-              <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="36" Alias="ColRef_0036">
+              <dxl:Ident ColId="36" ColName="ColRef_0036" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="43" Alias="ColRef_0043">
-              <dxl:Ident ColId="43" ColName="ColRef_0043" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="37" Alias="ColRef_0037">
+              <dxl:Ident ColId="37" ColName="ColRef_0037" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356698084.004717" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324915.583859" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="42" Alias="ColRef_0042">
+              <dxl:ProjElem ColId="36" Alias="ColRef_0036">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                          <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:Comparison>
-                        <dxl:If TypeMdid="0.16.1.0">
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                            <dxl:Ident ColId="32" ColName="ColRef_0032" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="30" ColName="ColRef_0030" TypeMdid="0.20.1.0"/>
+                      <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                        <dxl:TestExpr>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:If>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:If>
+                        </dxl:TestExpr>
+                        <dxl:ParamList>
+                          <dxl:Param ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                        </dxl:ParamList>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.006221" Rows="9.000000" Width="5"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="b">
+                              <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.006221" Rows="9.000000" Width="5"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="34" Alias="ColRef_0034">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="9" Alias="b">
+                                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Result>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.006206" Rows="9.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="b">
+                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter>
+                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
+                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
+                                  <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+                                </dxl:Comparison>
+                              </dxl:Filter>
+                              <dxl:OneTimeFilter/>
+                              <dxl:Materialize Eager="false">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.001468" Rows="27.000000" Width="8"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="b">
+                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                  <dxl:ProjElem ColId="10" Alias="c">
+                                    <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.001396" Rows="27.000000" Width="8"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="9" Alias="b">
+                                      <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                    <dxl:ProjElem ColId="10" Alias="c">
+                                      <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:SortingColumnList/>
+                                  <dxl:TableScan>
+                                    <dxl:Properties>
+                                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="9.000000" Width="8"/>
+                                    </dxl:Properties>
+                                    <dxl:ProjList>
+                                      <dxl:ProjElem ColId="9" Alias="b">
+                                        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                      <dxl:ProjElem ColId="10" Alias="c">
+                                        <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
+                                      </dxl:ProjElem>
+                                    </dxl:ProjList>
+                                    <dxl:Filter/>
+                                    <dxl:TableDescriptor Mdid="6.98456.1.0" TableName="temp_b">
+                                      <dxl:Columns>
+                                        <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="10" Attno="2" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      </dxl:Columns>
+                                    </dxl:TableDescriptor>
+                                  </dxl:TableScan>
+                                </dxl:BroadcastMotion>
+                              </dxl:Materialize>
+                            </dxl:Result>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:SubPlan>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
                     </dxl:If>
@@ -582,7 +678,7 @@
                   <dxl:ValuesList ParamType="aggdistinct"/>
                 </dxl:AggFunc>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+              <dxl:ProjElem ColId="37" Alias="ColRef_0037">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
@@ -612,7 +708,7 @@
                               <dxl:Cost StartupCost="0" TotalCost="431.006221" Rows="9.000000" Width="5"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="33" Alias="ColRef_0033">
+                              <dxl:ProjElem ColId="35" Alias="ColRef_0035">
                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="19" Alias="b">
@@ -637,7 +733,7 @@
                                 </dxl:Comparison>
                               </dxl:Filter>
                               <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Materialize Eager="true">
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="431.001468" Rows="27.000000" Width="8"/>
                                 </dxl:Properties>
@@ -708,410 +804,33 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324038.442452" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324053.443596" Rows="1000.000000" Width="9"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="0"/>
-                <dxl:GroupingColumn ColId="1"/>
-                <dxl:GroupingColumn ColId="2"/>
-                <dxl:GroupingColumn ColId="8"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="30" Alias="ColRef_0030">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="32" Alias="ColRef_0032">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324038.442326" Rows="8.000000" Width="34"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="ctid">
-                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                    <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                    <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324038.441598" Rows="8.000000" Width="34"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                      <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                      <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324038.441314" Rows="8.000000" Width="34"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="b">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="ctid">
-                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                        <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                        <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324038.441314" Rows="8.000000" Width="34"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="0"/>
-                        <dxl:GroupingColumn ColId="1"/>
-                        <dxl:GroupingColumn ColId="2"/>
-                        <dxl:GroupingColumn ColId="8"/>
-                      </dxl:GroupingColumns>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="ctid">
-                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Sort SortDiscardDuplicates="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324038.441078" Rows="10.880000" Width="23"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                            <dxl:Ident ColId="31" ColName="ColRef_0031" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="0" Alias="a">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="ctid">
-                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                            <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        </dxl:SortingColumnList>
-                        <dxl:LimitCount/>
-                        <dxl:LimitOffset/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324038.440199" Rows="10.880000" Width="23"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="31" Alias="ColRef_0031">
-                              <dxl:If TypeMdid="0.23.1.0">
-                                <dxl:IsNull>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:Comparison>
-                                </dxl:IsNull>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                              </dxl:If>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="0" Alias="a">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="b">
-                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="ctid">
-                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                              <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324038.440116" Rows="10.880000" Width="23"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="a">
-                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="1" Alias="b">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="2" Alias="ctid">
-                                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="9" Alias="b">
-                                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                                <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:JoinFilter>
-                              <dxl:And>
-                                <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.521.1.0">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                                <dxl:IsNotFalse>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:Comparison>
-                                </dxl:IsNotFalse>
-                              </dxl:And>
-                            </dxl:JoinFilter>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="8.000000" Width="18"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="a">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="1" Alias="b">
-                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="2" Alias="ctid">
-                                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.98453.1.0" TableName="temp_a">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                            <dxl:Materialize Eager="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.001558" Rows="27.000000" Width="9"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                                  <dxl:Ident ColId="29" ColName="ColRef_0029" TypeMdid="0.16.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="9" Alias="b">
-                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="10" Alias="c">
-                                  <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.001477" Rows="27.000000" Width="9"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="29" Alias="ColRef_0029">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="9" Alias="b">
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="10" Alias="c">
-                                    <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.001396" Rows="27.000000" Width="8"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="9" Alias="b">
-                                      <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                    <dxl:ProjElem ColId="10" Alias="c">
-                                      <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="9.000000" Width="8"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="9" Alias="b">
-                                        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                      <dxl:ProjElem ColId="10" Alias="c">
-                                        <dxl:Ident ColId="10" ColName="c" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:TableDescriptor Mdid="6.98456.1.0" TableName="temp_b">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="10" Attno="2" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:BroadcastMotion>
-                              </dxl:Result>
-                            </dxl:Materialize>
-                          </dxl:NestedLoopJoin>
-                        </dxl:Result>
-                      </dxl:Sort>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
-            </dxl:Aggregate>
+              <dxl:TableDescriptor Mdid="6.98453.1.0" TableName="temp_a">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
           </dxl:Aggregate>
         </dxl:GatherMotion>
       </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregates.mdp
@@ -572,14 +572,14 @@
     <dxl:Plan Id="0" SpaceSize="449">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1356695751.048855" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="1324911.166882" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="28" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="46" ColName="ColRef_0046" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -589,7 +589,7 @@
           <dxl:ProjElem ColId="38" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -600,43 +600,110 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1356695751.048847" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="1324911.166875" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="52" Alias="ColRef_0052">
-              <dxl:Ident ColId="52" ColName="ColRef_0052" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="46" Alias="ColRef_0046">
+              <dxl:Ident ColId="46" ColName="ColRef_0046" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="53" Alias="ColRef_0053">
-              <dxl:Ident ColId="53" ColName="ColRef_0053" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="47" Alias="ColRef_0047">
+              <dxl:Ident ColId="47" ColName="ColRef_0047" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1356695751.048788" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1324911.166815" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+              <dxl:ProjElem ColId="46" Alias="ColRef_0046">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                          <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:Comparison>
-                        <dxl:If TypeMdid="0.16.1.0">
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                            <dxl:Ident ColId="42" ColName="ColRef_0042" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="40" ColName="ColRef_0040" TypeMdid="0.20.1.0"/>
+                      <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                        <dxl:TestExpr>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:If>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:If>
+                        </dxl:TestExpr>
+                        <dxl:ParamList/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="b">
+                              <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="44" Alias="ColRef_0044">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="9" Alias="b">
+                                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Materialize Eager="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000765" Rows="27.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="b">
+                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="b">
+                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="9.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="9" Alias="b">
+                                      <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="6.98456.1.0" TableName="temp_b">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:BroadcastMotion>
+                            </dxl:Materialize>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:SubPlan>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
                     </dxl:If>
@@ -646,7 +713,7 @@
                   <dxl:ValuesList ParamType="aggdistinct"/>
                 </dxl:AggFunc>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+              <dxl:ProjElem ColId="47" Alias="ColRef_0047">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
@@ -676,7 +743,7 @@
                               <dxl:Cost StartupCost="0" TotalCost="431.006221" Rows="9.000000" Width="5"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="43" Alias="ColRef_0043">
+                              <dxl:ProjElem ColId="45" Alias="ColRef_0045">
                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="29" Alias="b">
@@ -701,7 +768,7 @@
                                 </dxl:Comparison>
                               </dxl:Filter>
                               <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Materialize Eager="true">
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="431.001468" Rows="27.000000" Width="8"/>
                                 </dxl:Properties>
@@ -772,391 +839,33 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.164175" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324049.026552" Rows="1000.000000" Width="9"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="0"/>
-                <dxl:GroupingColumn ColId="1"/>
-                <dxl:GroupingColumn ColId="2"/>
-                <dxl:GroupingColumn ColId="8"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="40" Alias="ColRef_0040">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="42" Alias="ColRef_0042">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.164048" Rows="8.000000" Width="34"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="ctid">
-                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                    <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                    <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.163321" Rows="8.000000" Width="34"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                      <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                      <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="b">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="ctid">
-                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                        <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                        <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="0"/>
-                        <dxl:GroupingColumn ColId="1"/>
-                        <dxl:GroupingColumn ColId="2"/>
-                        <dxl:GroupingColumn ColId="8"/>
-                      </dxl:GroupingColumns>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.23.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="ctid">
-                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Sort SortDiscardDuplicates="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324036.162639" Rows="32.000000" Width="23"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                            <dxl:Ident ColId="41" ColName="ColRef_0041" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="0" Alias="a">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="ctid">
-                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                            <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        </dxl:SortingColumnList>
-                        <dxl:LimitCount/>
-                        <dxl:LimitOffset/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324036.157889" Rows="32.000000" Width="23"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="41" Alias="ColRef_0041">
-                              <dxl:If TypeMdid="0.23.1.0">
-                                <dxl:IsNull>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:Comparison>
-                                </dxl:IsNull>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                              </dxl:If>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="0" Alias="a">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="b">
-                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="ctid">
-                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                              <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324036.157643" Rows="32.000000" Width="23"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="a">
-                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="1" Alias="b">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="2" Alias="ctid">
-                                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="9" Alias="b">
-                                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                                <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:JoinFilter>
-                              <dxl:IsNotFalse>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:IsNotFalse>
-                            </dxl:JoinFilter>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="8.000000" Width="18"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="a">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="1" Alias="b">
-                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="2" Alias="ctid">
-                                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.98453.1.0" TableName="temp_a">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                            <dxl:Materialize Eager="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000819" Rows="27.000000" Width="5"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                                  <dxl:Ident ColId="39" ColName="ColRef_0039" TypeMdid="0.16.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="9" Alias="b">
-                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000774" Rows="27.000000" Width="5"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="39" Alias="ColRef_0039">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="9" Alias="b">
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="9" Alias="b">
-                                      <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="9.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="9" Alias="b">
-                                        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:TableDescriptor Mdid="6.98456.1.0" TableName="temp_b">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:BroadcastMotion>
-                              </dxl:Result>
-                            </dxl:Materialize>
-                          </dxl:NestedLoopJoin>
-                        </dxl:Result>
-                      </dxl:Sort>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
-            </dxl:Aggregate>
+              <dxl:TableDescriptor Mdid="6.98453.1.0" TableName="temp_a">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
           </dxl:Aggregate>
         </dxl:GatherMotion>
       </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Subquery-ExistsAllAggregatesWithDisjuncts.mdp
@@ -639,14 +639,14 @@
     <dxl:Plan Id="0" SpaceSize="3143">
       <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="2712065392.598691" Rows="1.000000" Width="16"/>
+          <dxl:Cost StartupCost="0" TotalCost="2648515.287313" Rows="1.000000" Width="16"/>
         </dxl:Properties>
         <dxl:GroupingColumns/>
         <dxl:ProjList>
           <dxl:ProjElem ColId="28" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="61" ColName="ColRef_0061" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -656,7 +656,7 @@
           <dxl:ProjElem ColId="47" Alias="sum">
             <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="">
               <dxl:ValuesList ParamType="aggargs">
-                <dxl:Ident ColId="62" ColName="ColRef_0062" TypeMdid="0.20.1.0"/>
+                <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
               </dxl:ValuesList>
               <dxl:ValuesList ParamType="aggdirectargs"/>
               <dxl:ValuesList ParamType="aggorder"/>
@@ -667,43 +667,111 @@
         <dxl:Filter/>
         <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="2712065392.598684" Rows="1.000000" Width="16"/>
+            <dxl:Cost StartupCost="0" TotalCost="2648515.287306" Rows="1.000000" Width="16"/>
           </dxl:Properties>
           <dxl:ProjList>
-            <dxl:ProjElem ColId="61" Alias="ColRef_0061">
-              <dxl:Ident ColId="61" ColName="ColRef_0061" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="55" Alias="ColRef_0055">
+              <dxl:Ident ColId="55" ColName="ColRef_0055" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
-            <dxl:ProjElem ColId="62" Alias="ColRef_0062">
-              <dxl:Ident ColId="62" ColName="ColRef_0062" TypeMdid="0.20.1.0"/>
+            <dxl:ProjElem ColId="56" Alias="ColRef_0056">
+              <dxl:Ident ColId="56" ColName="ColRef_0056" TypeMdid="0.20.1.0"/>
             </dxl:ProjElem>
           </dxl:ProjList>
           <dxl:Filter/>
           <dxl:SortingColumnList/>
           <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="2712065392.598624" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="2648515.287247" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:GroupingColumns/>
             <dxl:ProjList>
-              <dxl:ProjElem ColId="61" Alias="ColRef_0061">
+              <dxl:ProjElem ColId="55" Alias="ColRef_0055">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
-                      <dxl:If TypeMdid="0.16.1.0">
-                        <dxl:Comparison ComparisonOperator="&gt;" OperatorMdid="0.413.1.0">
-                          <dxl:Ident ColId="49" ColName="ColRef_0049" TypeMdid="0.20.1.0"/>
-                          <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                        </dxl:Comparison>
-                        <dxl:If TypeMdid="0.16.1.0">
-                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.410.1.0">
-                            <dxl:Ident ColId="51" ColName="ColRef_0051" TypeMdid="0.20.1.0"/>
-                            <dxl:Ident ColId="49" ColName="ColRef_0049" TypeMdid="0.20.1.0"/>
+                      <dxl:SubPlan TypeMdid="0.16.1.0" SubPlanType="AnySubPlan">
+                        <dxl:TestExpr>
+                          <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
+                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
+                            <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
                           </dxl:Comparison>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" IsNull="true"/>
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                        </dxl:If>
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                      </dxl:If>
+                        </dxl:TestExpr>
+                        <dxl:ParamList/>
+                        <dxl:Result>
+                          <dxl:Properties>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                          </dxl:Properties>
+                          <dxl:ProjList>
+                            <dxl:ProjElem ColId="9" Alias="b">
+                              <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                            </dxl:ProjElem>
+                          </dxl:ProjList>
+                          <dxl:Filter/>
+                          <dxl:OneTimeFilter/>
+                          <dxl:Result>
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000810" Rows="27.000000" Width="5"/>
+                            </dxl:Properties>
+                            <dxl:ProjList>
+                              <dxl:ProjElem ColId="53" Alias="ColRef_0053">
+                                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                              </dxl:ProjElem>
+                              <dxl:ProjElem ColId="9" Alias="b">
+                                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                              </dxl:ProjElem>
+                            </dxl:ProjList>
+                            <dxl:Filter/>
+                            <dxl:OneTimeFilter/>
+                            <dxl:Materialize Eager="false">
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000765" Rows="27.000000" Width="4"/>
+                              </dxl:Properties>
+                              <dxl:ProjList>
+                                <dxl:ProjElem ColId="9" Alias="b">
+                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                </dxl:ProjElem>
+                              </dxl:ProjList>
+                              <dxl:Filter/>
+                              <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
+                                <dxl:Properties>
+                                  <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
+                                </dxl:Properties>
+                                <dxl:ProjList>
+                                  <dxl:ProjElem ColId="9" Alias="b">
+                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                  </dxl:ProjElem>
+                                </dxl:ProjList>
+                                <dxl:Filter/>
+                                <dxl:SortingColumnList/>
+                                <dxl:TableScan>
+                                  <dxl:Properties>
+                                    <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="9.000000" Width="4"/>
+                                  </dxl:Properties>
+                                  <dxl:ProjList>
+                                    <dxl:ProjElem ColId="9" Alias="b">
+                                      <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
+                                    </dxl:ProjElem>
+                                  </dxl:ProjList>
+                                  <dxl:Filter/>
+                                  <dxl:TableDescriptor Mdid="6.98456.1.0" TableName="temp_b">
+                                    <dxl:Columns>
+                                      <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="10" Attno="2" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                                      <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                                      <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                                    </dxl:Columns>
+                                  </dxl:TableDescriptor>
+                                </dxl:TableScan>
+                              </dxl:BroadcastMotion>
+                            </dxl:Materialize>
+                          </dxl:Result>
+                        </dxl:Result>
+                      </dxl:SubPlan>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                       <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
                     </dxl:If>
@@ -713,7 +781,7 @@
                   <dxl:ValuesList ParamType="aggdistinct"/>
                 </dxl:AggFunc>
               </dxl:ProjElem>
-              <dxl:ProjElem ColId="62" Alias="ColRef_0062">
+              <dxl:ProjElem ColId="56" Alias="ColRef_0056">
                 <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="">
                   <dxl:ValuesList ParamType="aggargs">
                     <dxl:If TypeMdid="0.23.1.0">
@@ -743,7 +811,7 @@
                               <dxl:Cost StartupCost="0" TotalCost="1324034.164096" Rows="135.375000" Width="5"/>
                             </dxl:Properties>
                             <dxl:ProjList>
-                              <dxl:ProjElem ColId="52" Alias="ColRef_0052">
+                              <dxl:ProjElem ColId="54" Alias="ColRef_0054">
                                 <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
                               </dxl:ProjElem>
                               <dxl:ProjElem ColId="29" Alias="b">
@@ -774,7 +842,7 @@
                                 </dxl:Or>
                               </dxl:Filter>
                               <dxl:OneTimeFilter/>
-                              <dxl:Materialize Eager="false">
+                              <dxl:Materialize Eager="true">
                                 <dxl:Properties>
                                   <dxl:Cost StartupCost="0" TotalCost="1324034.107019" Rows="216.000000" Width="12"/>
                                 </dxl:Properties>
@@ -918,392 +986,33 @@
               </dxl:ProjElem>
             </dxl:ProjList>
             <dxl:Filter/>
-            <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
+            <dxl:TableScan>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="1324036.164175" Rows="8.000000" Width="24"/>
+                <dxl:Cost StartupCost="0" TotalCost="1324049.026552" Rows="1000.000000" Width="9"/>
               </dxl:Properties>
-              <dxl:GroupingColumns>
-                <dxl:GroupingColumn ColId="0"/>
-                <dxl:GroupingColumn ColId="1"/>
-                <dxl:GroupingColumn ColId="2"/>
-                <dxl:GroupingColumn ColId="8"/>
-              </dxl:GroupingColumns>
               <dxl:ProjList>
-                <dxl:ProjElem ColId="49" Alias="ColRef_0049">
-                  <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="16">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="51" Alias="ColRef_0051">
-                  <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Final" AggKind="n" AggArgTypes="23">
-                    <dxl:ValuesList ParamType="aggargs">
-                      <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
-                    </dxl:ValuesList>
-                    <dxl:ValuesList ParamType="aggdirectargs"/>
-                    <dxl:ValuesList ParamType="aggorder"/>
-                    <dxl:ValuesList ParamType="aggdistinct"/>
-                  </dxl:AggFunc>
-                </dxl:ProjElem>
                 <dxl:ProjElem ColId="0" Alias="a">
                   <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
                 <dxl:ProjElem ColId="1" Alias="b">
                   <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
                 </dxl:ProjElem>
-                <dxl:ProjElem ColId="2" Alias="ctid">
-                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
               </dxl:ProjList>
               <dxl:Filter/>
-              <dxl:Sort SortDiscardDuplicates="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="1324036.164048" Rows="8.000000" Width="34"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="0" Alias="a">
-                    <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="1" Alias="b">
-                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="2" Alias="ctid">
-                    <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                    <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                    <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                    <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:SortingColumnList>
-                  <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                  <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                </dxl:SortingColumnList>
-                <dxl:LimitCount/>
-                <dxl:LimitOffset/>
-                <dxl:RedistributeMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="1324036.163321" Rows="8.000000" Width="34"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="0" Alias="a">
-                      <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="1" Alias="b">
-                      <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="2" Alias="ctid">
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                      <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                      <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:HashExprList>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                    </dxl:HashExpr>
-                    <dxl:HashExpr>
-                      <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                    </dxl:HashExpr>
-                  </dxl:HashExprList>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="0" Alias="a">
-                        <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="1" Alias="b">
-                        <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="2" Alias="ctid">
-                        <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                        <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                        <dxl:Ident ColId="59" ColName="ColRef_0059" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                        <dxl:Ident ColId="60" ColName="ColRef_0060" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Aggregate AggregationStrategy="Sorted" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="1324036.163037" Rows="8.000000" Width="34"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns>
-                        <dxl:GroupingColumn ColId="0"/>
-                        <dxl:GroupingColumn ColId="1"/>
-                        <dxl:GroupingColumn ColId="2"/>
-                        <dxl:GroupingColumn ColId="8"/>
-                      </dxl:GroupingColumns>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="59" Alias="ColRef_0059">
-                          <dxl:AggFunc AggMdid="0.2147.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="16">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="60" Alias="ColRef_0060">
-                          <dxl:AggFunc AggMdid="0.2108.1.0" AggDistinct="false" AggStage="Partial" AggKind="n" AggArgTypes="23">
-                            <dxl:ValuesList ParamType="aggargs">
-                              <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.23.1.0"/>
-                            </dxl:ValuesList>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="0" Alias="a">
-                          <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="1" Alias="b">
-                          <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="2" Alias="ctid">
-                          <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                        </dxl:ProjElem>
-                        <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                          <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:Sort SortDiscardDuplicates="false">
-                        <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="1324036.162639" Rows="32.000000" Width="23"/>
-                        </dxl:Properties>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                            <dxl:Ident ColId="50" ColName="ColRef_0050" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="0" Alias="a">
-                            <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="1" Alias="b">
-                            <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="2" Alias="ctid">
-                            <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                            <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                          </dxl:ProjElem>
-                          <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                            <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
-                        <dxl:Filter/>
-                        <dxl:SortingColumnList>
-                          <dxl:SortingColumn ColId="2" SortOperatorMdid="0.2799.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                          <dxl:SortingColumn ColId="8" SortOperatorMdid="0.97.1.0" SortOperatorName="&lt;" SortNullsFirst="false"/>
-                        </dxl:SortingColumnList>
-                        <dxl:LimitCount/>
-                        <dxl:LimitOffset/>
-                        <dxl:Result>
-                          <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="1324036.157889" Rows="32.000000" Width="23"/>
-                          </dxl:Properties>
-                          <dxl:ProjList>
-                            <dxl:ProjElem ColId="50" Alias="ColRef_0050">
-                              <dxl:If TypeMdid="0.23.1.0">
-                                <dxl:IsNull>
-                                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                    <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:Comparison>
-                                </dxl:IsNull>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                                <dxl:ConstValue TypeMdid="0.23.1.0" Value="0"/>
-                              </dxl:If>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="0" Alias="a">
-                              <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="1" Alias="b">
-                              <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="2" Alias="ctid">
-                              <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                              <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:ProjElem>
-                            <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                              <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
-                            </dxl:ProjElem>
-                          </dxl:ProjList>
-                          <dxl:Filter/>
-                          <dxl:OneTimeFilter/>
-                          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                            <dxl:Properties>
-                              <dxl:Cost StartupCost="0" TotalCost="1324036.157643" Rows="32.000000" Width="23"/>
-                            </dxl:Properties>
-                            <dxl:ProjList>
-                              <dxl:ProjElem ColId="0" Alias="a">
-                                <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="1" Alias="b">
-                                <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="2" Alias="ctid">
-                                <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                                <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="9" Alias="b">
-                                <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                              </dxl:ProjElem>
-                              <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                                <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
-                              </dxl:ProjElem>
-                            </dxl:ProjList>
-                            <dxl:Filter/>
-                            <dxl:JoinFilter>
-                              <dxl:IsNotFalse>
-                                <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.96.1.0">
-                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:Comparison>
-                              </dxl:IsNotFalse>
-                            </dxl:JoinFilter>
-                            <dxl:TableScan>
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000056" Rows="8.000000" Width="18"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="0" Alias="a">
-                                  <dxl:Ident ColId="0" ColName="a" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="1" Alias="b">
-                                  <dxl:Ident ColId="1" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="2" Alias="ctid">
-                                  <dxl:Ident ColId="2" ColName="ctid" TypeMdid="0.27.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="8" Alias="gp_segment_id">
-                                  <dxl:Ident ColId="8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:TableDescriptor Mdid="6.98453.1.0" TableName="temp_a">
-                                <dxl:Columns>
-                                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                </dxl:Columns>
-                              </dxl:TableDescriptor>
-                            </dxl:TableScan>
-                            <dxl:Materialize Eager="false">
-                              <dxl:Properties>
-                                <dxl:Cost StartupCost="0" TotalCost="431.000819" Rows="27.000000" Width="5"/>
-                              </dxl:Properties>
-                              <dxl:ProjList>
-                                <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                                  <dxl:Ident ColId="48" ColName="ColRef_0048" TypeMdid="0.16.1.0"/>
-                                </dxl:ProjElem>
-                                <dxl:ProjElem ColId="9" Alias="b">
-                                  <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                </dxl:ProjElem>
-                              </dxl:ProjList>
-                              <dxl:Filter/>
-                              <dxl:Result>
-                                <dxl:Properties>
-                                  <dxl:Cost StartupCost="0" TotalCost="431.000774" Rows="27.000000" Width="5"/>
-                                </dxl:Properties>
-                                <dxl:ProjList>
-                                  <dxl:ProjElem ColId="48" Alias="ColRef_0048">
-                                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                                  </dxl:ProjElem>
-                                  <dxl:ProjElem ColId="9" Alias="b">
-                                    <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                  </dxl:ProjElem>
-                                </dxl:ProjList>
-                                <dxl:Filter/>
-                                <dxl:OneTimeFilter/>
-                                <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
-                                  <dxl:Properties>
-                                    <dxl:Cost StartupCost="0" TotalCost="431.000729" Rows="27.000000" Width="4"/>
-                                  </dxl:Properties>
-                                  <dxl:ProjList>
-                                    <dxl:ProjElem ColId="9" Alias="b">
-                                      <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                    </dxl:ProjElem>
-                                  </dxl:ProjList>
-                                  <dxl:Filter/>
-                                  <dxl:SortingColumnList/>
-                                  <dxl:TableScan>
-                                    <dxl:Properties>
-                                      <dxl:Cost StartupCost="0" TotalCost="431.000063" Rows="9.000000" Width="4"/>
-                                    </dxl:Properties>
-                                    <dxl:ProjList>
-                                      <dxl:ProjElem ColId="9" Alias="b">
-                                        <dxl:Ident ColId="9" ColName="b" TypeMdid="0.23.1.0"/>
-                                      </dxl:ProjElem>
-                                    </dxl:ProjList>
-                                    <dxl:Filter/>
-                                    <dxl:TableDescriptor Mdid="6.98456.1.0" TableName="temp_b">
-                                      <dxl:Columns>
-                                        <dxl:Column ColId="9" Attno="1" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="10" Attno="2" ColName="c" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="11" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                                        <dxl:Column ColId="12" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="13" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="14" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="15" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="16" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                                        <dxl:Column ColId="17" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                                      </dxl:Columns>
-                                    </dxl:TableDescriptor>
-                                  </dxl:TableScan>
-                                </dxl:BroadcastMotion>
-                              </dxl:Result>
-                            </dxl:Materialize>
-                          </dxl:NestedLoopJoin>
-                        </dxl:Result>
-                      </dxl:Sort>
-                    </dxl:Aggregate>
-                  </dxl:Result>
-                </dxl:RedistributeMotion>
-              </dxl:Sort>
-            </dxl:Aggregate>
+              <dxl:TableDescriptor Mdid="6.98453.1.0" TableName="temp_a">
+                <dxl:Columns>
+                  <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="1" Attno="2" ColName="b" TypeMdid="0.23.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="2" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                  <dxl:Column ColId="3" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="4" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="5" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="6" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="7" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                  <dxl:Column ColId="8" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+                </dxl:Columns>
+              </dxl:TableDescriptor>
+            </dxl:TableScan>
           </dxl:Aggregate>
         </dxl:GatherMotion>
       </dxl:Aggregate>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideArrayRef.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideArrayRef.mdp
@@ -277,7 +277,7 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="2">
+    <dxl:Plan Id="0" SpaceSize="5">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1324033.071390" Rows="1.000000" Width="4"/>

--- a/src/backend/gporca/data/dxl/minidump/SubqueryInsideArrayRefIndexList.mdp
+++ b/src/backend/gporca/data/dxl/minidump/SubqueryInsideArrayRefIndexList.mdp
@@ -297,10 +297,10 @@
         </dxl:LogicalGet>
       </dxl:LogicalProject>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="4">
+    <dxl:Plan Id="0" SpaceSize="20">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="904755234.476809" Rows="1.000000" Width="4"/>
+          <dxl:Cost StartupCost="0" TotalCost="883557.353763" Rows="1.000000" Width="4"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="18" Alias="a">
@@ -311,182 +311,59 @@
         <dxl:SortingColumnList/>
         <dxl:Result>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="904755234.476794" Rows="1.000000" Width="4"/>
+            <dxl:Cost StartupCost="0" TotalCost="883557.353748" Rows="1.000000" Width="4"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="18" Alias="a">
               <dxl:ArrayRef ElementType="0.23.1.0" ArrayType="0.1007.1.0" TypeMdid="0.23.1.0">
                 <dxl:ArrayIndexList Bound="Lower"/>
                 <dxl:ArrayIndexList Bound="Upper">
-                  <dxl:Ident ColId="9" ColName="?column?" TypeMdid="0.23.1.0"/>
-                </dxl:ArrayIndexList>
-                <dxl:RefExpr>
-                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
-                </dxl:RefExpr>
-                <dxl:AssignExpr/>
-              </dxl:ArrayRef>
-            </dxl:ProjElem>
-          </dxl:ProjList>
-          <dxl:Filter/>
-          <dxl:OneTimeFilter/>
-          <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-            <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="904755234.476792" Rows="4.000000" Width="12"/>
-            </dxl:Properties>
-            <dxl:ProjList>
-              <dxl:ProjElem ColId="9" Alias="?column?">
-                <dxl:Ident ColId="9" ColName="?column?" TypeMdid="0.23.1.0"/>
-              </dxl:ProjElem>
-              <dxl:ProjElem ColId="10" Alias="a">
-                <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
-              </dxl:ProjElem>
-            </dxl:ProjList>
-            <dxl:Filter/>
-            <dxl:JoinFilter>
-              <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-            </dxl:JoinFilter>
-            <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="882688.032580" Rows="2.000000" Width="4"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="9" Alias="?column?">
-                  <dxl:Ident ColId="9" ColName="?column?" TypeMdid="0.23.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:JoinFilter>
-                <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-              </dxl:JoinFilter>
-              <dxl:TableScan>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.000007" Rows="1.000000" Width="1"/>
-                </dxl:Properties>
-                <dxl:ProjList/>
-                <dxl:Filter/>
-                <dxl:TableDescriptor Mdid="6.41310.1.0" TableName="foo" LockMode="1" AclMode="2">
-                  <dxl:Columns>
-                    <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1007.1.0" ColWidth="8"/>
-                    <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
-                    <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
-                    <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
-                  </dxl:Columns>
-                </dxl:TableDescriptor>
-              </dxl:TableScan>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="0.000009" Rows="1.000000" Width="4"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="9" Alias="?column?">
-                    <dxl:Ident ColId="9" ColName="?column?" TypeMdid="0.23.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:Result>
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="9" Alias="?column?">
-                      <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:OneTimeFilter/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="8" Alias="">
-                        <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                  </dxl:Result>
-                </dxl:Result>
-              </dxl:Materialize>
-            </dxl:NestedLoopJoin>
-            <dxl:Assert ErrorCode="P0003">
-              <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="431.001008" Rows="3.000000" Width="8"/>
-              </dxl:Properties>
-              <dxl:ProjList>
-                <dxl:ProjElem ColId="10" Alias="a">
-                  <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:AssertConstraintList>
-                <dxl:AssertConstraint ErrorMessage="Expected no more than one row to be returned by expression">
-                  <dxl:Comparison ComparisonOperator="=" OperatorMdid="0.416.1.0">
-                    <dxl:Ident ColId="19" ColName="row_number" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
-                  </dxl:Comparison>
-                </dxl:AssertConstraint>
-              </dxl:AssertConstraintList>
-              <dxl:Materialize Eager="false">
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="431.001000" Rows="3.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="10" Alias="a">
-                    <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="19" Alias="row_number">
-                    <dxl:Ident ColId="19" ColName="row_number" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:BroadcastMotion InputSegments="-1" OutputSegments="0,1,2">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="431.000984" Rows="3.000000" Width="16"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="10" Alias="a">
-                      <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="19" Alias="row_number">
-                      <dxl:Ident ColId="19" ColName="row_number" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:SortingColumnList/>
-                  <dxl:Result>
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000" Width="16"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="10" Alias="a">
-                        <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
-                      </dxl:ProjElem>
-                      <dxl:ProjElem ColId="19" Alias="row_number">
-                        <dxl:Ident ColId="19" ColName="row_number" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:OneTimeFilter/>
-                    <dxl:Window PartitionColumns="">
+                  <dxl:SubPlan TypeMdid="0.23.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList/>
+                    <dxl:Result>
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000" Width="16"/>
+                        <dxl:Cost StartupCost="0" TotalCost="0.000005" Rows="1.000000" Width="4"/>
                       </dxl:Properties>
                       <dxl:ProjList>
-                        <dxl:ProjElem ColId="19" Alias="row_number">
-                          <dxl:WindowFunc Mdid="0.3100.1.0" TypeMdid="0.20.1.0" Distinct="false" WindowStarArg="false" WindowSimpleAgg="false" WindowStrategy="Immediate" WinSpecPos="0"/>
+                        <dxl:ProjElem ColId="9" Alias="?column?">
+                          <dxl:ConstValue TypeMdid="0.23.1.0" Value="1"/>
                         </dxl:ProjElem>
+                      </dxl:ProjList>
+                      <dxl:Filter/>
+                      <dxl:OneTimeFilter/>
+                      <dxl:Result>
+                        <dxl:Properties>
+                          <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        </dxl:Properties>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="8" Alias="">
+                            <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
+                        <dxl:Filter/>
+                        <dxl:OneTimeFilter/>
+                      </dxl:Result>
+                    </dxl:Result>
+                  </dxl:SubPlan>
+                </dxl:ArrayIndexList>
+                <dxl:RefExpr>
+                  <dxl:SubPlan TypeMdid="0.1007.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList/>
+                    <dxl:Materialize Eager="false">
+                      <dxl:Properties>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000473" Rows="3.000000" Width="8"/>
+                      </dxl:Properties>
+                      <dxl:ProjList>
                         <dxl:ProjElem ColId="10" Alias="a">
                           <dxl:Ident ColId="10" ColName="a" TypeMdid="0.1007.1.0"/>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
+                      <dxl:BroadcastMotion InputSegments="0,1,2" OutputSegments="0,1,2">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000125" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000465" Rows="3.000000" Width="8"/>
                         </dxl:Properties>
                         <dxl:ProjList>
                           <dxl:ProjElem ColId="10" Alias="a">
@@ -518,18 +395,35 @@
                             </dxl:Columns>
                           </dxl:TableDescriptor>
                         </dxl:TableScan>
-                      </dxl:GatherMotion>
-                      <dxl:WindowKeyList>
-                        <dxl:WindowKey>
-                          <dxl:SortingColumnList/>
-                        </dxl:WindowKey>
-                      </dxl:WindowKeyList>
-                    </dxl:Window>
-                  </dxl:Result>
-                </dxl:BroadcastMotion>
-              </dxl:Materialize>
-            </dxl:Assert>
-          </dxl:NestedLoopJoin>
+                      </dxl:BroadcastMotion>
+                    </dxl:Materialize>
+                  </dxl:SubPlan>
+                </dxl:RefExpr>
+                <dxl:AssignExpr/>
+              </dxl:ArrayRef>
+            </dxl:ProjElem>
+          </dxl:ProjList>
+          <dxl:Filter/>
+          <dxl:OneTimeFilter/>
+          <dxl:TableScan>
+            <dxl:Properties>
+              <dxl:Cost StartupCost="0" TotalCost="882695.332034" Rows="1000.000000" Width="4"/>
+            </dxl:Properties>
+            <dxl:ProjList/>
+            <dxl:Filter/>
+            <dxl:TableDescriptor Mdid="6.41310.1.0" TableName="foo" LockMode="1" AclMode="2">
+              <dxl:Columns>
+                <dxl:Column ColId="0" Attno="1" ColName="a" TypeMdid="0.1007.1.0" ColWidth="8"/>
+                <dxl:Column ColId="1" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0" ColWidth="6"/>
+                <dxl:Column ColId="2" Attno="-2" ColName="xmin" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="3" Attno="-3" ColName="cmin" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="4" Attno="-4" ColName="xmax" TypeMdid="0.28.1.0" ColWidth="4"/>
+                <dxl:Column ColId="5" Attno="-5" ColName="cmax" TypeMdid="0.29.1.0" ColWidth="4"/>
+                <dxl:Column ColId="6" Attno="-6" ColName="tableoid" TypeMdid="0.26.1.0" ColWidth="4"/>
+                <dxl:Column ColId="7" Attno="-7" ColName="gp_segment_id" TypeMdid="0.23.1.0" ColWidth="4"/>
+              </dxl:Columns>
+            </dxl:TableDescriptor>
+          </dxl:TableScan>
         </dxl:Result>
       </dxl:GatherMotion>
     </dxl:Plan>

--- a/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TVF-With-Deep-Subq-Args.mdp
@@ -291,7 +291,7 @@ SELECT generate_series((
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.123090" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="51" Alias="ColRef_0024">
@@ -302,107 +302,34 @@ SELECT generate_series((
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.123090" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0024">
-                  <dxl:Coalesce TypeMdid="0.20.1.0">
-                    <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                  </dxl:Coalesce>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="ColRef_0025">
-                  <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
-                    <dxl:Coalesce TypeMdid="0.20.1.0">
-                      <dxl:Ident ColId="77" ColName="ColRef_0077" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:Coalesce>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:OpExpr>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="76" Alias="ColRef_0076">
-                    <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="77" Alias="ColRef_0077">
-                    <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="64" Alias="count">
-                      <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="75" Alias="count">
-                      <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="64" Alias="count">
-                        <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
-                    <dxl:Result>
+                  <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="53" Alias="ColRef_0023">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                    <dxl:Materialize Eager="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="64" Alias="count">
-                          <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs"/>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Materialize Eager="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="64" Alias="count">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
+                        <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                           <dxl:Properties>
@@ -431,65 +358,84 @@ SELECT generate_series((
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
                         </dxl:GatherMotion>
-                      </dxl:Aggregate>
-                    </dxl:Materialize>
-                  </dxl:NestedLoopJoin>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="75" Alias="count">
-                        <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="75" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                      </dxl:Materialize>
+                    </dxl:Aggregate>
+                  </dxl:SubPlan>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="52" Alias="ColRef_0025">
+                  <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
+                    <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+                      <dxl:TestExpr/>
+                      <dxl:ParamList/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
-                        <dxl:ProjList/>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="75" Alias="count">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                              <dxl:ValuesList ParamType="aggargs"/>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:GatherMotion>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
+                          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList/>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:GatherMotion>
+                        </dxl:Materialize>
+                      </dxl:Aggregate>
+                    </dxl:SubPlan>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:OpExpr>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="53" Alias="ColRef_0023">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
               </dxl:Result>
             </dxl:Result>
           </dxl:Result>
@@ -500,7 +446,7 @@ SELECT generate_series((
           <dxl:ParamList/>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+              <dxl:Cost StartupCost="0" TotalCost="1724.123090" Rows="1.000000" Width="16"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="52" Alias="ColRef_0025">
@@ -511,107 +457,34 @@ SELECT generate_series((
             <dxl:OneTimeFilter/>
             <dxl:Result>
               <dxl:Properties>
-                <dxl:Cost StartupCost="0" TotalCost="6896.001855" Rows="1.000000" Width="16"/>
+                <dxl:Cost StartupCost="0" TotalCost="1724.123090" Rows="1.000000" Width="16"/>
               </dxl:Properties>
               <dxl:ProjList>
                 <dxl:ProjElem ColId="51" Alias="ColRef_0024">
-                  <dxl:Coalesce TypeMdid="0.20.1.0">
-                    <dxl:Ident ColId="76" ColName="ColRef_0076" TypeMdid="0.20.1.0"/>
-                    <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                  </dxl:Coalesce>
-                </dxl:ProjElem>
-                <dxl:ProjElem ColId="52" Alias="ColRef_0025">
-                  <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
-                    <dxl:Coalesce TypeMdid="0.20.1.0">
-                      <dxl:Ident ColId="77" ColName="ColRef_0077" TypeMdid="0.20.1.0"/>
-                      <dxl:ConstValue TypeMdid="0.20.1.0" Value="0"/>
-                    </dxl:Coalesce>
-                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
-                  </dxl:OpExpr>
-                </dxl:ProjElem>
-              </dxl:ProjList>
-              <dxl:Filter/>
-              <dxl:OneTimeFilter/>
-              <dxl:Result>
-                <dxl:Properties>
-                  <dxl:Cost StartupCost="0" TotalCost="6896.001839" Rows="4.000000" Width="16"/>
-                </dxl:Properties>
-                <dxl:ProjList>
-                  <dxl:ProjElem ColId="76" Alias="ColRef_0076">
-                    <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                  <dxl:ProjElem ColId="77" Alias="ColRef_0077">
-                    <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                  </dxl:ProjElem>
-                </dxl:ProjList>
-                <dxl:Filter/>
-                <dxl:OneTimeFilter/>
-                <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                  <dxl:Properties>
-                    <dxl:Cost StartupCost="0" TotalCost="6896.001775" Rows="4.000000" Width="16"/>
-                  </dxl:Properties>
-                  <dxl:ProjList>
-                    <dxl:ProjElem ColId="64" Alias="count">
-                      <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                    <dxl:ProjElem ColId="75" Alias="count">
-                      <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                    </dxl:ProjElem>
-                  </dxl:ProjList>
-                  <dxl:Filter/>
-                  <dxl:JoinFilter>
-                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                  </dxl:JoinFilter>
-                  <dxl:NestedLoopJoin JoinType="Left" IndexNestedLoopJoin="false" OuterRefAsParam="false">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="862.000117" Rows="2.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="64" Alias="count">
-                        <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:JoinFilter>
-                      <dxl:ConstValue TypeMdid="0.16.1.0" Value="true"/>
-                    </dxl:JoinFilter>
-                    <dxl:Result>
+                  <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+                    <dxl:TestExpr/>
+                    <dxl:ParamList/>
+                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                       <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                        <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                       </dxl:Properties>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="53" Alias="ColRef_0023">
-                          <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:OneTimeFilter/>
-                    </dxl:Result>
-                    <dxl:Materialize Eager="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
+                      <dxl:GroupingColumns/>
                       <dxl:ProjList>
                         <dxl:ProjElem ColId="64" Alias="count">
-                          <dxl:Ident ColId="64" ColName="count" TypeMdid="0.20.1.0"/>
+                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                            <dxl:ValuesList ParamType="aggargs"/>
+                            <dxl:ValuesList ParamType="aggdirectargs"/>
+                            <dxl:ValuesList ParamType="aggorder"/>
+                            <dxl:ValuesList ParamType="aggdistinct"/>
+                          </dxl:AggFunc>
                         </dxl:ProjElem>
                       </dxl:ProjList>
                       <dxl:Filter/>
-                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
+                      <dxl:Materialize Eager="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                         </dxl:Properties>
-                        <dxl:GroupingColumns/>
-                        <dxl:ProjList>
-                          <dxl:ProjElem ColId="64" Alias="count">
-                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                              <dxl:ValuesList ParamType="aggargs"/>
-                              <dxl:ValuesList ParamType="aggdirectargs"/>
-                              <dxl:ValuesList ParamType="aggorder"/>
-                              <dxl:ValuesList ParamType="aggdistinct"/>
-                            </dxl:AggFunc>
-                          </dxl:ProjElem>
-                        </dxl:ProjList>
+                        <dxl:ProjList/>
                         <dxl:Filter/>
                         <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
                           <dxl:Properties>
@@ -640,65 +513,84 @@ SELECT generate_series((
                             </dxl:TableDescriptor>
                           </dxl:TableScan>
                         </dxl:GatherMotion>
-                      </dxl:Aggregate>
-                    </dxl:Materialize>
-                  </dxl:NestedLoopJoin>
-                  <dxl:Materialize Eager="true">
-                    <dxl:Properties>
-                      <dxl:Cost StartupCost="0" TotalCost="431.000025" Rows="1.000000" Width="8"/>
-                    </dxl:Properties>
-                    <dxl:ProjList>
-                      <dxl:ProjElem ColId="75" Alias="count">
-                        <dxl:Ident ColId="75" ColName="count" TypeMdid="0.20.1.0"/>
-                      </dxl:ProjElem>
-                    </dxl:ProjList>
-                    <dxl:Filter/>
-                    <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
-                      <dxl:Properties>
-                        <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="8"/>
-                      </dxl:Properties>
-                      <dxl:GroupingColumns/>
-                      <dxl:ProjList>
-                        <dxl:ProjElem ColId="75" Alias="count">
-                          <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
-                            <dxl:ValuesList ParamType="aggargs"/>
-                            <dxl:ValuesList ParamType="aggdirectargs"/>
-                            <dxl:ValuesList ParamType="aggorder"/>
-                            <dxl:ValuesList ParamType="aggdistinct"/>
-                          </dxl:AggFunc>
-                        </dxl:ProjElem>
-                      </dxl:ProjList>
-                      <dxl:Filter/>
-                      <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                      </dxl:Materialize>
+                    </dxl:Aggregate>
+                  </dxl:SubPlan>
+                </dxl:ProjElem>
+                <dxl:ProjElem ColId="52" Alias="ColRef_0025">
+                  <dxl:OpExpr OperatorName="/" OperatorMdid="0.691.1.0">
+                    <dxl:SubPlan TypeMdid="0.20.1.0" SubPlanType="ScalarSubPlan">
+                      <dxl:TestExpr/>
+                      <dxl:ParamList/>
+                      <dxl:Aggregate AggregationStrategy="Plain" StreamSafe="false">
                         <dxl:Properties>
-                          <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                          <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="8"/>
                         </dxl:Properties>
-                        <dxl:ProjList/>
+                        <dxl:GroupingColumns/>
+                        <dxl:ProjList>
+                          <dxl:ProjElem ColId="75" Alias="count">
+                            <dxl:AggFunc AggMdid="0.2803.1.0" AggDistinct="false" AggStage="Normal" AggKind="n" AggArgTypes="">
+                              <dxl:ValuesList ParamType="aggargs"/>
+                              <dxl:ValuesList ParamType="aggdirectargs"/>
+                              <dxl:ValuesList ParamType="aggorder"/>
+                              <dxl:ValuesList ParamType="aggdistinct"/>
+                            </dxl:AggFunc>
+                          </dxl:ProjElem>
+                        </dxl:ProjList>
                         <dxl:Filter/>
-                        <dxl:SortingColumnList/>
-                        <dxl:TableScan>
+                        <dxl:Materialize Eager="true">
                           <dxl:Properties>
-                            <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                            <dxl:Cost StartupCost="0" TotalCost="431.000018" Rows="1.000000" Width="1"/>
                           </dxl:Properties>
                           <dxl:ProjList/>
                           <dxl:Filter/>
-                          <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
-                            <dxl:Columns>
-                              <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
-                              <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
-                              <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
-                              <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
-                              <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
-                              <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
-                            </dxl:Columns>
-                          </dxl:TableDescriptor>
-                        </dxl:TableScan>
-                      </dxl:GatherMotion>
-                    </dxl:Aggregate>
-                  </dxl:Materialize>
-                </dxl:NestedLoopJoin>
+                          <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
+                            <dxl:Properties>
+                              <dxl:Cost StartupCost="0" TotalCost="431.000017" Rows="1.000000" Width="1"/>
+                            </dxl:Properties>
+                            <dxl:ProjList/>
+                            <dxl:Filter/>
+                            <dxl:SortingColumnList/>
+                            <dxl:TableScan>
+                              <dxl:Properties>
+                                <dxl:Cost StartupCost="0" TotalCost="431.000012" Rows="1.000000" Width="1"/>
+                              </dxl:Properties>
+                              <dxl:ProjList/>
+                              <dxl:Filter/>
+                              <dxl:TableDescriptor Mdid="6.156718.1.1" TableName="x">
+                                <dxl:Columns>
+                                  <dxl:Column ColId="65" Attno="1" ColName="i" TypeMdid="0.23.1.0"/>
+                                  <dxl:Column ColId="68" Attno="-1" ColName="ctid" TypeMdid="0.27.1.0"/>
+                                  <dxl:Column ColId="69" Attno="-3" ColName="xmin" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="70" Attno="-4" ColName="cmin" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="71" Attno="-5" ColName="xmax" TypeMdid="0.28.1.0"/>
+                                  <dxl:Column ColId="72" Attno="-6" ColName="cmax" TypeMdid="0.29.1.0"/>
+                                  <dxl:Column ColId="73" Attno="-7" ColName="tableoid" TypeMdid="0.26.1.0"/>
+                                  <dxl:Column ColId="74" Attno="-8" ColName="gp_segment_id" TypeMdid="0.23.1.0"/>
+                                </dxl:Columns>
+                              </dxl:TableDescriptor>
+                            </dxl:TableScan>
+                          </dxl:GatherMotion>
+                        </dxl:Materialize>
+                      </dxl:Aggregate>
+                    </dxl:SubPlan>
+                    <dxl:ConstValue TypeMdid="0.23.1.0" Value="2"/>
+                  </dxl:OpExpr>
+                </dxl:ProjElem>
+              </dxl:ProjList>
+              <dxl:Filter/>
+              <dxl:OneTimeFilter/>
+              <dxl:Result>
+                <dxl:Properties>
+                  <dxl:Cost StartupCost="0" TotalCost="0.000001" Rows="1.000000" Width="1"/>
+                </dxl:Properties>
+                <dxl:ProjList>
+                  <dxl:ProjElem ColId="53" Alias="ColRef_0023">
+                    <dxl:ConstValue TypeMdid="0.16.1.0" Value="false"/>
+                  </dxl:ProjElem>
+                </dxl:ProjList>
+                <dxl:Filter/>
+                <dxl:OneTimeFilter/>
               </dxl:Result>
             </dxl:Result>
           </dxl:Result>

--- a/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
+++ b/src/backend/gporca/data/dxl/minidump/TranslateFilterWithCTEAndTableScanIntoFilterAndOneTimeFilter.mdp
@@ -596,7 +596,7 @@
     <dxl:Plan Id="0" SpaceSize="616">
       <dxl:GatherMotion InputSegments="0,1,2" OutputSegments="-1">
         <dxl:Properties>
-          <dxl:Cost StartupCost="0" TotalCost="1852062876647.470947" Rows="10.000001" Width="12"/>
+          <dxl:Cost StartupCost="0" TotalCost="1767988.635053" Rows="10.000001" Width="12"/>
         </dxl:Properties>
         <dxl:ProjList>
           <dxl:ProjElem ColId="55" Alias="?column?">
@@ -613,7 +613,7 @@
         <dxl:SortingColumnList/>
         <dxl:Sequence>
           <dxl:Properties>
-            <dxl:Cost StartupCost="0" TotalCost="1852062876647.470459" Rows="10.000001" Width="12"/>
+            <dxl:Cost StartupCost="0" TotalCost="1767988.634606" Rows="10.000001" Width="12"/>
           </dxl:Properties>
           <dxl:ProjList>
             <dxl:ProjElem ColId="55" Alias="?column?">
@@ -712,7 +712,7 @@
           </dxl:CTEProducer>
           <dxl:Result>
             <dxl:Properties>
-              <dxl:Cost StartupCost="0" TotalCost="1852062875785.468994" Rows="10.000001" Width="12"/>
+              <dxl:Cost StartupCost="0" TotalCost="1767126.633024" Rows="10.000001" Width="12"/>
             </dxl:Properties>
             <dxl:ProjList>
               <dxl:ProjElem ColId="55" Alias="?column?">
@@ -825,7 +825,7 @@
                             <dxl:Cast TypeMdid="0.701.1.0" FuncId="0.316.1.0">
                               <dxl:Ident ColId="18" ColName="a" TypeMdid="0.23.1.0"/>
                             </dxl:Cast>
-                            <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0"/>
+                            <dxl:FuncExpr FuncId="0.1598.1.0" FuncRetSet="false" TypeMdid="0.701.1.0" FuncVariadic="false"/>
                           </dxl:Comparison>
                         </dxl:Filter>
                         <dxl:OneTimeFilter>

--- a/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-InnerChild.mdp
+++ b/src/backend/gporca/data/dxl/minidump/Union-OuterRefs-InnerChild.mdp
@@ -314,7 +314,7 @@ select * from y where m in (select 1 union select n from x);
         </dxl:LogicalGet>
       </dxl:LogicalSelect>
     </dxl:Query>
-    <dxl:Plan Id="0" SpaceSize="24">
+    <dxl:Plan Id="0" SpaceSize="36">
       <dxl:GatherMotion InputSegments="0,1" OutputSegments="-1">
         <dxl:Properties>
           <dxl:Cost StartupCost="0" TotalCost="1293.000516" Rows="1.000000" Width="16"/>

--- a/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
+++ b/src/backend/gporca/libgpopt/include/gpopt/base/CUtils.h
@@ -586,6 +586,9 @@ public:
 	// check if a given operator is a correlated nested loops join
 	static BOOL FCorrelatedNLJoin(COperator *pop);
 
+	// check if the correlated left outer NLJ is of scalar subplan type
+	static BOOL FSubplanTypeScalarCorrelatedLOJ(COperator *pop);
+
 	// check if a given operator is a nested loops join
 	static BOOL FNLJoin(COperator *pop);
 

--- a/src/backend/gporca/libgpopt/src/base/CUtils.cpp
+++ b/src/backend/gporca/libgpopt/src/base/CUtils.cpp
@@ -46,6 +46,7 @@
 #include "gpopt/operators/CPhysicalAgg.h"
 #include "gpopt/operators/CPhysicalCTEConsumer.h"
 #include "gpopt/operators/CPhysicalCTEProducer.h"
+#include "gpopt/operators/CPhysicalCorrelatedLeftOuterNLJoin.h"
 #include "gpopt/operators/CPhysicalMotionRandom.h"
 #include "gpopt/operators/CPhysicalNLJoin.h"
 #include "gpopt/operators/CPredicateUtils.h"
@@ -1136,6 +1137,23 @@ CUtils::FCorrelatedNLJoin(COperator *pop)
 	}
 
 	return fCorrelatedNLJ;
+}
+
+// check if the correlated left outer NLJ is of scalar subplan type
+BOOL
+CUtils::FSubplanTypeScalarCorrelatedLOJ(COperator *pop)
+{
+	GPOS_ASSERT(COperator::EopPhysicalCorrelatedLeftOuterNLJoin ==
+				pop->Eopid());
+
+	COperator::EOperatorId eopidSubq =
+		CPhysicalCorrelatedLeftOuterNLJoin::PopConvert(pop)->EopidOriginSubq();
+	if (COperator::EopScalarSubquery == eopidSubq)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 // check if a given operator is a nested loops join

--- a/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
+++ b/src/backend/gporca/libgpopt/src/translate/CTranslatorExprToDXL.cpp
@@ -3988,6 +3988,17 @@ CTranslatorExprToDXL::BuildDxlnSubPlan(CDXLNode *pdxlnRelChild,
 									   CDXLColRefArray *dxl_colref_array)
 {
 	GPOS_ASSERT(nullptr != colref);
+
+	// If the output column is already present in the map then
+	// the subplan already exists. No need to create a subplan
+	// dxl node again.
+	if (nullptr != m_phmcrdxln->Find(const_cast<CColRef *>(colref)))
+	{
+		pdxlnRelChild->Release();
+		dxl_colref_array->Release();
+		return;
+	}
+
 	IMDId *mdid = colref->RetrieveType()->MDId();
 	mdid->AddRef();
 

--- a/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
+++ b/src/backend/gporca/libnaucrates/include/naucrates/traceflags/traceflags.h
@@ -256,6 +256,10 @@ enum EOptTraceFlag
 
 	// Use experimental cost model
 	EopttraceExperimentalCostModel = 104009,
+
+	// Penalize correlated left outer nested loop join
+	EopttraceEnablePenalizeCorrelatedLeftOuterNLJ = 104010,
+
 	///////////////////////////////////////////////////////
 	/////////// constant expression evaluator flags ///////
 	///////////////////////////////////////////////////////

--- a/src/backend/utils/misc/guc_gp.c
+++ b/src/backend/utils/misc/guc_gp.c
@@ -372,6 +372,7 @@ int			optimizer_penalize_broadcast_threshold;
 double		optimizer_cost_threshold;
 double		optimizer_nestloop_factor;
 double		optimizer_sort_factor;
+bool		optimizer_enable_penalize_correlated_left_outer_nljoin;
 
 /* Optimizer hints */
 int			optimizer_join_arity_for_associativity_commutativity;
@@ -2859,6 +2860,16 @@ struct config_bool ConfigureNamesBool_gp[] =
 		},
 		&optimizer_replicated_table_insert,
 		true, NULL, NULL
+	},
+
+	{
+		{"optimizer_enable_penalize_correlated_left_outer_nljoin", PGC_USERSET, QUERY_TUNING_METHOD,
+			gettext_noop("Penalize correlated left outer nested loop join"),
+			NULL,
+			GUC_NOT_IN_SAMPLE
+		},
+		&optimizer_enable_penalize_correlated_left_outer_nljoin,
+		false, NULL, NULL, NULL
 	},
 
 	{

--- a/src/include/utils/guc.h
+++ b/src/include/utils/guc.h
@@ -547,6 +547,7 @@ extern int optimizer_penalize_broadcast_threshold;
 extern double optimizer_cost_threshold;
 extern double optimizer_nestloop_factor;
 extern double optimizer_sort_factor;
+extern bool optimizer_enable_penalize_correlated_left_outer_nljoin;
 
 /* Optimizer hints */
 extern int optimizer_array_expansion_threshold;

--- a/src/include/utils/unsync_guc_name.h
+++ b/src/include/utils/unsync_guc_name.h
@@ -386,6 +386,7 @@
 		"optimizer_enable_outerjoin_to_unionall_rewrite",
 		"optimizer_enable_partition_propagation",
 		"optimizer_enable_partition_selection",
+		"optimizer_enable_penalize_correlated_left_outer_nljoin",
 		"optimizer_enable_push_join_below_union_all",
 		"optimizer_enable_range_predicate_dpe",
 		"optimizer_enable_redistribute_nestloop_loj_inner_child",

--- a/src/test/regress/expected/bfv_cte_optimizer.out
+++ b/src/test/regress/expected/bfv_cte_optimizer.out
@@ -663,40 +663,24 @@ case when (t2.b in (1,2)) then (select rep_cte.a from rep_cte)
 when (t2.b in (1,2)) then (select rep_cte.a from rep_cte)
 end as rep_cte_a
 from t1_cte join t2 on t1_cte.b = t2.b;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------
+                             QUERY PLAN                              
+---------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    ->  Sequence
          ->  Shared Scan (share slice:id 1:1)
-               ->  Result
-                     One-Time Filter: (gp_execution_segment() = 1)
-                     ->  Seq Scan on rep
-         ->  Nested Loop Left Join
-               Join Filter: true
-               ->  Nested Loop Left Join
-                     Join Filter: true
-                     ->  Hash Join
-                           Hash Cond: (t1.b = t2.b)
-                           ->  Seq Scan on t1
-                           ->  Hash
-                                 ->  Broadcast Motion 3:3  (slice6; segments: 3)
-                                       ->  Seq Scan on t2
-                     ->  Assert
-                           Assert Cond: ((row_number() OVER (?)) = 1)
-                           ->  Materialize
-                                 ->  Broadcast Motion 1:3  (slice4)
-                                       ->  WindowAgg
-                                             ->  Gather Motion 3:1  (slice5; segments: 3)
-                                                   ->  Shared Scan (share slice:id 5:1)
-               ->  Assert
-                     Assert Cond: ((row_number() OVER (?)) = 1)
-                     ->  Materialize
-                           ->  Broadcast Motion 1:3  (slice2)
-                                 ->  WindowAgg
-                                       ->  Gather Motion 3:1  (slice3; segments: 3)
-                                             ->  Shared Scan (share slice:id 3:1)
+               ->  Seq Scan on rep
+         ->  Hash Join
+               Hash Cond: (t1.b = t2.b)
+               ->  Seq Scan on t1
+               ->  Hash
+                     ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                           ->  Seq Scan on t2
+               SubPlan 1
+                 ->  Shared Scan (share slice:id 1:1)
+               SubPlan 2
+                 ->  Shared Scan (share slice:id 1:1)
  Optimizer: GPORCA
-(31 rows)
+(15 rows)
 
 with t1_cte as (select b from t1),
 rep_cte as (select a from rep)

--- a/src/test/regress/expected/gporca.out
+++ b/src/test/regress/expected/gporca.out
@@ -14986,3 +14986,54 @@ explain (analyze, costs off, summary off, timing off) with cte as (select * from
  Optimizer: Postgres-based planner
 (5 rows)
 
+-- By default the GUC optimizer_enable_penalize_correlated_left_outer_nljoin is
+-- set to OFF.
+-- If the GUC is set to OFF then nested correlated left outer NLJ will not be
+-- penalized.
+-- If the GUC is set to ON then nested correlated left outer NLJ will be
+-- penalized similar to nested loop join.
+-- If the GUC is OFF we will get a plan with subplans since the correlated left
+-- outer NLJ is not penalized like nested loop join.
+-- If the GUC is turned ON then we will get a plan with nested loop join.
+create table foo (a int, b text, c int) distributed by (a);
+create table bar (a int, b int, c int) distributed by (a);
+create table baz (a int, b text, c int) distributed by (a);
+insert into foo VALUES (100, 'false', 1);
+insert into foo VALUES (200, 'true', 2);
+insert into bar VALUES (2,2,2);
+insert into baz VALUES (200, 'falseg', 1);
+analyze foo,bar,baz;
+explain select * from foo where b::bool = ( exists(select c from bar) and not exists (select c from baz));
+cdev=# explain select * from foo where b::bool = ( exists(select c from bar) and not exists (select c from baz));
+                                     QUERY PLAN
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.06..3.10 rows=1 width=13)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+           ->  Seq Scan on bar  (cost=0.00..1.01 rows=1 width=4)
+   InitPlan 2 (returns $1)  (slice4)
+     ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+           ->  Seq Scan on baz  (cost=0.00..1.01 rows=1 width=4)
+   ->  Seq Scan on foo  (cost=0.00..1.02 rows=1 width=13)
+         Filter: ((b)::boolean = ($0 AND (NOT $1)))
+ Optimizer: Postgres-based planner
+(10 rows)
+
+set optimizer_enable_penalize_correlated_left_outer_nljoin to on;
+explain select * from foo where b::bool = ( exists(select c from bar) and not exists (select c from baz));
+                                     QUERY PLAN
+------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=2.06..3.10 rows=1 width=13)
+   InitPlan 1 (returns $0)  (slice2)
+     ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+           ->  Seq Scan on bar  (cost=0.00..1.01 rows=1 width=4)
+   InitPlan 2 (returns $1)  (slice4)
+     ->  Gather Motion 3:1  (slice5; segments: 3)  (cost=0.00..1.03 rows=1 width=4)
+           ->  Seq Scan on baz  (cost=0.00..1.01 rows=1 width=4)
+   ->  Seq Scan on foo  (cost=0.00..1.02 rows=1 width=13)
+         Filter: ((b)::boolean = ($0 AND (NOT $1)))
+ Optimizer: Postgres-based planner
+(10 rows)
+
+reset optimizer_enable_penalize_correlated_left_outer_nljoin;
+drop table foo,bar,baz;

--- a/src/test/regress/expected/gporca_optimizer.out
+++ b/src/test/regress/expected/gporca_optimizer.out
@@ -15046,3 +15046,71 @@ explain (analyze, costs off, summary off, timing off) with cte as (select * from
  Optimizer: GPORCA
 (8 rows)
 
+-- By default the GUC optimizer_enable_penalize_correlated_left_outer_nljoin is
+-- set to OFF.
+-- If the GUC is set to OFF then nested correlated left outer NLJ will not be
+-- penalized.
+-- If the GUC is set to ON then nested correlated left outer NLJ will be
+-- penalized similar to nested loop join.
+-- If the GUC is OFF we will get a plan with subplans since the correlated left
+-- outer NLJ is not penalized like nested loop join.
+-- If the GUC is turned ON then we will get a plan with nested loop join.
+create table foo (a int, b text, c int) distributed by (a);
+create table bar (a int, b int, c int) distributed by (a);
+create table baz (a int, b text, c int) distributed by (a);
+insert into foo VALUES (100, 'false', 1);
+insert into foo VALUES (200, 'true', 2);
+insert into bar VALUES (2,2,2);
+insert into baz VALUES (200, 'falseg', 1);
+analyze foo,bar,baz;
+explain select * from foo where b::bool = ( exists(select c from bar) and not exists (select c from baz));
+                                                QUERY PLAN
+-----------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1324917.68 rows=2 width=13)
+   ->  Result  (cost=0.00..1324917.68 rows=1 width=13)
+         Filter: ((foo.b)::boolean = ((SubPlan 1) AND (SubPlan 2)))
+         ->  Seq Scan on foo  (cost=0.00..1324055.62 rows=334 width=17)
+         SubPlan 1
+           ->  Result  (cost=0.00..431.00 rows=1 width=5)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=4)
+         SubPlan 2
+           ->  Result  (cost=0.00..431.00 rows=1 width=5)
+                 ->  Materialize  (cost=0.00..431.00 rows=1 width=4)
+                       ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=4)
+                             ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: GPORCA
+(15 rows)
+
+set optimizer_enable_penalize_correlated_left_outer_nljoin to on;
+explain select * from foo where b::bool = ( exists(select c from bar) and not exists (select c from baz));
+                                                                                 QUERY PLAN
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1356691750.44 rows=2 width=13)
+   ->  GroupAggregate  (cost=0.00..1356691750.44 rows=1 width=13)
+         Group Key: foo.a, foo.b, foo.c, foo.ctid, foo.gp_segment_id, (true), (true)
+         ->  Sort  (cost=0.00..1356691750.44 rows=1 width=25)
+               Sort Key: foo.a, foo.b, foo.c, foo.ctid, foo.gp_segment_id, (true), (true)
+               ->  Result  (cost=0.00..1356691750.44 rows=1 width=25)
+                     Filter: ((foo.b)::boolean = (CASE WHEN (NOT ((true) IS NULL)) THEN true ELSE false END AND CASE WHEN (NOT ((true) IS NULL)) THEN false ELSE true END))
+                     ->  Nested Loop Left Join  (cost=0.00..1356691750.44 rows=2 width=25)
+                           Join Filter: true
+                           ->  GroupAggregate  (cost=0.00..1324032.29 rows=1 width=24)
+                                 Group Key: foo.a, foo.b, foo.c, foo.ctid, foo.gp_segment_id, (true)
+                                 ->  Sort  (cost=0.00..1324032.29 rows=2 width=24)
+                                       Sort Key: foo.a, foo.b, foo.c, foo.ctid, foo.gp_segment_id, (true)
+                                       ->  Nested Loop Left Join  (cost=0.00..1324032.29 rows=2 width=24)
+                                             Join Filter: true
+                                             ->  Seq Scan on foo  (cost=0.00..431.00 rows=1 width=23)
+                                             ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                                   ->  Broadcast Motion 3:3  (slice3; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                                         ->  Seq Scan on bar  (cost=0.00..431.00 rows=1 width=1)
+                           ->  Materialize  (cost=0.00..431.00 rows=1 width=1)
+                                 ->  Broadcast Motion 3:3  (slice2; segments: 3)  (cost=0.00..431.00 rows=1 width=1)
+                                       ->  Seq Scan on baz  (cost=0.00..431.00 rows=1 width=1)
+ Optimizer: GPORCA
+(23 rows)
+
+reset optimizer_enable_penalize_correlated_left_outer_nljoin;
+drop table foo,bar,baz;

--- a/src/test/regress/expected/join_hash_optimizer.out
+++ b/src/test/regress/expected/join_hash_optimizer.out
@@ -1103,58 +1103,58 @@ WHERE
     AND (SELECT hjtest_1.b * 5) < 50
     AND (SELECT hjtest_2.c * 5) < 55
     AND hjtest_1.a <> hjtest_2.b;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: hjtest_1.a, hjtest_2.a, ((hjtest_1.tableoid)::regclass), ((hjtest_2.tableoid)::regclass)
    ->  Hash Join
          Output: hjtest_1.a, hjtest_2.a, hjtest_1.tableoid, hjtest_2.tableoid
-         Hash Cond: (((1) = hjtest_1.id) AND (((SubPlan 2)) = ((SubPlan 4))))
+         Hash Cond: ((((SubPlan 2)) = hjtest_1.id) AND (((SubPlan 3)) = ((SubPlan 5))))
          Join Filter: (hjtest_1.a <> hjtest_2.b)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), ((SubPlan 2))
-               Hash Key: (1)
-               ->  Nested Loop Left Join
-                     Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), (SubPlan 2)
-                     Join Filter: (hjtest_2.id = 1)
-                     ->  Seq Scan on public.hjtest_2
-                           Output: hjtest_2.a, hjtest_2.id, hjtest_2.b, hjtest_2.c, hjtest_2.tableoid
-                           Filter: (SubPlan 1)
-                           SubPlan 1
-                             ->  Result
-                                   Output: true
-                                   Filter: (((hjtest_2.c * 5)) < 55)
-                                   ->  Result
-                                         Output: (hjtest_2.c * 5)
-                     ->  Materialize
-                           Output: (1)
-                           ->  Result
-                                 Output: 1
+               Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, ((SubPlan 2)), ((SubPlan 3))
+               Hash Key: ((SubPlan 2))
+               ->  Seq Scan on public.hjtest_2
+                     Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (SubPlan 2), (SubPlan 3)
+                     Filter: (SubPlan 1)
                      SubPlan 2
+                       ->  Result
+                             Output: 1
+                             ->  Result
+                                   One-Time Filter: (hjtest_2.id = 1)
+                                   ->  Result
+                                         Output: true
+                     SubPlan 3
                        ->  Result
                              Output: (hjtest_2.c * 5)
                              ->  Result
                                    Output: true
+                     SubPlan 1
+                       ->  Result
+                             Output: true
+                             Filter: (((hjtest_2.c * 5)) < 55)
+                             ->  Result
+                                   Output: (hjtest_2.c * 5)
          ->  Hash
-               Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+               Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 5))
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+                     Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 5))
                      Hash Key: hjtest_1.id
                      ->  Seq Scan on public.hjtest_1
-                           Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, (SubPlan 4)
-                           Filter: (SubPlan 3)
-                           SubPlan 4
+                           Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, (SubPlan 5)
+                           Filter: (SubPlan 4)
+                           SubPlan 5
                              ->  Result
                                    Output: (hjtest_1.b * 5)
                                    ->  Result
                                          Output: true
-                           SubPlan 3
+                           SubPlan 4
                              ->  Result
                                    Output: true
                                    Filter: (((hjtest_1.b * 5)) < 50)
                                    ->  Result
                                          Output: (hjtest_1.b * 5)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
  Settings: enable_sort = 'off', from_collapse_limit = '1'
 (51 rows)
 
@@ -1180,58 +1180,58 @@ WHERE
     AND (SELECT hjtest_1.b * 5) < 50
     AND (SELECT hjtest_2.c * 5) < 55
     AND hjtest_1.a <> hjtest_2.b;
-                                              QUERY PLAN                                              
-------------------------------------------------------------------------------------------------------
+                                             QUERY PLAN                                             
+----------------------------------------------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
    Output: hjtest_1.a, hjtest_2.a, ((hjtest_1.tableoid)::regclass), ((hjtest_2.tableoid)::regclass)
    ->  Hash Join
          Output: hjtest_1.a, hjtest_2.a, hjtest_1.tableoid, hjtest_2.tableoid
-         Hash Cond: (((1) = hjtest_1.id) AND (((SubPlan 2)) = ((SubPlan 4))))
+         Hash Cond: ((((SubPlan 2)) = hjtest_1.id) AND (((SubPlan 3)) = ((SubPlan 5))))
          Join Filter: (hjtest_1.a <> hjtest_2.b)
          ->  Redistribute Motion 3:3  (slice2; segments: 3)
-               Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), ((SubPlan 2))
-               Hash Key: (1), ((SubPlan 2))
-               ->  Nested Loop Left Join
-                     Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (1), (SubPlan 2)
-                     Join Filter: (hjtest_2.id = 1)
-                     ->  Seq Scan on public.hjtest_2
-                           Output: hjtest_2.a, hjtest_2.id, hjtest_2.b, hjtest_2.c, hjtest_2.tableoid
-                           Filter: (SubPlan 1)
-                           SubPlan 1
-                             ->  Result
-                                   Output: true
-                                   Filter: (((hjtest_2.c * 5)) < 55)
-                                   ->  Result
-                                         Output: (hjtest_2.c * 5)
-                     ->  Materialize
-                           Output: (1)
-                           ->  Result
-                                 Output: 1
+               Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, ((SubPlan 2)), ((SubPlan 3))
+               Hash Key: ((SubPlan 2)), ((SubPlan 3))
+               ->  Seq Scan on public.hjtest_2
+                     Output: hjtest_2.a, hjtest_2.b, hjtest_2.tableoid, (SubPlan 2), (SubPlan 3)
+                     Filter: (SubPlan 1)
                      SubPlan 2
+                       ->  Result
+                             Output: 1
+                             ->  Result
+                                   One-Time Filter: (hjtest_2.id = 1)
+                                   ->  Result
+                                         Output: true
+                     SubPlan 3
                        ->  Result
                              Output: (hjtest_2.c * 5)
                              ->  Result
                                    Output: true
+                     SubPlan 1
+                       ->  Result
+                             Output: true
+                             Filter: (((hjtest_2.c * 5)) < 55)
+                             ->  Result
+                                   Output: (hjtest_2.c * 5)
          ->  Hash
-               Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
+               Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 5))
                ->  Redistribute Motion 3:3  (slice3; segments: 3)
-                     Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 4))
-                     Hash Key: hjtest_1.id, ((SubPlan 4))
+                     Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, ((SubPlan 5))
+                     Hash Key: hjtest_1.id, ((SubPlan 5))
                      ->  Seq Scan on public.hjtest_1
-                           Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, (SubPlan 4)
-                           Filter: (SubPlan 3)
-                           SubPlan 4
+                           Output: hjtest_1.a, hjtest_1.id, hjtest_1.tableoid, (SubPlan 5)
+                           Filter: (SubPlan 4)
+                           SubPlan 5
                              ->  Result
                                    Output: (hjtest_1.b * 5)
                                    ->  Result
                                          Output: true
-                           SubPlan 3
+                           SubPlan 4
                              ->  Result
                                    Output: true
                                    Filter: (((hjtest_1.b * 5)) < 50)
                                    ->  Result
                                          Output: (hjtest_1.b * 5)
- Optimizer: Pivotal Optimizer (GPORCA)
+ Optimizer: GPORCA
  Settings: enable_sort = 'off', from_collapse_limit = '1'
 (51 rows)
 

--- a/src/test/regress/expected/notin_optimizer.out
+++ b/src/test/regress/expected/notin_optimizer.out
@@ -660,38 +660,36 @@ select c1 from t1 where c1 not in
 explain select (case when c1%2 = 0 
  then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 
  else (select sum(c3) from t3 where c3 not in (select c4 from t4)) end) as foo from t1;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1809071284.19 rows=10 width=8)
-   ->  Nested Loop Left Join  (cost=0.00..1809071284.19 rows=14 width=20)
-         Join Filter: true
-         ->  Nested Loop Left Join  (cost=0.00..1765378.17 rows=7 width=12)
-               Join Filter: true
-               ->  Seq Scan on t1  (cost=0.00..431.00 rows=4 width=4)
-               ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
-                     ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..862.00 rows=3 width=8)
-                           ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                                 ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-                                       ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                                             ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                                   Hash Cond: (t2.c2 = t3_1.c3)
-                                                   ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
-                                                   ->  Hash  (cost=431.00..431.00 rows=3 width=4)
-                                                         ->  Broadcast Motion 3:3  (slice7; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
-                                                               ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=4)
-         ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
-               ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..862.00 rows=3 width=8)
-                     ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                           ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
-                                 ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
-                                       ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
-                                             Hash Cond: (t3.c3 = t4.c4)
-                                             ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
-                                             ->  Hash  (cost=431.00..431.00 rows=2 width=4)
-                                                   ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
-                                                         ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
- Optimizer: Pivotal Optimizer (GPORCA) version 3.83.0
-(29 rows)
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Gather Motion 3:1  (slice1; segments: 3)  (cost=0.00..1766690.23 rows=10 width=8)
+   ->  Seq Scan on t1  (cost=0.00..1765397.20 rows=334 width=12)
+         SubPlan 1
+           ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
+                 ->  Broadcast Motion 1:3  (slice2)  (cost=0.00..862.00 rows=1 width=8)
+                       ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                             ->  Gather Motion 3:1  (slice3; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                   ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                         ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
+                                               Hash Cond: (t2.c2 = t3.c3)
+                                               ->  Seq Scan on t2  (cost=0.00..431.00 rows=2 width=4)
+                                               ->  Hash  (cost=431.00..431.00 rows=3 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice4; segments: 3)  (cost=0.00..431.00 rows=3 width=4)
+                                                           ->  Seq Scan on t3  (cost=0.00..431.00 rows=1 width=4)
+         SubPlan 2
+           ->  Materialize  (cost=0.00..862.00 rows=1 width=8)
+                 ->  Broadcast Motion 1:3  (slice5)  (cost=0.00..862.00 rows=1 width=8)
+                       ->  Finalize Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                             ->  Gather Motion 3:1  (slice6; segments: 3)  (cost=0.00..862.00 rows=1 width=8)
+                                   ->  Partial Aggregate  (cost=0.00..862.00 rows=1 width=8)
+                                         ->  Hash Left Anti Semi (Not-In) Join  (cost=0.00..862.00 rows=1 width=4)
+                                               Hash Cond: (t3_1.c3 = t4.c4)
+                                               ->  Seq Scan on t3 t3_1  (cost=0.00..431.00 rows=1 width=4)
+                                               ->  Hash  (cost=431.00..431.00 rows=2 width=4)
+                                                     ->  Broadcast Motion 3:3  (slice7; segments: 3)  (cost=0.00..431.00 rows=2 width=4)
+                                                           ->  Seq Scan on t4  (cost=0.00..431.00 rows=1 width=4)
+ Optimizer: GPORCA
+(27 rows)
 
 select (case when c1%2 = 0 
  then (select sum(c2) from t2 where c2 not in (select c3 from t3)) 

--- a/src/test/regress/expected/subselect_gp_optimizer.out
+++ b/src/test/regress/expected/subselect_gp_optimizer.out
@@ -3843,15 +3843,13 @@ explain (costs off) select least((select 5), greatest(b, NULL, (select 1)), a) f
                 QUERY PLAN                
 ------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop Left Join
-         Join Filter: true
-         ->  Nested Loop Left Join
-               Join Filter: true
-               ->  Seq Scan on foo
-               ->  Materialize
-                     ->  Result
-         ->  Materialize
-               ->  Result
+   ->  Seq Scan on foo
+         SubPlan 1
+           ->  Result
+                 ->  Result
+         SubPlan 2
+           ->  Result
+                 ->  Result
  Optimizer: GPORCA
 (11 rows)
 
@@ -3893,25 +3891,19 @@ select (select a from bar)[1] from bar;
 (1 row)
 
 explain (costs off) select (select a from bar)[(select 1)] from bar;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop Left Join
-         Join Filter: true
-         ->  Nested Loop Left Join
-               Join Filter: true
-               ->  Seq Scan on bar bar_1
-               ->  Materialize
-                     ->  Result
-         ->  Assert
-               Assert Cond: ((row_number() OVER (?)) = 1)
-               ->  Materialize
-                     ->  Broadcast Motion 1:3  (slice2)
-                           ->  WindowAgg
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Seq Scan on bar
+   ->  Seq Scan on bar
+         SubPlan 2
+           ->  Materialize
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                       ->  Seq Scan on bar bar_1
+         SubPlan 1
+           ->  Result
+                 ->  Result
  Optimizer: GPORCA
-(16 rows)
+(10 rows)
 
 select (select a from bar)[(select 1)] from bar;
  a 
@@ -3943,25 +3935,19 @@ select (select b from bar)[1][1:3] from bar;
 (1 row)
 
 explain (costs off) select (select b from bar)[(select 1)][1:3] from bar;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                           QUERY PLAN                            
+-----------------------------------------------------------------
  Gather Motion 3:1  (slice1; segments: 3)
-   ->  Nested Loop Left Join
-         Join Filter: true
-         ->  Nested Loop Left Join
-               Join Filter: true
-               ->  Seq Scan on bar bar_1
-               ->  Materialize
-                     ->  Result
-         ->  Assert
-               Assert Cond: ((row_number() OVER (?)) = 1)
-               ->  Materialize
-                     ->  Broadcast Motion 1:3  (slice2)
-                           ->  WindowAgg
-                                 ->  Gather Motion 3:1  (slice3; segments: 3)
-                                       ->  Seq Scan on bar
+   ->  Seq Scan on bar
+         SubPlan 2
+           ->  Materialize
+                 ->  Broadcast Motion 3:3  (slice2; segments: 3)
+                       ->  Seq Scan on bar bar_1
+         SubPlan 1
+           ->  Result
+                 ->  Result
  Optimizer: GPORCA
-(16 rows)
+(10 rows)
 
 select (select b from bar)[(select 1)][1:3] from bar;
      b     


### PR DESCRIPTION
Consider the below plan tree
```
X
|-------Y
|           |---- Outer1
|           |---- Inner1
|           |---- Join Condition1      
|           
|-------Inner2
|
|------- Join Condition2


where 

X:  CPhysicalCorrelatedInnerNLJoin, CPhysicalCorrelatedLeftSemiNLJoin,
CPhysicalCorrelatedInLeftSemiNLJoin, CPhysicalCorrelatedLeftAntiSemiNLJoin,
CPhysicalCorrelatedNotInLeftAntiSemiNLJoin      

Y: CPhysicalCorrelatedInnerNLJoin, CPhysicalCorrelatedLeftSemiNLJoin,
CPhysicalCorrelatedInLeftSemiNLJoin, CPhysicalCorrelatedLeftAntiSemiNLJoin,
CPhysicalCorrelatedNotInLeftAntiSemiNLJoin, CPhysicalCorrelatedLeftOuterNLJoin
```
The explain plan will be like below
```
Result
	-> Outer1
		Subplan 1
			Inner1
	Subplan 2
		Inner2
```
By looking at the code of translating expr to dxl, observed that when we have a
correlated nested loop join of type X, an extra result node is added and the
inner tree(inner tree 2) which is converted to a subplan becomes a filter for
that result node.  So the subplan 1 will first run for all the rows in outer1
and based on the output rows subplan2 will run (subplans at different levels).
The behaviour is similar to a nested loop join within a nested loop join. So we
should penalize these operators like nested loop joins.

Now consider the below plan tree
```
X
|——— Y
|           |---- Outer1
|           |---- Inner1
|           |---- Join Condition1      
|           
|-------Inner2
|
|------- Join Condition2

where

 X: CPhysicalCorrelatedLeftOuterNLJoin

Y: CPhysicalCorrelatedInnerNLJoin, CPhysicalCorrelatedLeftSemiNLJoin,
CPhysicalCorrelatedInLeftSemiNLJoin, CPhysicalCorrelatedLeftAntiSemiNLJoin,
CPhysicalCorrelatedNotInLeftAntiSemiNLJoin, CPhysicalCorrelatedLeftOuterNLJoin
```
But when X is CPhysicalCorrelatedLeftOuterNLJoin no extra result node is added
(subplans at same level) if any of the below conditions are true
- If the subplan type of CPhysicalCorrelatedLeftOuterNLJoin is non scalar.
- If the subplan type of CPhysicalCorrelatedLeftOuterNLJoin is scalar then the
  join condition (Join Condition2) should be a scalarConstTrue

So CPhysicalCorrelatedLeftOuterNLJoin should not be penalized if the above
conditions are met since the subplans will be at the same level.

Created a GUC `optimizer_enable_penalize_correlated_left_outer_nljoin` which is
`OFF` by default. So the default behaviour will be to `not penalize the
CPhysicalCorrelatedLeftOuterNLJoin operator while costing`. By not penalizing
the opeartor observed better plans where the subplans are getting executed on
segments instead of coordinator which improved the performance of queries. Ran
the explain pipeline also and observed no unexpected plan changes.
